### PR TITLE
SphereFS returns error when saving an empty change (fixes #85)

### DIFF
--- a/rust/noosphere/src/view/mutation.rs
+++ b/rust/noosphere/src/view/mutation.rs
@@ -72,6 +72,12 @@ impl<'a> SphereMutation {
     pub fn revoked_ucans(&self) -> &RevokedUcansMutation {
         &self.revoked_ucans
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.links.changes.len() == 0
+        && self.allowed_ucans.changes.len() == 0
+        && self.revoked_ucans.changes.len() == 0
+    }
 }
 
 pub type LinksMutation = VersionedMapMutation<String, Cid>;


### PR DESCRIPTION
Make `SphereFS::save` return an error when there is neither a non-empty mutation nor any additional headers to save.

Issue: https://github.com/subconsciousnetwork/noosphere/issues/85 


