### PR TITLE
Introduce FS-like view into sphere data

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -151,6 +151,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-task"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1506,7 @@ dependencies = [
  "cid",
  "noosphere",
  "noosphere-cbor",
+ "noosphere-storage",
  "reqwest",
  "serde",
  "tokio",
@@ -1525,6 +1547,26 @@ dependencies = [
  "sha2 0.10.2",
  "tokio",
  "unsigned-varint",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "noosphere-fs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bytes",
+ "cid",
+ "futures-util",
+ "noosphere",
+ "noosphere-storage",
+ "once_cell",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ucan",
+ "ucan-key-support",
  "wasm-bindgen-test",
 ]
 
@@ -2743,6 +2785,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,8 @@ members = [
   "noosphere-collections",
   "noosphere",
   "noosphere-api",
-  "noosphere-gateway"
+  "noosphere-fs",
+  "noosphere-gateway",
 ]
 # See: https://github.com/rust-lang/rust/issues/90148#issuecomment-949194352
 resolver = "2"

--- a/rust/noosphere-api/src/authority.rs
+++ b/rust/noosphere-api/src/authority.rs
@@ -44,28 +44,28 @@ impl TryFrom<String> for GatewayAction {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct GatewayReference {
+pub struct GatewayIdentity {
     pub did: String,
 }
 
-impl Scope for GatewayReference {
+impl Scope for GatewayIdentity {
     fn contains(&self, other: &Self) -> bool {
         other.did == self.did
     }
 }
 
-impl ToString for GatewayReference {
-    fn to_string(&self) -> String {
-        format!("ng:{}", self.did)
+impl Display for GatewayIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ng:{}", self.did)
     }
 }
 
-impl TryFrom<Url> for GatewayReference {
+impl TryFrom<Url> for GatewayIdentity {
     type Error = anyhow::Error;
 
     fn try_from(value: Url) -> Result<Self> {
         match value.scheme() {
-            "ng" => Ok(GatewayReference {
+            "ng" => Ok(GatewayIdentity {
                 did: String::from(value.path()),
             }),
             _ => Err(anyhow!(
@@ -78,6 +78,6 @@ impl TryFrom<Url> for GatewayReference {
 
 pub struct GatewaySemantics {}
 
-impl CapabilitySemantics<GatewayReference, GatewayAction> for GatewaySemantics {}
+impl CapabilitySemantics<GatewayIdentity, GatewayAction> for GatewaySemantics {}
 
 pub const GATEWAY_SEMANTICS: GatewaySemantics = GatewaySemantics {};

--- a/rust/noosphere-api/src/client.rs
+++ b/rust/noosphere-api/src/client.rs
@@ -1,11 +1,14 @@
+use std::{ops::Deref, sync::Arc};
+
 use crate::{
-    authority::{GatewayAction, GatewayReference},
+    authority::{GatewayAction, GatewayIdentity},
     data::{FetchParameters, FetchResponse, IdentifyResponse, PushBody, PushResponse},
-    url::{GatewayIdentity, GatewayRequestUrl, Route},
+    gateway::{GatewayReference, GatewayRequestUrl, Route},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use noosphere_cbor::TryDagCbor;
+use noosphere_storage::interface::{StorageProvider, Store};
 use reqwest::Body;
 use ucan::{
     builder::UcanBuilder,
@@ -15,93 +18,66 @@ use ucan::{
 };
 use url::Url;
 
-pub struct Client<'a, Credential: KeyMaterial> {
-    gateway_identity: GatewayIdentity,
-    proofs: Option<Vec<Ucan>>,
-    credential: &'a Credential,
+pub struct Client<'a, K>
+where
+    K: KeyMaterial,
+{
+    pub gateway: GatewayReference,
+    pub credential: &'a K,
+    pub authorization: Vec<Ucan>,
     client: reqwest::Client,
 }
 
-impl<'a, Credential: KeyMaterial> Client<'a, Credential> {
+impl<'a, K> Client<'a, K>
+where
+    K: KeyMaterial,
+{
     pub async fn identify(
-        api_base: &str,
-        credential: &'a Credential,
-        proofs: Option<Vec<Ucan>>,
-        expected_identity: Option<&str>,
-    ) -> Result<Client<'a, Credential>> {
-        let mut url = Url::parse(api_base)?;
-
-        let scheme = url.scheme().to_string();
-        let host = url
-            .host()
-            .ok_or_else(|| anyhow!("No domain specified in {}", api_base))?
-            .to_string();
-        let port = url.port().unwrap_or(80);
+        gateway: &GatewayReference,
+        credential: &'a K,
+        authorization: Option<Vec<Ucan>>,
+    ) -> Result<Client<'a, K>> {
+        let mut url = Url::try_from(gateway)?;
 
         url.set_path(&Route::Identify.to_string());
 
         let IdentifyResponse { identity } = reqwest::get(url).await?.json().await?;
+        let claimed_identity = GatewayIdentity { did: identity };
 
-        if let Some(expected_identity) = expected_identity {
-            if identity != expected_identity {
-                return Err(anyhow!(
-                    "Expected gateway {} but got {}",
-                    expected_identity,
-                    identity
-                ));
-            }
-        }
-
-        let gateway_identity = GatewayIdentity {
-            scheme,
-            host,
-            port,
-            did: identity,
-        };
+        let mut gateway = gateway.clone();
+        gateway.ensure_identity(&claimed_identity)?;
 
         Ok(Client {
-            gateway_identity,
-            proofs,
+            gateway,
             credential,
+            authorization: authorization.unwrap_or_else(|| Vec::new()),
             client: reqwest::Client::new(),
         })
     }
 
-    pub fn gateway_identity(&self) -> &GatewayIdentity {
-        &self.gateway_identity
-    }
-
     async fn make_bearer_token(
         &self,
-        capability: &Capability<GatewayReference, GatewayAction>,
+        capability: &Capability<GatewayIdentity, GatewayAction>,
     ) -> Result<String> {
         let mut builder = UcanBuilder::default()
             .issued_by(self.credential)
-            .for_audience(&self.gateway_identity.did)
+            .for_audience(&self.gateway.require_identity()?.did)
             .with_lifetime(120)
             .claiming_capability(capability)
             .with_nonce();
 
-        if let Some(proofs) = &self.proofs {
-            for proof in proofs {
-                builder = builder.witnessed_by(proof);
-            }
+        for proof in &self.authorization {
+            builder = builder.witnessed_by(proof);
         }
 
         Ok(builder.build()?.sign().await?.encode()?)
     }
 
     async fn fetch(&self, params: &FetchParameters) -> Result<FetchResponse> {
-        let url = Url::try_from(GatewayRequestUrl(
-            &self.gateway_identity,
-            Route::Fetch,
-            Some(params),
-        ))?;
+        let url = Url::try_from(GatewayRequestUrl(&self.gateway, Route::Fetch, Some(params)))?;
         let capability = Capability {
             with: With::Resource {
-                kind: Resource::Scoped(GatewayReference {
-                    did: self.gateway_identity.did.clone(),
-                }),
+                kind: Resource::Scoped(self.gateway.require_identity()?.clone()),
             },
             can: GatewayAction::Fetch,
         };
@@ -121,17 +97,11 @@ impl<'a, Credential: KeyMaterial> Client<'a, Credential> {
     }
 
     pub async fn push(&self, push_body: &PushBody) -> Result<PushResponse> {
-        let url = Url::try_from(GatewayRequestUrl::<()>(
-            &self.gateway_identity,
-            Route::Push,
-            None,
-        ))?;
+        let url = Url::try_from(GatewayRequestUrl::<()>(&self.gateway, Route::Push, None))?;
 
         let capability = Capability {
             with: With::Resource {
-                kind: Resource::Scoped(GatewayReference {
-                    did: self.gateway_identity.did.clone(),
-                }),
+                kind: Resource::Scoped(self.gateway.require_identity()?.clone()),
             },
             can: GatewayAction::Push,
         };

--- a/rust/noosphere-api/src/lib.rs
+++ b/rust/noosphere-api/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod authority;
 pub mod client;
 pub mod data;
-pub mod url;
+pub mod gateway;
 
 #[cfg(test)]
 mod tests {

--- a/rust/noosphere-fs/Cargo.toml
+++ b/rust/noosphere-fs/Cargo.toml
@@ -1,29 +1,32 @@
 [package]
-name = "noosphere-api"
+name = "noosphere-fs"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "^1"
-cid = "~0.8"
-url = "^2"
-serde = "^1"
 noosphere = { path = "../noosphere" }
-noosphere-cbor = { path = "../noosphere-cbor" }
 noosphere-storage = { path = "../noosphere-storage" }
-reqwest = { version = "~0.11", features = ["json"] }
+
+tokio = { version = "^1", features = ["sync", "io-util"] }
+tokio-util = { version = "~0.7", features = ["io"] }
+tokio-stream = "~0.1"
+async-stream = "~0.3"
+bytes = "^1"
+once_cell = "^1"
+cid = "~0.8"
+anyhow = "^1"
+
+futures-util = "~0.3"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "^1", features = ["full"] }
 ucan = { version = "0.6.0-alpha.1", git = "https://github.com/cdata/rs-ucan.git" }
 ucan-key-support = { version = "0.4.0-alpha.1", git = "https://github.com/cdata/rs-ucan.git" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "~0.2"
 ucan = { version = "0.6.0-alpha.1", features = ["web"], git = "https://github.com/cdata/rs-ucan.git" }
 ucan-key-support = { version = "0.4.0-alpha.1", features = ["web"], git = "https://github.com/cdata/rs-ucan.git" }
-
-[dev-dependencies]
-wasm-bindgen-test = "~0.3"

--- a/rust/noosphere-fs/src/decoder.rs
+++ b/rust/noosphere-fs/src/decoder.rs
@@ -1,0 +1,25 @@
+use async_stream::try_stream;
+use bytes::Bytes;
+use cid::Cid;
+use noosphere::data::BodyChunkIpld;
+use noosphere_storage::interface::{DagCborStore, Store};
+use tokio_stream::Stream;
+
+/// Helper to easily decode a linked list of `BodyChunkIpld` as a byte stream
+pub struct BodyChunkDecoder<'a, 'b, S: Store>(pub &'a Cid, pub &'b S);
+
+impl<'a, 'b, S: Store> BodyChunkDecoder<'a, 'b, S> {
+    pub fn stream(self) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Unpin {
+        let mut next = Some(self.0.clone());
+        let store = self.1.clone();
+        Box::pin(try_stream! {
+            while let Some(cid) = next {
+                let chunk: BodyChunkIpld = store.load(&cid).await.map_err(|error| {
+                    std::io::Error::new(std::io::ErrorKind::UnexpectedEof, error.to_string())
+                })?;
+                yield Bytes::from(chunk.bytes);
+                next = chunk.next;
+            }
+        })
+    }
+}

--- a/rust/noosphere-fs/src/file.rs
+++ b/rust/noosphere-fs/src/file.rs
@@ -1,0 +1,10 @@
+use cid::Cid;
+use noosphere::data::MemoIpld;
+
+/// A descriptor for contents that is stored in a sphere.
+pub struct SphereFile<C> {
+    pub sphere_revision: Cid,
+    pub memo_revision: Cid,
+    pub memo: MemoIpld,
+    pub contents: C,
+}

--- a/rust/noosphere-fs/src/fs.rs
+++ b/rust/noosphere-fs/src/fs.rs
@@ -1,0 +1,371 @@
+use anyhow::{anyhow, Result};
+use noosphere::{
+    data::{BodyChunkIpld, ContentType, Header, MemoIpld, ReferenceIpld},
+    view::{Sphere, SphereMutation},
+};
+use noosphere_storage::interface::{DagCborStore, KeyValueStore, Store};
+use std::str::FromStr;
+use tokio_util::io::StreamReader;
+use ucan::{crypto::KeyMaterial, ucan::Ucan};
+
+use cid::Cid;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::{BodyChunkDecoder, SphereFile};
+
+/// SphereFs: An FS-like abstraction over Noosphere content.
+///
+/// A sphere implements a flat namespace that maps strings to CIDs, which in
+/// turn refer to the sphere owner's content. However, it is not particularly
+/// convenient for users to think of their content as organized around these
+/// primitives. The SphereFs interface offers a familiar, relatively high-level
+/// interface for operation on sphere content.
+pub struct SphereFs<S>
+where
+    S: Store,
+{
+    sphere_identity: String,
+    sphere_revision: Cid,
+    block_store: S,
+    sphere_store: S,
+}
+
+impl<S> SphereFs<S>
+where
+    S: Store,
+{
+    async fn require_sphere_revision(sphere_identity: &str, sphere_store: &S) -> Result<Cid> {
+        let reference: ReferenceIpld = sphere_store
+            .get(sphere_identity)
+            .await?
+            .ok_or_else(|| anyhow!("No reference to sphere {} found", sphere_identity))?;
+
+        Ok(reference.link)
+    }
+
+    async fn get_file(&self, memo_revision: &Cid) -> Result<SphereFile<impl AsyncRead + Unpin>> {
+        let memo: MemoIpld = self.block_store.load(memo_revision).await?;
+        let content_type = match memo.get_first_header(&Header::ContentType.to_string()) {
+            Some(content_type) => Some(ContentType::from_str(content_type.as_str())?),
+            None => None,
+        };
+
+        let stream = match content_type {
+            Some(ContentType::Subtext) | Some(ContentType::Bytes) => {
+                BodyChunkDecoder(&memo.body, &self.block_store).stream()
+            }
+            Some(content_type) => {
+                return Err(anyhow!("Unsupported content type: {}", content_type))
+            }
+            None => return Err(anyhow!("No content type specified")),
+        };
+
+        Ok(SphereFile {
+            sphere_revision: self.sphere_revision.clone(),
+            memo_revision: memo_revision.clone(),
+            memo,
+            contents: StreamReader::new(stream),
+        })
+    }
+
+    /// Create an FS view into the latest revision found in the provided sphere
+    /// reference storage
+    pub async fn latest(
+        sphere_identity: &str,
+        block_store: &S,
+        sphere_store: &S,
+    ) -> Result<SphereFs<S>> {
+        let sphere_revision = Self::require_sphere_revision(sphere_identity, sphere_store).await?;
+
+        Ok(SphereFs {
+            sphere_identity: sphere_identity.into(),
+            sphere_revision,
+            block_store: block_store.clone(),
+            sphere_store: sphere_store.clone(),
+        })
+    }
+
+    /// Create an FS view into the sphere data at a specific revision; note that
+    /// writes to this view will "fork" history and update the sphere reference
+    /// to point to the fork.
+    pub fn at(
+        sphere_identity: &str,
+        sphere_revision: &Cid,
+        block_store: &S,
+        sphere_store: &S,
+    ) -> Result<Option<SphereFs<S>>> {
+        Ok(Some(SphereFs {
+            sphere_identity: sphere_identity.into(),
+            sphere_revision: sphere_revision.clone(),
+            block_store: block_store.clone(),
+            sphere_store: sphere_store.clone(),
+        }))
+    }
+
+    /// Rewind the view to point to the version of the sphere just prior to this
+    /// one in the edit chronology. If there was a previous version to rewind to
+    /// then the returned `Option` has the CID of the revision, otherwise if the
+    /// current version is the oldest one it is `None`.
+    pub async fn rewind(&mut self) -> Result<Option<Cid>> {
+        let sphere = Sphere::at(&self.sphere_revision, &self.block_store);
+
+        match sphere.try_get_parent().await? {
+            Some(parent) => {
+                self.sphere_revision = parent.cid().clone();
+                Ok(Some(self.sphere_revision.clone()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Read a file that is associated with a given slug at the revision of the
+    /// sphere that this view is pointing to.
+    /// Note that "contents" are `AsyncRead`, and content bytes won't be read
+    /// until contents is polled.
+    pub async fn read(&self, slug: &str) -> Result<Option<SphereFile<impl AsyncRead>>> {
+        let sphere = Sphere::at(&self.sphere_revision, &self.block_store);
+        let links = sphere.try_get_links().await?;
+        let hamt = links.try_get_hamt().await?;
+
+        Ok(match hamt.get(&slug.to_string()).await? {
+            Some(content_cid) => Some(self.get_file(&content_cid).await?),
+            None => None,
+        })
+    }
+
+    /// Write to a slug in the sphere. In addition to commiting new content to
+    /// the sphere and block storage, this method:
+    ///
+    ///  - Creates a new revision based on the one that the view points to
+    ///  - Signs the new revision with provided key material
+    ///  - Updates the view to point to the new revision
+    ///
+    /// The returned CID is a link to the memo for the newly added content.
+    pub async fn write<R: AsyncRead + std::marker::Unpin, K: KeyMaterial>(
+        &mut self,
+        slug: &str,
+        content_type: &str,
+        mut value: R,
+        credential: &K,
+        proof: Option<&Ucan>,
+        additional_headers: Option<Vec<(String, String)>>,
+    ) -> Result<Cid> {
+        let current_file = self.read(slug).await?;
+        let previous_memo_cid = current_file.map_or(None, |file| Some(file.memo_revision));
+
+        // let sphere_cid = self.require_sphere_revision().await?;
+        let sphere_cid =
+            Self::require_sphere_revision(&self.sphere_identity, &self.sphere_store).await?;
+        let sphere = Sphere::at(&sphere_cid, &self.block_store);
+
+        let mut bytes = Vec::new();
+        value.read_to_end(&mut bytes).await?;
+
+        // TODO(#38): We imply here that the only content types we care about
+        // amount to byte streams, but in point of fact we can support anything
+        // that may be referenced by CID including arbitrary IPLD structures
+        let body_cid = BodyChunkIpld::store_bytes(&bytes, &mut self.block_store).await?;
+
+        let mut new_memo = match previous_memo_cid {
+            Some(cid) => {
+                let mut memo = MemoIpld::branch_from(&cid, &self.block_store).await?;
+                memo.body = body_cid;
+                memo
+            }
+            None => MemoIpld {
+                parent: None,
+                headers: Vec::new(),
+                body: body_cid,
+            },
+        };
+
+        if let Some(headers) = additional_headers {
+            for (name, value) in headers {
+                new_memo.replace_header(&name, &value)
+            }
+        }
+
+        new_memo.replace_header(&Header::ContentType.to_string(), content_type);
+
+        // TODO(#43): Configure default/implicit headers here
+        let memo_cid = self.block_store.save(&new_memo).await?;
+
+        let author_did = credential.get_did().await?;
+
+        let mut mutation = SphereMutation::new(&author_did);
+        mutation.links_mut().set(slug, &memo_cid);
+
+        let mut revision = sphere.try_apply(&mutation).await?;
+        let next_sphere_cid = revision.try_sign(credential, proof).await?;
+
+        self.sphere_store
+            .set(
+                &self.sphere_identity,
+                &ReferenceIpld {
+                    link: next_sphere_cid.clone(),
+                },
+            )
+            .await?;
+
+        self.sphere_revision = next_sphere_cid;
+
+        Ok(memo_cid)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use noosphere::{
+        authority::generate_ed25519_key,
+        data::{ContentType, Header, ReferenceIpld},
+        view::Sphere,
+    };
+    use noosphere_storage::interface::KeyValueStore;
+    use noosphere_storage::memory::MemoryStore;
+    use tokio::io::AsyncReadExt;
+    use ucan::crypto::KeyMaterial;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use crate::SphereFs;
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_write_a_file_and_read_it_back() {
+        let mut sphere_store = MemoryStore::default();
+        let mut block_store = MemoryStore::default();
+
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await.unwrap();
+
+        let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut block_store)
+            .await
+            .unwrap();
+
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
+
+        sphere_store
+            .set(
+                &sphere_identity,
+                &ReferenceIpld {
+                    link: sphere.cid().clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut fs = SphereFs::latest(&sphere_identity, &block_store, &sphere_store)
+            .await
+            .unwrap();
+
+        fs.write(
+            "cats",
+            &ContentType::Subtext.to_string(),
+            b"Cats are great".as_ref(),
+            &owner_key,
+            Some(&proof),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut file = fs.read("cats").await.unwrap().unwrap();
+
+        file.memo
+            .expect_header(
+                &Header::ContentType.to_string(),
+                &ContentType::Subtext.to_string(),
+            )
+            .unwrap();
+
+        let mut value = String::new();
+        file.contents.read_to_string(&mut value).await.unwrap();
+
+        assert_eq!("Cats are great", value.as_str());
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_overwrite_a_file_with_new_contents_and_preserve_history() {
+        let mut sphere_store = MemoryStore::default();
+        let mut block_store = MemoryStore::default();
+
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await.unwrap();
+
+        let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut block_store)
+            .await
+            .unwrap();
+
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
+
+        sphere_store
+            .set(
+                &sphere_identity,
+                &ReferenceIpld {
+                    link: sphere.cid().clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut fs = SphereFs::latest(&sphere_identity, &block_store, &sphere_store)
+            .await
+            .unwrap();
+
+        fs.write(
+            "cats",
+            &ContentType::Subtext.to_string(),
+            b"Cats are great".as_ref(),
+            &owner_key,
+            Some(&proof),
+            None,
+        )
+        .await
+        .unwrap();
+
+        fs.write(
+            "cats",
+            &ContentType::Subtext.to_string(),
+            b"Cats are better than dogs".as_ref(),
+            &owner_key,
+            Some(&proof),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut file = fs.read("cats").await.unwrap().unwrap();
+
+        file.memo
+            .expect_header(
+                &Header::ContentType.to_string(),
+                &ContentType::Subtext.to_string(),
+            )
+            .unwrap();
+
+        let mut value = String::new();
+        file.contents.read_to_string(&mut value).await.unwrap();
+
+        assert_eq!("Cats are better than dogs", value.as_str());
+
+        assert!(fs.rewind().await.unwrap().is_some());
+
+        file = fs.read("cats").await.unwrap().unwrap();
+
+        file.memo
+            .expect_header(
+                &Header::ContentType.to_string(),
+                &ContentType::Subtext.to_string(),
+            )
+            .unwrap();
+
+        value.clear();
+        file.contents.read_to_string(&mut value).await.unwrap();
+
+        assert_eq!("Cats are great", value.as_str());
+    }
+}

--- a/rust/noosphere-fs/src/lib.rs
+++ b/rust/noosphere-fs/src/lib.rs
@@ -1,0 +1,7 @@
+mod decoder;
+mod file;
+mod fs;
+
+pub use decoder::*;
+pub use file::*;
+pub use fs::*;

--- a/rust/noosphere-gateway/src/gateway/authority/keeper.rs
+++ b/rust/noosphere-gateway/src/gateway/authority/keeper.rs
@@ -15,7 +15,7 @@ use ucan::{
 
 use crate::gateway::{environment::GatewayConfig, AuthzError};
 
-use noosphere_api::authority::{GatewayAction, GatewayReference, GATEWAY_SEMANTICS};
+use noosphere_api::authority::{GatewayAction, GatewayIdentity, GATEWAY_SEMANTICS};
 
 pub struct GatewayAuthority {
     proof_chain: ProofChain,
@@ -46,7 +46,7 @@ impl GatewayAuthority {
 
         let desired_capability = Capability {
             with: With::Resource {
-                kind: Resource::Scoped(GatewayReference {
+                kind: Resource::Scoped(GatewayIdentity {
                     did: gateway_identity,
                 }),
             },

--- a/rust/noosphere-gateway/src/gateway/handlers/push.rs
+++ b/rust/noosphere-gateway/src/gateway/handlers/push.rs
@@ -69,7 +69,7 @@ pub async fn push_handler(
 
     match (tip, push_body.base) {
         (Some(mine), theirs) => {
-            // TODO: Probably should do some diligence here to check if
+            // TODO(#26): Probably should do some diligence here to check if
             // their base is even in our lineage. Note that this condition
             // will be hit if theirs is ahead of mine, which actually
             // should be a "missing revisions" condition.

--- a/rust/noosphere-storage/src/interface.rs
+++ b/rust/noosphere-storage/src/interface.rs
@@ -6,7 +6,7 @@ use cid::{
 };
 use noosphere_cbor::{TryDagCbor, TryDagCborSendSync};
 
-const DAG_CBOR_CODEC: u64 = 0x71;
+pub const DAG_CBOR_CODEC: u64 = 0x71;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/rust/noosphere/src/data/body_chunk.rs
+++ b/rust/noosphere/src/data/body_chunk.rs
@@ -20,7 +20,7 @@ pub struct BodyChunkIpld {
 }
 
 impl BodyChunkIpld {
-    pub async fn store_bytes<Storage: Store>(bytes: &[u8], mut store: Storage) -> Result<Cid> {
+    pub async fn store_bytes<Storage: Store>(bytes: &[u8], store: &mut Storage) -> Result<Cid> {
         let chunks = FastCDC::new(
             bytes,
             fastcdc::MINIMUM_MIN,

--- a/rust/noosphere/src/data/mod.rs
+++ b/rust/noosphere/src/data/mod.rs
@@ -4,6 +4,7 @@ mod changelog;
 mod headers;
 mod links;
 mod memo;
+mod reference;
 mod sphere;
 mod versioned_map;
 
@@ -13,5 +14,6 @@ pub use changelog::*;
 pub use headers::*;
 pub use links::*;
 pub use memo::*;
+pub use reference::*;
 pub use sphere::*;
 pub use versioned_map::*;

--- a/rust/noosphere/src/data/reference.rs
+++ b/rust/noosphere/src/data/reference.rs
@@ -1,0 +1,7 @@
+use cid::Cid;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ReferenceIpld {
+    pub link: Cid,
+}


### PR DESCRIPTION
This change introduces an FS-like view over sphere data, in the spirit of APIs we prototyped in the early days of a couple months ago.

Given a sphere identity (a DID string), a block store and a "sphere" store - a store of pointers to our equivalent of "HEAD" for sphere lineages - a user can get a relatively ergonomic API for reading from or writing to slugs in a sphere. The view internally keeps a CID cursor over the lineage of the sphere, and allows the user to ignore most of the details related to IPLD and how history works.

This change is set up to take advantage of the streaming parser feature introduced in subconsciousnetwork/subtext#35, by offering file contents as an `AsyncRead` implementation. This can in turn be passed directly into e.g., the subtext parser, which will return a stream of parsed blocks.

Fixes #37 