### PR TITLE
Test automation via Github Actions

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -1,0 +1,48 @@
+on: [push, pull_request]
+
+name: Run test suite
+
+jobs:
+  run-test-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        if: always()
+        with:
+          path: |
+            ~/.cargo
+            ./rust/target
+          key: ${{ runner.os }}-cargo-artifacts-${{ hashFiles('**/Cargo.toml') }}
+      - name: 'Run Rust native target tests'
+        working-directory: ./rust
+        run: cargo test
+        shell: bash
+      - name: 'Install Rust/WASM test dependencies'
+        working-directory: ./rust
+        run: |
+          rustup target install wasm32-unknown-unknown
+          cargo install toml-cli
+          WASM_BINDGEN_VERSION=`toml get ./noosphere-storage/Cargo.toml 'target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen' | xargs echo`
+          cargo install wasm-bindgen-cli --vers "$WASM_BINDGEN_VERSION"
+        shell: bash
+      # See: https://github.com/SeleniumHQ/selenium/blob/5d108f9a679634af0bbc387e7e3811bc1565912b/.github/actions/setup-chrome/action.yml
+      - name: 'Setup Chrome and chromedriver'
+        run: |
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update -qqy
+          sudo apt-get -qqy install google-chrome-stable
+          CHROME_VERSION=$(google-chrome-stable --version)
+          CHROME_FULL_VERSION=${CHROME_VERSION%%.*}
+          CHROME_MAJOR_VERSION=${CHROME_FULL_VERSION//[!0-9]}
+          sudo rm /etc/apt/sources.list.d/google-chrome.list
+          export CHROMEDRIVER_VERSION=`curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION%%.*}`
+          curl -L -O "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+          unzip chromedriver_linux64.zip && chmod +x chromedriver && sudo mv chromedriver /usr/local/bin
+          chromedriver -version
+        shell: bash
+      - name: 'Run Rust headless browser tests'
+        working-directory: ./rust
+        run: CHROMEDRIVER=/usr/local/bin/chromedriver cargo test --target wasm32-unknown-unknown
+        shell: bash

--- a/rust/.cargo/config
+++ b/rust/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+rustflags = ["--cfg=web_sys_unstable_apis"]
+
+[target.'cfg(target_arch="wasm32")']
+runner = "wasm-bindgen-test-runner"

--- a/rust/noosphere-storage/Cargo.toml
+++ b/rust/noosphere-storage/Cargo.toml
@@ -21,7 +21,7 @@ sled = "0.34"
 tokio = { version = "^1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "~0.2"
 rexie = { git = "https://github.com/cdata/rexie" }
 js-sys = "0.3"
 


### PR DESCRIPTION
This change introduces test automation via Github Actions. Both "native" target and web-based WASM targets are covered. Headless browser test setup is borrowed from [Selenium's own Github Action for that purpose](https://github.com/SeleniumHQ/selenium/blob/selenium-4.0.0-beta-3/.github/actions/setup-chrome/action.yml).