### PR TITLE
feat(noosphere): Introduce `noosphere` crate

### DIFF
--- a/.github/workflows/noosphere_apple_build.yaml
+++ b/.github/workflows/noosphere_apple_build.yaml
@@ -1,0 +1,129 @@
+on:
+  - workflow_call
+  - workflow_dispatch
+
+name: 'Build Noosphere artifacts (Apple)'
+
+jobs:
+  # Build Noosphere out of the noosphere crate for Apple targets
+  noosphere-apple-build:
+    name: 'Build Noosphere libraries (Apple)'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # iOS
+          - target: aarch64-apple-ios
+          # iOS Simulator
+          - target: x86_64-apple-ios
+          - target: aarch64-apple-ios-sim
+          # Mac OS
+          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.target }}
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+      - uses: ConorMacBride/install-package@v1
+        with:
+          brew: protobuf cmake
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --package noosphere --release --locked --target ${{ matrix.target }}
+      - run: |
+          cd target/${{ matrix.target }}/release
+      - uses: actions/upload-artifact@v3
+        with:
+          name: lib_${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/libnoosphere.a
+
+  # Generates the FFI C header for Noosphere and bundles it with a
+  # modulemap for Apple use cases
+  noosphere-header-generation:
+    name: 'Generate Noosphere C header'
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - uses: ConorMacBride/install-package@v1
+        with:
+          brew: protobuf cmake
+      - name: 'Generate the header'
+        run: |
+          cd rust/noosphere/include
+          cargo run --example generate_header --features headers --locked
+          cd -
+      - uses: actions/upload-artifact@v3
+        with:
+          name: include
+          path: rust/noosphere/include
+
+  # Generate Apple "universal" libraries for Noosphere for supported targets
+  noosphere-apple-lipo:
+    name: 'Generate Noosphere universal libraries (Apple)'
+    needs: ['noosphere-apple-build']
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # iOS Simulator
+          - legacy_target: x86_64-apple-ios
+            future_target: aarch64-apple-ios-sim
+            platform: ios-simulator
+          # Mac OS
+          - legacy_target: x86_64-apple-darwin
+            future_target: aarch64-apple-darwin
+            platform: macos
+    runs-on: macos-12
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: 'Make a universal library'
+        run: |
+          lipo -create \
+            ./lib_${{ matrix.legacy_target }}/libnoosphere.a \
+            ./lib_${{ matrix.future_target }}/libnoosphere.a \
+            -output ./libnoosphere.a
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: lib_${{ matrix.platform }}-universal
+          path: libnoosphere.a
+
+  # Generates an Apple XCode Framework for Noosphere from all the built
+  # Apple libraries
+  noosphere-apple-xcframework:
+    name: 'Generate Noosphere XCFramework'
+    needs: ['noosphere-apple-lipo', 'noosphere-header-generation']
+    runs-on: macos-12
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: 'Generate XCFramework'
+        run: |
+          xcodebuild -create-xcframework \
+            -library ./lib_macos-universal/libnoosphere.a \
+            -headers ./include/ \
+            -library ./lib_ios-simulator-universal/libnoosphere.a \
+            -headers ./include/ \
+            -library ./lib_aarch64-apple-ios/libnoosphere.a \
+            -headers ./include/ \
+            -output ./LibNoosphere.xcframework
+          zip -r ./libnoosphere.zip ./LibNoosphere.xcframework
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libnoosphere_apple_framework
+          path: ./libnoosphere.zip

--- a/.github/workflows/noosphere_cli_build.yaml
+++ b/.github/workflows/noosphere_cli_build.yaml
@@ -1,0 +1,48 @@
+on:
+  - workflow_call
+  - workflow_dispatch
+
+name: 'Build Noosphere CLI'
+
+jobs:
+  # Build the orb binary for supported targets
+  noosphere-cli-build:
+    name: 'Build Noosphere CLI for supported targets'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Add additional targets here as we are ready to support them
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: orb-x86_64-unknown-linux-gnu.tar.gz
+    runs-on: ${{matrix.os}}
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+      - name: 'Install environment packages'
+        run: |
+          sudo apt-get update -qqy
+          sudo apt-get install protobuf-compiler cmake libssl-dev pkg-config
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --release --locked --target ${{ matrix.target }}
+
+      - name: 'Generate build tarball (*nix)'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf ../../../${{ matrix.name }} orb
+          cd -
+      - name: 'Upload build artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ matrix.name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,16 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.repository_owner == 'subconsciousnetwork'
     outputs:
-      any_noosphere_release: ${{
-        steps.release.outputs['rust/noosphere-cli--release_created'] ||
-        steps.release.outputs['rust/noosphere-core--release_created'] ||
-        steps.release.outputs['rust/noosphere-api--release_created'] ||
-        steps.release.outputs['rust/noosphere-ns--release_created'] ||
-        steps.release.outputs['rust/noosphere-storage--release_created'] ||
-        steps.release.outputs['rust/noosphere-fs--release_created'] ||
-        steps.release.outputs['rust/noosphere-into--release_created'] }}
       noosphere_cli_released: ${{ steps.release.outputs['rust/noosphere-cli--release_created'] }}
       noosphere_cli_release_tag_name: ${{ steps.release.outputs['rust/noosphere-cli--tag_name'] }}
+      noosphere_released: ${{ steps.release.outputs['rust/noosphere--release_created'] }}
+      noosphere_release_tag_name: ${{ steps.release.outputs['rust/noosphere--tag_name'] }}
     steps:
       - uses: chainguard-dev/actions/setup-gitsign@main
       - name: 'Run release-please'
@@ -43,50 +37,12 @@ jobs:
             Cargo.toml
 
   noosphere-cli-build:
-    name: 'Run a build for supported targets'
     needs: ['release-please']
     if: ${{ needs['release-please'].outputs.noosphere_cli_released }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Add additional targets here as we are ready to support them
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            name: orb-x86_64-unknown-linux-gnu.tar.gz
-    runs-on: ${{matrix.os}}
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-      - name: 'Install environment packages'
-        run: |
-          sudo apt-get update -qqy
-          sudo apt-get install jq protobuf-compiler cmake libssl-dev pkg-config
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: build
-          args: --release --locked --target ${{ matrix.target }}
+    uses: ./.github/workflows/noosphere_cli_build.yaml
 
-      - name: 'Generate build tarball (*nix)'
-        run: |
-          cd target/${{ matrix.target }}/release
-          tar czvf ../../../${{ matrix.name }} orb
-          cd -
-      - name: 'Upload build artifact'
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.name }}
-          path: ${{ matrix.name }}
-
-  upload-release-artifacts:
-    name: 'Add build artifacts to release'
+  noosphere-cli-release-artifacts:
+    name: 'Add Noosphere CLI artifacts to release'
     needs: ['release-please', 'noosphere-cli-build']
     runs-on: ubuntu-latest
     steps:
@@ -109,11 +65,52 @@ jobs:
           files: orb-*/orb-*
           tag_name: ${{ needs['release-please'].outputs.noosphere_cli_release_tag_name }}
 
+  noosphere-apple-build:
+    name: 'Build Noosphere artifacts (Apple)'
+    needs: ['release-please']
+    if: ${{ needs['release-please'].outputs.noosphere_released }}
+    uses: ./.github/workflows/noosphere_apple_build.yaml
+
+  noosphere-release-artifacts:
+    name: 'Add Noosphere artifacts to release'
+    needs: ['release-please', 'noosphere-apple-build']
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download XCode Framework artifact'
+        uses: actions/download-artifact@v3
+        with:
+          name: libnoosphere_apple_framework
+
+      - name: 'Generate checksum'
+        run: openssl dgst -sha256 ./libnoosphere.zip > ./CHECKSUM
+
+      # NOTE: The release has to be published before adding build artifacts,
+      # otherwise the upload causes a different release to be made (???)
+      - name: 'Publish release'
+        run: gh release edit ${{ needs['release-please'].outputs.noosphere_release_tag_name }} --draft=false --repo=subconsciousnetwork/noosphere
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Add build artifacts to release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            libnoosphere.zip
+            CHECKSUM
+          tag_name: ${{ needs['release-please'].outputs.noosphere_release_tag_name }}
+
+  # Publishes crates to crates.io in dependency order. This command is
+  # idempotent and won't re-publish crates that are already published, so it's
+  # safe for us to run it indiscriminately
   publish-crates:
     name: 'Publish to crates.io'
-    needs: ['release-please', 'noosphere-cli-build']
+    needs:
+      [
+        'release-please',
+        'noosphere-cli-release-artifacts',
+        'noosphere-release-artifacts',
+      ]
     runs-on: ubuntu-latest
-    if: ${{ needs['release-please'].outputs.any_noosphere_release }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 optimized_wasm
 dist
 .DS_Store
+noosphere.h

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,21 +1003,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "forest_hash_utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1260,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb19fe8de3ea0920d282f7b77dd4227aea6b8b999b42cdf0ca41b2472b14443a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,16 +1469,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "bytes",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1555,6 +1551,28 @@ dependencies = [
  "stdweb",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2042,6 +2060,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini_paste"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2499b7bd9834270bf24cfc4dd96be59020ba6fd7f3276b772aee2de66e82b63"
+dependencies = [
+ "mini_paste-proc_macro",
+]
+
+[[package]]
+name = "mini_paste-proc_macro"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c5f1f52e39b728e73af4b454f1b29173d4544607bd395dafe1918fd149db67"
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,24 +2169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "netlink-packet-core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2256,22 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "noosphere"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "noosphere-api",
+ "noosphere-core",
+ "noosphere-fs",
+ "noosphere-storage",
+ "safer-ffi",
+ "thiserror",
+ "ucan",
+ "ucan-key-support",
+]
 
 [[package]]
 name = "noosphere-api"
@@ -2600,51 +2631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,12 +2815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
-
-[[package]]
 name = "polling"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +2891,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -3153,6 +3139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "require_unsafe_in_body"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296446f2214753e33792f632262451e8d037cd9697df15db2fd531bdce5a0138"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,25 +3164,27 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg 0.10.1",
 ]
 
@@ -3289,6 +3288,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,13 +3332,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
-name = "schannel"
-version = "0.1.20"
+name = "safer-ffi"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "40c710243617290d86a49a30564d94d0b646eacf6d7b67035e20d6e8a21f1193"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "inventory",
+ "libc",
+ "mini_paste",
+ "proc-macro-hack",
+ "require_unsafe_in_body",
+ "safer_ffi-proc_macro",
+]
+
+[[package]]
+name = "safer_ffi-proc_macro"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc02dc034daa0944eb133b448f261ef7422ccae768e30f30ce5cdeb4ae4e506c"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3334,26 +3370,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "security-framework"
-version = "2.7.0"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3949,13 +3972,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
+name = "tokio-rustls"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -4341,12 +4365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4484,6 +4502,25 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "rust/noosphere-into",
   "rust/noosphere-cli",
   "rust/noosphere-ns",
+  "rust/noosphere"
 ]
 
 # See: https://github.com/rust-lang/rust/issues/90148#issuecomment-949194352

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,6 @@
       "release-as": "0.1.0"
     },
     "rust/noosphere-cli": {
-      "release-as": "0.1.0",
       "draft": true
     },
     "rust/noosphere-collections": {
@@ -29,6 +28,10 @@
     },
     "rust/noosphere-storage": {
       "release-as": "0.1.0"
+    },
+    "rust/noosphere": {
+      "draft": true,
+      "release-as": "0.1.0-alpha.1"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/rust/noosphere/.gitignore
+++ b/rust/noosphere/.gitignore
@@ -1,0 +1,1 @@
+noosphere.h

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "noosphere"
+version = "0.1.0"
+edition = "2021"
+description = "A high-level package for dealing with accessing the Noosphere"
+keywords = ["noosphere"]
+categories = ["filesystem"]
+rust-version = "1.60.0"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/noosphere"
+repository = "https://github.com/subconsciousnetwork/noosphere"
+homepage = "https://github.com/subconsciousnetwork/noosphere"
+readme = "README.md"
+
+[lib]
+crate-type = ["rlib", "staticlib", "cdylib"]
+
+[profile.release]
+opt-level = 'z'
+lto = true
+
+[features]
+headers = ["safer-ffi/headers"]
+
+[dependencies]
+anyhow = "^1"
+thiserror = "^1"
+lazy_static = "^1"
+safer-ffi = { version = "~0.0.10", features = ["proc_macros"] }
+
+noosphere-core = { version = "0.1.0-alpha.1", path = "../noosphere-core" }
+noosphere-fs = { version = "0.1.0-alpha.1", path = "../noosphere-fs" }
+noosphere-storage = { version = "0.1.0-alpha.1", path = "../noosphere-storage" }
+noosphere-api = { version = "0.1.0-alpha.1", path = "../noosphere-api" }
+ucan = { version = "0.7.0-alpha.1" }
+ucan-key-support = { version = "0.7.0-alpha.1" }

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -26,7 +26,7 @@ headers = ["safer-ffi/headers"]
 anyhow = "^1"
 thiserror = "^1"
 lazy_static = "^1"
-safer-ffi = { version = "~0.0.10", features = ["proc_macros"] }
+
 
 noosphere-core = { version = "0.1.0-alpha.1", path = "../noosphere-core" }
 noosphere-fs = { version = "0.1.0-alpha.1", path = "../noosphere-fs" }
@@ -34,3 +34,6 @@ noosphere-storage = { version = "0.1.0-alpha.1", path = "../noosphere-storage" }
 noosphere-api = { version = "0.1.0-alpha.1", path = "../noosphere-api" }
 ucan = { version = "0.7.0-alpha.1" }
 ucan-key-support = { version = "0.7.0-alpha.1" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+safer-ffi = { version = "~0.0.10", features = ["proc_macros"] }

--- a/rust/noosphere/README.md
+++ b/rust/noosphere/README.md
@@ -1,0 +1,7 @@
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+
+# Noosphere
+
+This is the entrypoint for most language-specific distributable packages the
+deal with accessing the Noosphere. It contains language-specific bindings and
+platform-sensitive behavior to provide a common set of high-level APIs.

--- a/rust/noosphere/examples/generate_header.rs
+++ b/rust/noosphere/examples/generate_header.rs
@@ -1,0 +1,6 @@
+fn main() -> std::io::Result<()> {
+    #[cfg(feature = "headers")]
+    noosphere::ffi::generate_headers()?;
+
+    Ok(())
+}

--- a/rust/noosphere/include/module.modulemap
+++ b/rust/noosphere/include/module.modulemap
@@ -1,0 +1,4 @@
+module Noosphere {
+    header "noosphere.h"
+    export *
+}

--- a/rust/noosphere/src/builder.rs
+++ b/rust/noosphere/src/builder.rs
@@ -7,10 +7,3 @@ use noosphere_core::{authority::Authorization, view::Sphere};
 use noosphere_fs::SphereFs;
 use noosphere_storage::{db::SphereDb, interface::Store};
 use ucan::crypto::KeyMaterial;
-
-
-
-
-// pub struct NoosphereBuilder<'a, K, S> {
-//   user_key: Option<K>
-// }

--- a/rust/noosphere/src/builder.rs
+++ b/rust/noosphere/src/builder.rs
@@ -1,0 +1,16 @@
+use anyhow::{anyhow, Result};
+use noosphere_api::{
+    client::Client,
+    data::{FetchParameters, FetchResponse},
+};
+use noosphere_core::{authority::Authorization, view::Sphere};
+use noosphere_fs::SphereFs;
+use noosphere_storage::{db::SphereDb, interface::Store};
+use ucan::crypto::KeyMaterial;
+
+
+
+
+// pub struct NoosphereBuilder<'a, K, S> {
+//   user_key: Option<K>
+// }

--- a/rust/noosphere/src/error.rs
+++ b/rust/noosphere/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NoosphereError {
+    #[error("Network access required but network is currently offline")]
+    NetworkOffline,
+
+    #[error("{0}")]
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for NoosphereError {
+    fn from(error: anyhow::Error) -> Self {
+        NoosphereError::Other(error)
+    }
+}

--- a/rust/noosphere/src/ffi.rs
+++ b/rust/noosphere/src/ffi.rs
@@ -1,0 +1,59 @@
+use std::collections::BTreeMap;
+
+use lazy_static::lazy_static;
+use safer_ffi::prelude::*;
+
+use crate::{
+    platform::{PlatformKeyMaterial, PlatformStore},
+    sphere::SphereContext,
+};
+
+lazy_static! {
+    static ref ACTIVE_SPHERES: BTreeMap<SphereHandle, Box<SphereContext<'static, PlatformKeyMaterial, PlatformStore>>> =
+        BTreeMap::new();
+}
+
+static mut GLOBAL_STORAGE_PATH: Option<String> = None;
+static mut SPHERE_STORAGE_PATH: Option<String> = None;
+
+ReprC! {
+    #[repr(C)]
+    pub struct SphereHandle {
+        user_identity: char_p::Box,
+        sphere_identity: char_p::Box,
+    }
+
+}
+
+ReprC! {
+    #[repr(C)]
+    pub struct SphereCreationResult {
+        mnemonic: char_p::Box
+    }
+}
+
+/// Set the global Noosphere storage path. This will be used to store user
+/// data and configuration that is cross-cutting with respect to sphere data
+#[ffi_export]
+pub fn noosphere_set_global_storage_path(path: char_p::Ref<'_>) {
+    unsafe {
+        GLOBAL_STORAGE_PATH = Some(path.to_string());
+    }
+}
+
+/// Set the sphere storage path. This will be used as the root for storing
+/// sphere data. Spheres will be stored in distinctive sub-hierarchies within
+/// this path.
+#[ffi_export]
+pub fn noosphere_set_sphere_storage_path(path: char_p::Ref<'_>) {
+    unsafe {
+        SPHERE_STORAGE_PATH = Some(path.to_string());
+    }
+}
+
+#[cfg(feature = "headers")]
+pub fn generate_headers() -> std::io::Result<()> {
+    safer_ffi::headers::builder()
+        .to_file("noosphere.h")?
+        .generate()
+}

--- a/rust/noosphere/src/lib.rs
+++ b/rust/noosphere/src/lib.rs
@@ -1,0 +1,12 @@
+// pub mod builder;
+pub mod error;
+pub mod ffi;
+pub mod platform;
+pub mod sphere;
+// let key = create_key();
+// let sphere_context = noosphere_create_sphere(key);
+// noosphere_config_set(sphere_context, "gateway_url", "http://127.0.0.1:4433");
+// noosphere_
+
+// #[no_mangle]
+// pub unsafe extern "C" fn create_key()

--- a/rust/noosphere/src/lib.rs
+++ b/rust/noosphere/src/lib.rs
@@ -1,6 +1,8 @@
 // pub mod builder;
 pub mod error;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod ffi;
+
 pub mod platform;
 pub mod sphere;
 // let key = create_key();

--- a/rust/noosphere/src/lib.rs
+++ b/rust/noosphere/src/lib.rs
@@ -5,10 +5,3 @@ pub mod ffi;
 
 pub mod platform;
 pub mod sphere;
-// let key = create_key();
-// let sphere_context = noosphere_create_sphere(key);
-// noosphere_config_set(sphere_context, "gateway_url", "http://127.0.0.1:4433");
-// noosphere_
-
-// #[no_mangle]
-// pub unsafe extern "C" fn create_key()

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -17,7 +17,7 @@ mod inner {
 #[cfg(target_arch = "wasm32")]
 mod inner {
     use noosphere_storage::web::WebStore;
-    use ucan_key_support::WebCryptoRsaKeyMaterial;
+    use ucan_key_support::web_crypto::WebCryptoRsaKeyMaterial;
 
     pub type PlatformKeyMaterial = WebCryptoRsaKeyMaterial;
     pub type PlatformStore = WebStore;

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -1,0 +1,41 @@
+///! Platform-specific types and bindings
+
+#[cfg(all(
+    any(target_arch = "aarch64", target_arch = "x86_64"),
+    target_vendor = "apple"
+))]
+mod inner {
+    use noosphere_storage::native::NativeStore;
+    use ucan_key_support::ed25519::Ed25519KeyMaterial;
+
+    // NOTE: This is going to change when we transition to secure key storage
+    // This key material type implies insecure storage on disk
+    pub type PlatformKeyMaterial = Ed25519KeyMaterial;
+    pub type PlatformStore = NativeStore;
+}
+
+#[cfg(target_arch = "wasm32")]
+mod inner {
+    use noosphere_storage::web::WebStore;
+    use ucan_key_support::WebCryptoRsaKeyMaterial;
+
+    pub type PlatformKeyMaterial = WebCryptoRsaKeyMaterial;
+    pub type PlatformStore = WebStore;
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(all(
+        any(target_arch = "aarch64", target_arch = "x86_64"),
+        target_vendor = "apple"
+    ))
+))]
+mod inner {
+    use noosphere_storage::native::NativeStore;
+    use ucan_key_support::ed25519::Ed25519KeyMaterial;
+
+    pub type PlatformKeyMaterial = Ed25519KeyMaterial;
+    pub type PlatformStore = NativeStore;
+}
+
+pub use inner::*;

--- a/rust/noosphere/src/sphere.rs
+++ b/rust/noosphere/src/sphere.rs
@@ -1,0 +1,69 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use anyhow::{anyhow, Result};
+use noosphere_api::{
+    client::Client,
+    data::{FetchParameters, FetchResponse},
+};
+use noosphere_core::{authority::Authorization, view::Sphere};
+use noosphere_fs::SphereFs;
+use noosphere_storage::{db::SphereDb, interface::Store};
+use ucan::crypto::KeyMaterial;
+
+use crate::error::NoosphereError;
+
+pub enum SphereAccess<K> {
+    ReadOnly,
+    ReadWrite {
+        user_key: K,
+        user_identity: String,
+        authorization: Authorization,
+    },
+}
+
+pub enum SphereNetwork<'a, K, S>
+where
+    K: KeyMaterial,
+    S: Store,
+{
+    Online {
+        client: Arc<Client<'a, K, SphereDb<S>>>,
+    },
+    Offline,
+}
+
+pub struct SphereContext<'a, K, S>
+where
+    K: KeyMaterial,
+    S: Store,
+{
+    user_identity: String,
+    sphere_identity: String,
+    access: SphereAccess<K>,
+    db: SphereDb<S>,
+    network: SphereNetwork<'a, K, S>,
+}
+
+impl<'a, K, S> SphereContext<'a, K, S>
+where
+    K: KeyMaterial,
+    S: Store,
+{
+    pub async fn fs(&self) -> Result<SphereFs<S>, NoosphereError> {
+        let author_identity = match &self.access {
+            SphereAccess::ReadOnly => None,
+            SphereAccess::ReadWrite { user_identity, .. } => Some(user_identity.as_str()),
+        };
+
+        SphereFs::latest(&self.sphere_identity, author_identity, &self.db)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    fn require_online(&self) -> Result<Arc<Client<'a, K, SphereDb<S>>>, NoosphereError> {
+        match &self.network {
+            SphereNetwork::Online { client } => Ok(client.clone()),
+            SphereNetwork::Offline => Err(NoosphereError::NetworkOffline),
+        }
+    }
+}


### PR DESCRIPTION
The `noosphere` crate is the highest level entrypoint into Noosphere APIs that we offer. It re-exports the functionality of most of our other crates, and offers FFI interfaces for C and JS/WASM consumers.

In addition to the `noosphere` crate, this change introduces some major improvements to our Github Actions workflows. Workflows now let you build associated artifacts on demand, and are also assembled into a larger release orchestration.

NOTE: The `noosphere` crate is currently barebones because we just needed to get it to a point where we could compile it for different Apple targets and expose a trivial FFI. The focus of this change is on establishing our automation workflow for these kinds of artifacts.