### PR TITLE
docs: Add crate READMEs and Cargo.toml metadata

### DIFF
--- a/rust/noosphere-api/Cargo.toml
+++ b/rust/noosphere-api/Cargo.toml
@@ -2,8 +2,20 @@
 name = "noosphere-api"
 version = "0.1.0-alpha.1"
 edition = "2021"
+keywords = ["rest", "api", "noosphere", "p2p"]
+categories = [
+  "web-programming",
+  "http-client",
+  "authentication",
+  "web-assembly"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-api"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "^1"

--- a/rust/noosphere-api/README.md
+++ b/rust/noosphere-api/README.md
@@ -1,0 +1,7 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere API
+
+This crate contains type information pertinent to the REST API of the gateway
+server that is a part of the Noosphere CLI, as well as a reference client that
+can be used on the web or on native targets.

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -2,6 +2,18 @@
 name = "noosphere-cli"
 version = "0.1.0-alpha.1"
 edition = "2021"
+keywords = ["cli", "sync", "noosphere", "p2p", "ucan"]
+categories = [
+  "authentication",
+  "filesystem",
+  "command-line interface"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-cli"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/noosphere-cli/README.md
+++ b/rust/noosphere-cli/README.md
@@ -1,0 +1,7 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere CLI
+
+The Noosphere CLI is a reference client and pedagogical tool to demonstrate
+the principles of the Noosphere protocol and give interested users a
+no-code, low-complexity tool to synchronize content through the Noosphere.

--- a/rust/noosphere-collections/Cargo.toml
+++ b/rust/noosphere-collections/Cargo.toml
@@ -2,8 +2,18 @@
 name = "noosphere-collections"
 version = "0.1.0-alpha.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+keywords = ["hamt", "ipld", "noosphere", "p2p", "async"]
+categories = [
+  "data structures",
+  "asynchronous",
+  "web-assembly"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-collections"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
 [dependencies]
 anyhow = "^1"

--- a/rust/noosphere-collections/README.md
+++ b/rust/noosphere-collections/README.md
@@ -1,0 +1,6 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere Collections
+
+This crate contains sophisticated collection data types that are needed by an
+efficient implementation of Noosphere's IPLD data structures.

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -2,8 +2,20 @@
 name = "noosphere-core"
 version = "0.1.0-alpha.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+keywords = ["hamt", "ipld", "noosphere", "p2p", "async"]
+categories = [
+  "data-structures",
+  "asynchronous",
+  "encoding",
+  "web-programming",
+  "web-assembly"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-core"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
 [dependencies]
 log = "~0.4"

--- a/rust/noosphere-core/README.md
+++ b/rust/noosphere-core/README.md
@@ -1,0 +1,7 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere Core
+
+This crate contains the core data types of the Rust Noosphere implementation,
+as well as some higher-order views over those data types to make asynchronous
+operations over IPLD data a little more ergonomic for typical usages.

--- a/rust/noosphere-fs/Cargo.toml
+++ b/rust/noosphere-fs/Cargo.toml
@@ -2,8 +2,20 @@
 name = "noosphere-fs"
 version = "0.1.0-alpha.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+keywords = ["fs", "ipld", "noosphere", "p2p", "async"]
+categories = [
+  "asynchronous",
+  "encoding",
+  "web-programming",
+  "file-system",
+  "web-assembly"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-fs"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
 [dependencies]
 noosphere-core = { path = "../noosphere-core" }

--- a/rust/noosphere-fs/README.md
+++ b/rust/noosphere-fs/README.md
@@ -1,0 +1,7 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere FS
+
+A high-level view over a sphere - the Noosphere data type that represents an
+entity's data - that enables the user to read and write content to the sphere
+as though they were accessing a typical file system.

--- a/rust/noosphere-into/Cargo.toml
+++ b/rust/noosphere-into/Cargo.toml
@@ -2,8 +2,18 @@
 name = "noosphere-into"
 version = "0.1.0-alpha.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+keywords = ["html", "ipld", "noosphere", "subtext", "transcode"]
+categories = [
+  "asynchronous",
+  "web-programming",
+  "file-system"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-into"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
 [dependencies]
 noosphere-core = { path = "../noosphere-core" }

--- a/rust/noosphere-into/README.md
+++ b/rust/noosphere-into/README.md
@@ -3,5 +3,6 @@
 # noosphere-into
 
 This crate implements transformations of Noosphere content into various target
-formats. Currently, only transformation into HTML has been implemented. In
-time, we will also support rendering raw Noosphere content to a disk and possibly even transformation to other note formats.
+formats. Currently, only transformation into HTML has been implemented. In time,
+we will also support rendering raw Noosphere content to a disk and possibly
+even transformation to other note formats.

--- a/rust/noosphere-storage/Cargo.toml
+++ b/rust/noosphere-storage/Cargo.toml
@@ -2,6 +2,19 @@
 name = "noosphere-storage"
 version = "0.1.0-alpha.1"
 edition = "2021"
+keywords = ["storage", "web", "noosphere", "sled", "ipld", "indexeddb"]
+categories = [
+  "asynchronous",
+  "file-system",
+  "web-programming",
+  "web-assembly"
+]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere-storage"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/noosphere-storage/README.md
+++ b/rust/noosphere-storage/README.md
@@ -1,0 +1,8 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere Storage
+
+The Rust implementation of Noosphere supports pluggable backing storage. This
+crate defines the trait that must be implemented by a storage implementation,
+and also contains ready-to-use implementations for native file storage (backed
+by Sled), in-memory storage and web browser storage (backed by IndexedDB).


### PR DESCRIPTION
Note: the READMEs are just stubs with a high-level description of the crate at this time.