### PR TITLE
Bolster CI Actions

### DIFF
--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -1,0 +1,46 @@
+name: Run Checks
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  run-checks:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-toolchain:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Cache Project
+        uses: Swatinem/rust-cache@v2
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          components: rustfmt, clippy
+          toolchain: ${{ matrix.rust-toolchain }}
+      - name: Check Format
+        uses: actions-rs/cargo@v1
+        with:
+          args: --all -- --check
+          command: fmt
+          toolchain: ${{ matrix.rust-toolchain }}
+      - name: Lint
+        uses: actions-rs/cargo@v1
+        with:
+          args: --all -- -D warnings
+          command: clippy
+          toolchain: ${{ matrix.rust-toolchain }}
+      - name: Install Cargo Audit
+        uses: "actions-rs/cargo@v1"
+        with:
+          args: "--force cargo-audit"
+          command: install
+      - name: Run Audit on Deps
+        run: cargo-audit audit

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Lint
         uses: ClementTsang/cargo-action@v0.0.3
         with:
-          args: --all -- -D warnings
+          args: --all
           command: clippy
           directory: ./rust
           toolchain: ${{ matrix.rust-toolchain }}

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -8,8 +8,6 @@ on:
 jobs:
   run-checks:
     runs-on: ubuntu-latest
-    env:
-      PROTOC: /usr/bin/protoc
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   run-checks:
     runs-on: ubuntu-latest
+    env:
+      PROTOC: /usr/bin/protoc
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -26,21 +26,21 @@ jobs:
           components: rustfmt, clippy
           toolchain: ${{ matrix.rust-toolchain }}
       - name: Check Format
-        working-directory: ./rust
-        uses: actions-rs/cargo@v1
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           args: --all -- --check
           command: fmt
+          directory: ./rust
           toolchain: ${{ matrix.rust-toolchain }}
       - name: Lint
-        working-directory: ./rust
-        uses: actions-rs/cargo@v1
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           args: --all -- -D warnings
           command: clippy
+          directory: ./rust
           toolchain: ${{ matrix.rust-toolchain }}
       - name: Install Cargo Audit
-        uses: "actions-rs/cargo@v1"
+        uses: ClementTsang/cargo-action@v0.0.3
         with:
           args: "--force cargo-audit"
           command: install

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -26,12 +26,14 @@ jobs:
           components: rustfmt, clippy
           toolchain: ${{ matrix.rust-toolchain }}
       - name: Check Format
+        working-directory: ./rust
         uses: actions-rs/cargo@v1
         with:
           args: --all -- --check
           command: fmt
           toolchain: ${{ matrix.rust-toolchain }}
       - name: Lint
+        working-directory: ./rust
         uses: actions-rs/cargo@v1
         with:
           args: --all -- -D warnings
@@ -43,4 +45,5 @@ jobs:
           args: "--force cargo-audit"
           command: install
       - name: Run Audit on Deps
+        working-directory: ./rust
         run: cargo-audit audit

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -15,6 +15,8 @@ jobs:
           - stable
           - nightly
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Cache Project

--- a/rust/noosphere-api/src/route.rs
+++ b/rust/noosphere-api/src/route.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use std::fmt::Display;
-use url::{Url};
+use url::Url;
 
 use crate::data::AsQuery;
 

--- a/rust/noosphere-cli/src/native/commands/config.rs
+++ b/rust/noosphere-cli/src/native/commands/config.rs
@@ -4,10 +4,7 @@ use tokio::fs;
 use tokio::sync::OnceCell;
 use url::Url;
 
-use crate::native::{
-    workspace::Workspace,
-    ConfigGetCommand, ConfigSetCommand,
-};
+use crate::native::{workspace::Workspace, ConfigGetCommand, ConfigSetCommand};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ConfigContents {

--- a/rust/noosphere-cli/src/native/commands/save.rs
+++ b/rust/noosphere-cli/src/native/commands/save.rs
@@ -57,7 +57,9 @@ pub async fn save(matching: Option<Glob>, workspace: &Workspace) -> Result<()> {
         }) = content.matched.get(slug)
         {
             println!("Saving {}...", slug);
-            let headers = extension.as_ref().map(|extension| vec![(Header::FileExtension.to_string(), extension.clone())]);
+            let headers = extension
+                .as_ref()
+                .map(|extension| vec![(Header::FileExtension.to_string(), extension.clone())]);
 
             fs.link(slug, &content_type.to_string(), cid, headers)
                 .await?;

--- a/rust/noosphere-cli/src/native/commands/serve/gateway.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/gateway.rs
@@ -117,7 +117,7 @@ mod tests {
     use url::Url;
 
     use crate::native::{
-        commands::{key::key_create, serve::tracing::initialize_tracing, sphere::sphere_create},
+        commands::{key::key_create, sphere::sphere_create},
         workspace::Workspace,
     };
 
@@ -125,7 +125,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_can_be_identified_by_the_client_of_its_owner() {
-        initialize_tracing();
+        // initialize_tracing();
 
         let gateway_workspace = Workspace::temporary().unwrap();
         let client_workspace = Workspace::temporary().unwrap();
@@ -429,8 +429,6 @@ mod tests {
             }
             .unwrap();
 
-            let mut final_cid;
-
             for value in ["one", "two", "three"] {
                 let memo = MemoIpld::for_body(&mut client_db, vec![value])
                     .await
@@ -441,7 +439,7 @@ mod tests {
                 mutation.links_mut().set(&value.into(), &memo_cid);
 
                 let mut revision = sphere.try_apply_mutation(&mutation).await.unwrap();
-                final_cid = revision
+                let final_cid = revision
                     .try_sign(&client_key, Some(&client_authorization))
                     .await
                     .unwrap();

--- a/rust/noosphere-cli/src/native/commands/serve/gateway.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/gateway.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
-use ucan::{crypto::KeyMaterial};
+use ucan::crypto::KeyMaterial;
 
 use noosphere::authority::{Authorization, SUPPORTED_KEYS};
 use noosphere_api::route::Route as GatewayRoute;

--- a/rust/noosphere-cli/src/native/commands/serve/route/fetch.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/route/fetch.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 
-
 use axum::{extract::Query, http::StatusCode, response::IntoResponse, Extension};
 use cid::Cid;
 use noosphere::{

--- a/rust/noosphere-cli/src/native/commands/serve/route/identify.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/route/identify.rs
@@ -9,10 +9,7 @@ use ucan::{
     crypto::KeyMaterial,
 };
 
-use crate::native::commands::serve::{
-    authority::GatewayAuthority,
-    gateway::{GatewayScope},
-};
+use crate::native::commands::serve::{authority::GatewayAuthority, gateway::GatewayScope};
 
 pub async fn identify_route<K: KeyMaterial>(
     authority: GatewayAuthority,

--- a/rust/noosphere-cli/src/native/commands/serve/route/push.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/route/push.rs
@@ -13,7 +13,6 @@ use noosphere_storage::{db::SphereDb, native::NativeStore};
 use ucan::capability::{Capability, Resource, With};
 use ucan::crypto::KeyMaterial;
 
-
 use crate::native::commands::serve::gateway::GatewayScope;
 use crate::native::commands::serve::{authority::GatewayAuthority, extractor::Cbor};
 

--- a/rust/noosphere-into/src/html/transform/subtext.rs
+++ b/rust/noosphere-into/src/html/transform/subtext.rs
@@ -78,10 +78,8 @@ where
     async fn transform_block(&self, block: Block<Entity>) -> Result<String> {
         let mut content_html_strings = Vec::new();
         let mut transclude_html_strings = Vec::new();
-        let content_entities: Vec<Entity> = block
-            .to_content_entities()
-            .into_iter().cloned()
-            .collect();
+        let content_entities: Vec<Entity> =
+            block.to_content_entities().into_iter().cloned().collect();
         let is_solo_slashlink = if let (Some(&Entity::SlashLink(_)), 1) =
             (content_entities.first(), content_entities.len())
         {

--- a/rust/noosphere-into/src/html/transform/transclude.rs
+++ b/rust/noosphere-into/src/html/transform/transclude.rs
@@ -26,21 +26,23 @@ where
     pub async fn transform(&'a self, slug: &str) -> Result<Option<String>> {
         let transclude = self.transcluder.transclude(slug).await?;
 
-        Ok(transclude.map(|Transclude::Text(text_transclude)| html! {
-                    li(class="transclude-item") {
-                        a(class="transclude-format-text", href=&text_transclude.href) {
-                            @ if let Some(title) = &text_transclude.title {
-                                span(class="title") : title
-                            }
-
-                            @ if let Some(excerpt) = &text_transclude.excerpt {
-                                span(class="excerpt") : excerpt
-                            }
-
-                            span(class="link-text") : &text_transclude.link_text
+        Ok(transclude.map(|Transclude::Text(text_transclude)| {
+            html! {
+                li(class="transclude-item") {
+                    a(class="transclude-format-text", href=&text_transclude.href) {
+                        @ if let Some(title) = &text_transclude.title {
+                            span(class="title") : title
                         }
+
+                        @ if let Some(excerpt) = &text_transclude.excerpt {
+                            span(class="excerpt") : excerpt
+                        }
+
+                        span(class="link-text") : &text_transclude.link_text
                     }
                 }
-                .to_string()))
+            }
+            .to_string()
+        }))
     }
 }

--- a/rust/noosphere-p2p/src/dht/channel.rs
+++ b/rust/noosphere-p2p/src/dht/channel.rs
@@ -2,7 +2,6 @@ use core::{fmt, result::Result};
 use tokio;
 use tokio::sync::{mpsc, mpsc::error::SendError, oneshot, oneshot::error::RecvError};
 
-
 impl std::error::Error for ChannelError {}
 impl fmt::Display for ChannelError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/rust/noosphere-p2p/src/dht/config.rs
+++ b/rust/noosphere-p2p/src/dht/config.rs
@@ -60,10 +60,7 @@ mod tests {
         let (peer_id, mut address) = DHTConfig::get_peer_id_and_address(&config);
 
         assert_eq!(peer_id, libp2p::PeerId::from(keypair.public()));
-        assert_eq!(
-            address.pop().unwrap(),
-            Protocol::P2p(peer_id.into())
-        );
+        assert_eq!(address.pop().unwrap(), Protocol::P2p(peer_id.into()));
         assert_eq!(address.pop().unwrap(), Protocol::Tcp(33333));
         assert_eq!(
             address.pop().unwrap(),

--- a/rust/noosphere-p2p/src/dht/processor.rs
+++ b/rust/noosphere-p2p/src/dht/processor.rs
@@ -111,7 +111,7 @@ impl DHTProcessor {
                 _ = bootstrap_tick.tick() => self.execute_bootstrap()?,
                 _ = peer_dialing_tick.tick() => self.dial_next_peer(),
             }
-        };
+        }
         Ok(())
     }
 
@@ -144,9 +144,7 @@ impl DHTProcessor {
             }
             */
             DHTRequest::Bootstrap => {
-                message.respond(
-                    self.execute_bootstrap().map(|_| DHTResponse::Success),
-                );
+                message.respond(self.execute_bootstrap().map(|_| DHTResponse::Success));
             }
             DHTRequest::GetNetworkInfo => {
                 let info = self.swarm.network_info();
@@ -325,7 +323,13 @@ impl DHTProcessor {
                 } => {}
                 kad::InboundRequest::PutRecord { source, record, .. } => match record {
                     Some(rec) => {
-                        if self.swarm.behaviour_mut().kad.store_mut().put(rec.clone()).is_err()
+                        if self
+                            .swarm
+                            .behaviour_mut()
+                            .kad
+                            .store_mut()
+                            .put(rec.clone())
+                            .is_err()
                         {
                             warn!("InboundRequest::PutRecord failed: {:?} {:?}", rec, source);
                         }
@@ -411,7 +415,8 @@ impl DHTProcessor {
         let addr = self.p2p_address.clone();
         dht_event_trace(self, &format!("Start listening on {}", addr));
         self.swarm
-            .listen_on(addr).map(|_| ())
+            .listen_on(addr)
+            .map(|_| ())
             .map_err(DHTError::from)
     }
 
@@ -424,7 +429,8 @@ impl DHTProcessor {
         self.swarm
             .behaviour_mut()
             .kad
-            .bootstrap().map(|_| ())
+            .bootstrap()
+            .map(|_| ())
             .map_err(|_| DHTError::NoKnownPeers)
     }
 }
@@ -453,9 +459,7 @@ fn dht_event_trace<T: std::fmt::Debug>(processor: &DHTProcessor, data: &T) {
     let peer_id_b58 = processor.peer_id.to_base58();
     trace!(
         "\nFrom ..{:#?}..\n{:#?}",
-        peer_id_b58
-            .get(8..14)
-            .unwrap_or("INVALID PEER ID"),
+        peer_id_b58.get(8..14).unwrap_or("INVALID PEER ID"),
         data
     );
 }

--- a/rust/noosphere-p2p/tests/integration_test.rs
+++ b/rust/noosphere-p2p/tests/integration_test.rs
@@ -3,7 +3,6 @@
 use noosphere_p2p::dht::{DHTError, DHTNetworkInfo, DHTNode, DHTStatus};
 use std::str;
 
-
 //use tracing::*;
 mod utils;
 use utils::{create_test_config, generate_multiaddr, initialize_network, swarm_command};

--- a/rust/noosphere-storage/src/db.rs
+++ b/rust/noosphere-storage/src/db.rs
@@ -7,7 +7,7 @@ use libipld_core::{
     raw::RawCodec,
 };
 use std::{collections::BTreeSet, fmt::Debug};
-use tokio_stream::{Stream};
+use tokio_stream::Stream;
 use ucan::store::{UcanStore, UcanStoreConditionalSend};
 
 use crate::interface::{BlockStore, KeyValueStore, StorageProvider, Store};

--- a/rust/noosphere-storage/src/encoding.rs
+++ b/rust/noosphere-storage/src/encoding.rs
@@ -12,7 +12,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 /// Encode some bytes as an unpadded URL-safe base64 string
 pub fn base64_encode(data: &[u8]) -> Result<String> {
-    Ok(base64::encode_config(&data, base64::URL_SAFE_NO_PAD))
+    Ok(base64::encode_config(data, base64::URL_SAFE_NO_PAD))
 }
 
 /// Decode some bytes from an unpadded URL-safe base64 string

--- a/rust/noosphere/src/data/sphere.rs
+++ b/rust/noosphere/src/data/sphere.rs
@@ -43,11 +43,7 @@ mod tests {
         data::{ContentType, Header, MemoIpld, SphereIpld},
     };
 
-    use noosphere_storage::{
-        db::SphereDb,
-        interface::BlockStore,
-        memory::{MemoryStorageProvider},
-    };
+    use noosphere_storage::{db::SphereDb, interface::BlockStore, memory::MemoryStorageProvider};
 
     fn generate_credential() -> Ed25519KeyMaterial {
         let private_key = Ed25519PrivateKey::new(rand::thread_rng());

--- a/rust/noosphere/src/view/mutation.rs
+++ b/rust/noosphere/src/view/mutation.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use cid::Cid;
 use libipld_cbor::DagCborCodec;
-use ucan::{crypto::KeyMaterial};
+use ucan::crypto::KeyMaterial;
 
 use crate::{
     authority::Authorization,


### PR DESCRIPTION
This change brings some extra functionality into the CI process. Using Github Actions, we should be able to

- Run lint checks on change-sets
- Audit dependencies
- Runs the formatting tool

…on pull requests.

_p.s: I've kept this away from pushes on the invariant that the development process here receives all contributions to the main branch through some pull request of some sort._

Fixes subconsciousnetwork/noosphere#94
