### PR TITLE
Implement `orb save` and `orb status` subcommands

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -414,6 +414,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1122,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,13 +1703,19 @@ dependencies = [
  "anyhow",
  "cid",
  "clap 4.0.9",
+ "globset",
  "home",
+ "libipld-cbor",
+ "libipld-core",
+ "mime_guess",
  "noosphere",
  "noosphere-api",
  "noosphere-fs",
  "noosphere-storage",
  "path-absolutize",
+ "pathdiff",
  "serde_json",
+ "subtext",
  "tokio",
  "tokio-stream",
  "ucan",
@@ -2114,6 +2142,12 @@ checksum = "d611d5291372b3738a34ebf0d1f849e58b1dcc1101032f76a346eaa1f8ddbb5b"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -26,7 +26,12 @@ url = "^2"
 whoami = "^1"
 cid = "~0.8"
 serde_json = "^1"
-
+globset = "~0.4"
+pathdiff = "~0.2"
+subtext = "~0.3"
+mime_guess = "^2"
+libipld-core = "~0.14"
+libipld-cbor = "~0.14"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "~0.2"

--- a/rust/noosphere-cli/src/native/commands/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/auth.rs
@@ -43,10 +43,7 @@ pub async fn auth_add(did: &str, name: Option<String>, workspace: &Workspace) ->
     let my_key = workspace.get_local_key().await?;
     let my_did = my_key.get_did().await?;
     let sphere_did = workspace.get_local_identity().await?;
-    let latest_sphere_cid = db
-        .get_version(&sphere_did)
-        .await?
-        .ok_or_else(|| anyhow!("Sphere version pointer is missing or corrupted"))?;
+    let latest_sphere_cid = db.require_version(&sphere_did).await?;
     let authorization = workspace.get_local_authorization().await?;
 
     let jwt = UcanBuilder::default()

--- a/rust/noosphere-cli/src/native/commands/mod.rs
+++ b/rust/noosphere-cli/src/native/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod auth;
 pub mod config;
 pub mod key;
+pub mod save;
 pub mod sphere;
+pub mod status;

--- a/rust/noosphere-cli/src/native/commands/save.rs
+++ b/rust/noosphere-cli/src/native/commands/save.rs
@@ -1,0 +1,64 @@
+use anyhow::{anyhow, Result};
+use cid::Cid;
+use globset::Glob;
+use libipld_cbor::DagCborCodec;
+use noosphere_fs::SphereFs;
+use noosphere_storage::{interface::BlockStore, memory::MemoryStore};
+use ucan::crypto::KeyMaterial;
+
+use crate::native::workspace::Workspace;
+
+pub async fn save(matching: Option<Glob>, workspace: &Workspace) -> Result<()> {
+    workspace.expect_local_directories()?;
+
+    let mut memory_store = MemoryStore::default();
+    let mut db = workspace.get_local_db().await?;
+
+    let pattern = matching.map(|glob| glob.compile_matcher());
+
+    let (content, content_changes) = workspace
+        .get_local_content_changes(pattern, &db, &mut memory_store)
+        .await?;
+
+    if content_changes.is_empty() {
+        return Err(anyhow!("No changes to save"));
+    }
+
+    let content_entries = memory_store.entries.lock().await;
+
+    for (cid_bytes, block) in content_entries.iter() {
+        let cid = Cid::try_from(cid_bytes.as_slice())?;
+        db.put_block(&cid, block).await?;
+        db.put_links::<DagCborCodec>(&cid, block).await?;
+    }
+
+    let my_key = workspace.get_local_key().await?;
+    let my_did = my_key.get_did().await?;
+    let sphere_did = workspace.get_local_identity().await?;
+    let latest_sphere_cid = db.require_version(&sphere_did).await?;
+    let authorization = workspace.get_local_authorization().await?;
+
+    let mut fs = SphereFs::at(&sphere_did, &latest_sphere_cid, Some(&my_did), &db);
+
+    for (slug, _) in content_changes
+        .new
+        .iter()
+        .chain(content_changes.updated.iter())
+    {
+        if let Some((content_type, cid)) = content.matched.get(slug) {
+            println!("Updating {}...", slug);
+            // TODO(#87): Note and preserve original file extension in a header
+            fs.link(slug, &content_type.to_string(), cid, None).await?;
+        }
+    }
+
+    for (slug, _) in &content_changes.removed {
+        println!("Removing {}...", slug);
+        fs.remove(slug).await?;
+    }
+
+    let cid = fs.save(&my_key, Some(&authorization), None).await?;
+
+    println!("Save complete!\nThe latest sphere revision is {}", cid);
+    Ok(())
+}

--- a/rust/noosphere-cli/src/native/commands/status.rs
+++ b/rust/noosphere-cli/src/native/commands/status.rs
@@ -1,0 +1,85 @@
+use std::collections::BTreeMap;
+
+use crate::native::Workspace;
+use anyhow::Result;
+use noosphere::data::ContentType;
+use noosphere_storage::memory::MemoryStore;
+
+pub fn status_section(
+    name: &str,
+    entries: &BTreeMap<String, Option<ContentType>>,
+    section: &mut Vec<(String, String, String)>,
+    max_name_length: &mut usize,
+    max_content_type_length: &mut usize,
+) {
+    for (slug, content_type) in entries {
+        let content_type = content_type
+            .as_ref()
+            .map(|content_type| content_type.to_string())
+            .unwrap_or_else(|| "Unknown".into());
+
+        *max_name_length = *max_name_length.max(&mut slug.len());
+        *max_content_type_length = *max_content_type_length.max(&mut content_type.len());
+
+        section.push((slug.to_string(), content_type, String::from(name)));
+    }
+}
+
+pub async fn status(workspace: &Workspace) -> Result<()> {
+    workspace.expect_local_directories()?;
+
+    let mut memory_store = MemoryStore::default();
+    let db = workspace.get_local_db().await?;
+
+    let (_, mut changes) = workspace
+        .get_local_content_changes(None, &db, &mut memory_store)
+        .await?;
+
+    if changes.is_empty() {
+        println!("No new changes to sphere content!");
+        return Ok(());
+    }
+
+    let mut content = Vec::new();
+
+    let mut max_name_length = 7usize;
+    let mut max_content_type_length = 16usize;
+
+    status_section(
+        "Updated",
+        &mut changes.updated,
+        &mut content,
+        &mut max_name_length,
+        &mut max_content_type_length,
+    );
+
+    status_section(
+        "New",
+        &mut changes.new,
+        &mut content,
+        &mut max_name_length,
+        &mut max_content_type_length,
+    );
+
+    status_section(
+        "Removed",
+        &mut changes.removed,
+        &mut content,
+        &mut max_name_length,
+        &mut max_content_type_length,
+    );
+
+    println!(
+        "{:max_name_length$}  {:max_content_type_length$}  STATUS",
+        "NAME", "CONTENT-TYPE"
+    );
+
+    for (slug, content_type, status) in content {
+        println!(
+            "{:max_name_length$}  {:max_content_type_length$}  {}",
+            slug, content_type, status
+        );
+    }
+
+    Ok(())
+}

--- a/rust/noosphere-cli/src/native/mod.rs
+++ b/rust/noosphere-cli/src/native/mod.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod workspace;
 
 use anyhow::Result;
+use globset::Glob;
 use std::ffi::OsString;
 
 use std::path::PathBuf;
@@ -21,6 +22,8 @@ use workspace::Workspace;
 use self::commands::auth::auth_add;
 use self::commands::auth::auth_list;
 use self::commands::auth::auth_revoke;
+use self::commands::save::save;
+use self::commands::status::status;
 
 // orb config set <key> <value> -> Set local configuration
 // orb config get <key> -> Read local configuration
@@ -94,7 +97,10 @@ pub enum OrbCommand {
     /// Saves changed files to a sphere, creating and signing a new revision in
     /// the process; does nothing if there have been no changes to the files
     /// since the last revision
-    Save,
+    Save {
+        #[clap(short = 'm', long)]
+        matching: Option<Glob>,
+    },
 
     /// Synchronizes the local sphere with the copy in a configured gateway;
     /// note that this is a "conflict-free" sync that may cause local changes
@@ -300,9 +306,9 @@ pub async fn main() -> Result<()> {
             }
             SphereCommand::Transfer { new_owner_key: _ } => todo!(),
         },
-        OrbCommand::Status => todo!(),
+        OrbCommand::Status => status(&workspace).await?,
         OrbCommand::Diff { paths: _, base: _ } => todo!(),
-        OrbCommand::Save => todo!(),
+        OrbCommand::Save { matching } => save(matching, &workspace).await?,
         OrbCommand::Sync => todo!(),
         OrbCommand::Publish { version: _ } => todo!(),
         OrbCommand::Auth { command } => match command {

--- a/rust/noosphere-into/examples/notes-to-html/implementation.rs
+++ b/rust/noosphere-into/examples/notes-to-html/implementation.rs
@@ -12,10 +12,7 @@ use noosphere::{
     data::{ContentType, Header},
     view::Sphere,
 };
-use noosphere_storage::{
-    db::SphereDb,
-    memory::{MemoryStorageProvider},
-};
+use noosphere_storage::{db::SphereDb, memory::MemoryStorageProvider};
 use ucan::crypto::KeyMaterial;
 
 pub async fn main() -> Result<()> {
@@ -37,7 +34,7 @@ pub async fn main() -> Result<()> {
     println!("Content root: {:?}", content_root);
     println!("HTML root: {:?}", html_root.path());
 
-    let mut sphere_fs = SphereFs::latest(&sphere_identity, &db).await?;
+    let mut sphere_fs = SphereFs::latest(&sphere_identity, Some(&owner_did), &db).await?;
 
     let mut read_dir = fs::read_dir(content_root).await?;
 
@@ -64,12 +61,12 @@ pub async fn main() -> Result<()> {
                 slug,
                 &ContentType::Subtext.to_string(),
                 file,
-                &owner_key,
-                Some(&proof),
                 Some(vec![(Header::Title.to_string(), title)]),
             )
             .await?;
     }
+
+    sphere_fs.save(&owner_key, Some(&proof), None).await?;
 
     let native_fs = NativeFs {
         root: html_root.path().to_path_buf(),

--- a/rust/noosphere/src/data/headers/content_type.rs
+++ b/rust/noosphere/src/data/headers/content_type.rs
@@ -1,5 +1,6 @@
 use std::{convert::Infallible, fmt::Display, str::FromStr};
 
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Debug)]
 pub enum ContentType {
     Subtext,
     Sphere,

--- a/rust/noosphere/src/view/sphere.rs
+++ b/rust/noosphere/src/view/sphere.rs
@@ -1,7 +1,5 @@
 use anyhow::{anyhow, Result};
-use cid::{
-    Cid,
-};
+use cid::Cid;
 use libipld_cbor::DagCborCodec;
 use libipld_core::{codec::Codec, ipld::Ipld, raw::RawCodec};
 use ucan::{


### PR DESCRIPTION

This change introduces the `orb save` and `orb status` subcommands, as a follow-on to #71 and #80.

The `orb save` command commits content changes in the current workspace to the sphere, signing the revision and displaying the CID of that revision for the user.

The `orb status` command shows you the status of content in the current sphere workspace. It gives you an at-a-glance view of what changes will be performed if `orb save` is invoked.

As a convenience, `orb save` can be filtered using a glob pattern with the `-m` flag.

Files that are saved have their extension stripped. A `content-type` is inferred based on the file extension.

In addition to the implementation of the two new subcommands, some refactoring has been performed on the `SphereFs` construct. Previously, the FS view would save and sign a revision for every incremental write. Now, an explicit `save` call must be made to save any writes. Also, the view has been enhanced to enable unlinking a slug from some content.

Follow-on work has been filed in these issues: #85, #86 and #87.


[output.webm](https://user-images.githubusercontent.com/240083/194432668-0bb5f380-55ce-48c8-87ec-d77027af38ea.webm)

Fixes #73 
