### PR TITLE
Fix link syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,25 @@ Noosphere is the foundational protocol that the Subconscious app builds upon to 
 
 Our ambition is to build a new kind of web, but we have only begun to discover what that means. Our work is rapidly advancing but still in-progress, and we need your help to drive it forward!
 
-Check out our [Roadmap](roadmap) see where we are headed.
+Check out our [Roadmap][roadmap] see where we are headed.
 
-Follow along with the daily development process on the [Noosphere kanban](noosphere-kanban).
+Follow along with the daily development process on the [Noosphere kanban][noosphere-kanban].
 
 ## Project layout
 
-The [`rust`](rust) folder contains the core implementation of the Noosphere protocol as well as convenience abstractions and a reference client and server. Most crates can be compiled for native targets and/or WASM targets as desired. In time, we intend that JavaScript-specific packages will be maintained in this repository, backed the core Rust implementation compiled to WASM.
+The [`rust`][rust] folder contains the core implementation of the Noosphere protocol as well as convenience abstractions and a reference client and server. Most crates can be compiled for native targets and/or WASM targets as desired. In time, we intend that JavaScript-specific packages will be maintained in this repository, backed the core Rust implementation compiled to WASM.
 
-The [`design`](design) folder contains documents describing Noosphere data structures and protocols in generalized terms. Our aspiration is to document the protocol sufficiently that other implementations can be built without having to dissect and analyze our code to do it.
+The [`design`][design] folder contains documents describing Noosphere data structures and protocols in generalized terms. Our aspiration is to document the protocol sufficiently that other implementations can be built without having to dissect and analyze our code to do it.
 
 ## License
 
 This project is dual licensed under MIT and Apache-2.0.
 
-MIT: https://www.opensource.org/licenses/mit
+MIT: https://www.opensource.org/licenses/mit  
 Apache-2.0: https://www.apache.org/licenses/license-2.0
 
-[ucan]: https://ucan.xyz/
-[noosphere]: https://en.wikipedia.org/wiki/Noosphere#cite_note-4:~:text=The%20noosphere%20represents%20the%20highest%20stage%20of%20biospheric%20development%2C%20its%20defining%20factor%20being%20the%20development%20of%20humankind%27s%20rational%20activities.
-[rust]: https://github.com/subconsciousnetwork/noosphere/main/rust/
-[design]: https://github.com/subconsciousnetwork/noosphere/main/design/
-[roadmap-board]: https://github.com/orgs/subconsciousnetwork/projects/1/views/4
+[rust]: https://github.com/subconsciousnetwork/noosphere/tree/main/rust
+[design]: https://github.com/subconsciousnetwork/noosphere/tree/main/design/
+[roadmap]: https://github.com/orgs/subconsciousnetwork/projects/1/views/4
 [noosphere-kanban]: https://github.com/orgs/subconsciousnetwork/projects/1/views/8
 


### PR DESCRIPTION
We are using reference-style links, which should look like `[link][ref]`, not `[link](url)`.

Also:

- Fix a couple URLs that point to repo
- Remove a couple URLs that are no longer used