### PR TITLE
Clean up build / runtime warnings

### DIFF
--- a/rust/noosphere-api/src/data.rs
+++ b/rust/noosphere-api/src/data.rs
@@ -12,7 +12,6 @@ use ucan::{
     capability::{Capability, Resource, With},
     chain::ProofChain,
     crypto::{did::DidParser, KeyMaterial},
-    serde::Base64Encode,
     store::UcanStore,
     Ucan,
 };

--- a/rust/noosphere-cli/src/native/commands/config.rs
+++ b/rust/noosphere-cli/src/native/commands/config.rs
@@ -5,7 +5,7 @@ use tokio::sync::OnceCell;
 use url::Url;
 
 use crate::native::{
-    workspace::{self, Workspace},
+    workspace::Workspace,
     ConfigGetCommand, ConfigSetCommand,
 };
 

--- a/rust/noosphere-cli/src/native/commands/serve/extractor.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/extractor.rs
@@ -4,7 +4,6 @@ use axum::{
     extract::{FromRequest, RequestParts},
     http::{header, StatusCode},
     response::IntoResponse,
-    response::Response,
     BoxError,
 };
 use libipld_cbor::DagCborCodec;

--- a/rust/noosphere-cli/src/native/commands/sphere.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere.rs
@@ -100,7 +100,7 @@ Type or paste the code here and press enter:"#,
         Some(token) => token,
     };
 
-    todo!();
+    // TODO: ...
 
     Ok(())
 }

--- a/rust/noosphere-cli/src/native/commands/sphere.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere.rs
@@ -100,9 +100,7 @@ Type or paste the code here and press enter:"#,
         Some(token) => token,
     };
 
-    // TODO: ...
-
-    Ok(())
+    todo!();
 }
 
 pub async fn authorize(_key_did: &str, working_paths: &Workspace) -> Result<()> {

--- a/rust/noosphere-fs/src/fs.rs
+++ b/rust/noosphere-fs/src/fs.rs
@@ -9,7 +9,7 @@ use noosphere_storage::{
     interface::{BlockStore, Store},
 };
 use once_cell::sync::OnceCell;
-use std::{str::FromStr, sync::Once};
+use std::{str::FromStr};
 use tokio_util::io::StreamReader;
 use ucan::{crypto::KeyMaterial, ucan::Ucan};
 

--- a/rust/noosphere-storage/src/db.rs
+++ b/rust/noosphere-storage/src/db.rs
@@ -7,7 +7,7 @@ use libipld_core::{
     raw::RawCodec,
 };
 use std::{collections::BTreeSet, fmt::Debug};
-use tokio_stream::{Stream, StreamExt};
+use tokio_stream::{Stream};
 use ucan::store::{UcanStore, UcanStoreConditionalSend};
 
 use crate::interface::{BlockStore, KeyValueStore, StorageProvider, Store};

--- a/rust/noosphere/src/data/bundle.rs
+++ b/rust/noosphere/src/data/bundle.rs
@@ -6,7 +6,7 @@ use cid::Cid;
 
 use futures::{pin_mut, StreamExt};
 use libipld_cbor::DagCborCodec;
-use libipld_core::{ipld::Ipld, raw::RawCodec, serde::to_ipld};
+use libipld_core::{raw::RawCodec, serde::to_ipld};
 use noosphere_cbor::{TryDagCbor, TryDagCborSendSync};
 use noosphere_storage::{
     encoding::{block_deserialize, block_serialize},

--- a/rust/noosphere/src/view/sphere.rs
+++ b/rust/noosphere/src/view/sphere.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use cid::Cid;
 use libipld_cbor::DagCborCodec;
-use libipld_core::{codec::Codec, ipld::Ipld, raw::RawCodec};
+use libipld_core::{ipld::Ipld, raw::RawCodec};
 use ucan::{
     builder::UcanBuilder,
     capability::{Capability, Resource, With},


### PR DESCRIPTION
When I tried building and running the tools, I realized there were some warnings output with the runtime / build-time text. Thankfully, these errors made sense™ to me despite my rust-fu being technically non-existent at the moment. So I thought to do something about it.

There were two classes of warnings:

1. Unused imports
1. Unreachable code

I'm pretty confident about the "unused imports" warnings; since this is something my editor can help with. The "unreachable code" bits, I had to trust that the tests already existing in the package would fail if I broke something.

Changelog:
- Implement `orb config` and `orb serve` subcommands (#92)
- Remove unused imports
- Change todo! to // TODO: so Ok(()) is reachable.

_p.s: I'm not responsible for the first point here, but it's part of my changeset. If Github doesn't filter this out, I'll work on cleaning it up._
