### PR TITLE
Implement `orb auth` subcommand

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "path-absolutize",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "ucan",
  "ucan-key-support",
  "url",

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "^1", features = ["full"] }
+tokio-stream = "~0.1"
 home = "~0.5"
 clap = { version = "^4", features = ["derive", "cargo"] }
 path-absolutize = "^3"

--- a/rust/noosphere-cli/src/bin/orb.rs
+++ b/rust/noosphere-cli/src/bin/orb.rs
@@ -1,5 +1,3 @@
-// pub use noosphere_cli::native::main;
-
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {

--- a/rust/noosphere-cli/src/native/commands/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/auth.rs
@@ -1,12 +1,27 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use cid::Cid;
+use noosphere::{
+    authority::{SphereAction, SphereReference},
+    data::{CidKey, DelegationIpld, RevocationIpld},
+    view::{Sphere, SphereMutation, SPHERE_LIFETIME},
+};
+use serde_json::{json, Value};
+use ucan::{
+    builder::UcanBuilder,
+    capability::{Capability, Resource, With},
+    crypto::KeyMaterial,
+    store::UcanJwtStore,
+    Ucan,
+};
 
+use tokio_stream::StreamExt;
 
 use crate::native::workspace::Workspace;
 
-pub async fn auth_add(_did: &str, name: Option<String>, workspace: &Workspace) -> Result<()> {
+pub async fn auth_add(did: &str, name: Option<String>, workspace: &Workspace) -> Result<()> {
     workspace.expect_local_directories()?;
 
-    let _name = match name {
+    let name = match name {
         Some(name) => name,
         None => {
             let random_name = witty_phrase_generator::WPGen::new()
@@ -17,17 +32,169 @@ pub async fn auth_add(_did: &str, name: Option<String>, workspace: &Workspace) -
                 .collect::<Vec<String>>()
                 .join("-");
             println!(
-                "Note: since no name was specified, the authorization will be saved with the pet name \"{}\"",
+                "Note: since no name was specified, the authorization will be saved with the generated name \"{}\"",
                 random_name
             );
             random_name
         }
     };
 
-    // let key_material = workspace.get_local_key().await?;
-    // let sphere =
+    let mut db = workspace.get_local_db().await?;
+    let my_key = workspace.get_local_key().await?;
+    let my_did = my_key.get_did().await?;
+    let sphere_did = workspace.get_local_identity().await?;
+    let latest_sphere_cid = db
+        .get_version(&sphere_did)
+        .await?
+        .ok_or_else(|| anyhow!("Sphere version pointer is missing or corrupted"))?;
+    let authorization = workspace.get_local_authorization().await?;
 
-    // let ucan = UcanBuilder::default().issued_by(&key_material).for_audience(did).claiming_capability(capability)
+    let jwt = UcanBuilder::default()
+        .issued_by(&my_key)
+        .for_audience(did)
+        .claiming_capability(&Capability {
+            with: With::Resource {
+                kind: Resource::Scoped(SphereReference {
+                    did: sphere_did.clone(),
+                }),
+            },
+            can: SphereAction::Authorize,
+        })
+        .with_expiration(SPHERE_LIFETIME)
+        .witnessed_by(&authorization)
+        .build()?
+        .sign()
+        .await?
+        .encode()?;
+
+    let delegation = DelegationIpld::try_register(&name, &jwt, &mut db).await?;
+
+    let sphere = Sphere::at(&latest_sphere_cid, &db);
+
+    let mut mutation = SphereMutation::new(&my_did);
+
+    mutation
+        .allowed_ucans_mut()
+        .set(&CidKey(delegation.jwt), &delegation);
+
+    let mut revision = sphere.try_apply_mutation(&mutation).await?;
+    let version_cid = revision.try_sign(&my_key, Some(&authorization)).await?;
+
+    db.set_version(&sphere_did, &version_cid).await?;
+
+    println!(
+        r#"Successfully authorized {did} to access your sphere.
+
+NOTE: You *must* run `orb sync` before the other client can access the sphere!
+
+Use the following code to complete authorization in the other client:
+
+  {}"#,
+        delegation.jwt
+    );
 
     Ok(())
+}
+
+pub async fn auth_list(as_json: bool, workspace: &Workspace) -> Result<()> {
+    workspace.expect_local_directories()?;
+
+    let db = workspace.get_local_db().await?;
+    let sphere_did = workspace.get_local_identity().await?;
+    let latest_sphere_cid = db
+        .get_version(&sphere_did)
+        .await?
+        .ok_or_else(|| anyhow!("Sphere version pointer is missing or corrupted"))?;
+
+    let sphere = Sphere::at(&latest_sphere_cid, &db);
+
+    let authorization = sphere.try_get_authorization().await?;
+
+    let allowed_ucans = authorization.try_get_allowed_ucans().await?;
+
+    let mut authorizations: Vec<(String, String, Cid)> = Vec::new();
+    let mut delegation_stream = allowed_ucans.stream().await?;
+    let mut max_name_length: usize = 7;
+
+    while let Some(Ok((_, delegation))) = delegation_stream.next().await {
+        let jwt = db.require_token(&delegation.jwt).await?;
+        let ucan = Ucan::try_from_token_string(&jwt)?;
+        let name = delegation.name.clone();
+
+        max_name_length = max_name_length.max(name.len());
+        authorizations.push((
+            delegation.name.clone(),
+            ucan.audience().into(),
+            delegation.jwt.clone(),
+        ));
+    }
+
+    if as_json {
+        let authorizations: Vec<Value> = authorizations
+            .into_iter()
+            .map(|(name, did, cid)| {
+                json!({
+                    "name": name,
+                    "did": did,
+                    "cid": cid.to_string()
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json!(authorizations))?);
+    } else {
+        println!("{:1$}  AUTHORIZED KEY", "NAME", max_name_length);
+        for (name, did, _) in authorizations {
+            println!("{:1$}  {did}", name, max_name_length);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn auth_revoke(name: &str, workspace: &Workspace) -> Result<()> {
+    workspace.expect_local_directories()?;
+
+    let mut db = workspace.get_local_db().await?;
+    let sphere_did = workspace.get_local_identity().await?;
+    let latest_sphere_cid = db
+        .get_version(&sphere_did)
+        .await?
+        .ok_or_else(|| anyhow!("Sphere version pointer is missing or corrupted"))?;
+
+    let my_key = workspace.get_local_key().await?;
+    let my_did = my_key.get_did().await?;
+
+    let sphere = Sphere::at(&latest_sphere_cid, &db);
+
+    let authorization = sphere.try_get_authorization().await?;
+
+    let allowed_ucans = authorization.try_get_allowed_ucans().await?;
+
+    let mut delegation_stream = allowed_ucans.stream().await?;
+
+    while let Some(Ok((CidKey(cid), delegation))) = delegation_stream.next().await {
+        if delegation.name == name {
+            let revocation = RevocationIpld::try_revoke(&cid, &my_key).await?;
+
+            let mut mutation = SphereMutation::new(&my_did);
+
+            let key = CidKey(cid.clone());
+
+            mutation.allowed_ucans_mut().remove(&key);
+            mutation.revoked_ucans_mut().set(&key, &revocation);
+
+            let mut revision = sphere.try_apply_mutation(&mutation).await?;
+            let ucan = workspace.get_local_authorization().await?;
+
+            let sphere_cid = revision.try_sign(&my_key, Some(&ucan)).await?;
+
+            db.set_version(&sphere_did, &sphere_cid).await?;
+
+            println!("The authorization named {:?} has been revoked", name);
+
+            return Ok(());
+        }
+    }
+
+    Err(anyhow!("There is no authorization named {:?}", name))
 }

--- a/rust/noosphere-cli/src/native/mod.rs
+++ b/rust/noosphere-cli/src/native/mod.rs
@@ -19,6 +19,8 @@ use commands::sphere::join_sphere;
 use workspace::Workspace;
 
 use self::commands::auth::auth_add;
+use self::commands::auth::auth_list;
+use self::commands::auth::auth_revoke;
 
 // orb config set <key> <value> -> Set local configuration
 // orb config get <key> -> Read local configuration
@@ -239,13 +241,13 @@ pub enum AuthCommand {
     /// Print the name and DID for all keys that the owner has authorized
     /// to work on this sphere
     List {
-        /// Output the list of available keys as formatted JSON
+        /// Output the list of authorized keys as formatted JSON
         #[clap(short = 'j', long)]
         as_json: bool,
     },
 
     /// Revoke authorization to work on the sphere from a specified key
-    Remove {
+    Revoke {
         /// The name of a key to revoke authorization for
         name: String,
     },
@@ -305,8 +307,8 @@ pub async fn main() -> Result<()> {
         OrbCommand::Publish { version: _ } => todo!(),
         OrbCommand::Auth { command } => match command {
             AuthCommand::Add { did, name } => auth_add(&did, name, &workspace).await?,
-            AuthCommand::List { as_json: _ } => todo!(),
-            AuthCommand::Remove { name: _ } => todo!(),
+            AuthCommand::List { as_json } => auth_list(as_json, &workspace).await?,
+            AuthCommand::Revoke { name } => auth_revoke(&name, &workspace).await?,
         },
     };
 


### PR DESCRIPTION
This change implements basic support for authorization of other keys with the Noosphere CLI.

 - `orb auth add $DID` will generate a UCAN authorization for the given DID and store it in the sphere; you can give it a pet name, or else a random one is generated for you
 - `orb auth list [--as-json]` will enumerate the current set of authorizations 
 - `orb auth revoke $NAME` will revoke authorization by pet name, removing the authorization from the allowed list and adding a signed revocation of it to the sphere

Fixes #72 