### PR TITLE
dev: Implement a RecordValidator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,6 +2456,7 @@ name = "noosphere-ns"
 version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cid",
  "futures",
  "libipld-cbor",

--- a/rust/noosphere-ns/Cargo.toml
+++ b/rust/noosphere-ns/Cargo.toml
@@ -30,6 +30,7 @@ cid = "~0.8"
 serde = "^1"
 serde_json = "^1"
 futures = "0.3.1"
+async-trait = "~0.1"
 ucan = { version = "0.7.0-alpha.1" }
 ucan-key-support = { version = "0.7.0-alpha.1" }
 tokio = { version = "1.15", features = ["io-util", "io-std", "sync", "macros", "rt", "rt-multi-thread"] }

--- a/rust/noosphere-ns/src/dht/errors.rs
+++ b/rust/noosphere-ns/src/dht/errors.rs
@@ -8,6 +8,7 @@ use std::io;
 pub enum DHTError {
     Error(String),
     IO(io::ErrorKind),
+    ValidationError(Vec<u8>),
     LibP2PTransportError(Option<libp2p::Multiaddr>),
     LibP2PStorageError(KadStorageError),
     LibP2PGetRecordError(kad::GetRecordError),
@@ -34,6 +35,7 @@ impl fmt::Display for DHTError {
             DHTError::LibP2PGetProvidersError(e) => write!(fmt, "{:#?}", e),
             DHTError::IO(k) => write!(fmt, "{:#?}", k),
             DHTError::Error(m) => write!(fmt, "{:#?}", m),
+            DHTError::ValidationError(_) => write!(fmt, "validation error"),
         }
     }
 }

--- a/rust/noosphere-ns/src/dht/mod.rs
+++ b/rust/noosphere-ns/src/dht/mod.rs
@@ -6,8 +6,10 @@ mod processor;
 mod swarm;
 mod types;
 mod utils;
+mod validator;
 
 pub use config::DHTConfig;
 pub use errors::DHTError;
 pub use node::{DHTNode, DHTStatus};
 pub use types::DHTNetworkInfo;
+pub use validator::{DefaultRecordValidator, RecordValidator};

--- a/rust/noosphere-ns/src/dht/validator.rs
+++ b/rust/noosphere-ns/src/dht/validator.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+
+/// Trait that implements a `validate` function that determines
+/// what records can be set and stored on the [crate::dht::DHTNode].
+/// Currently only validates "Value" records.
+///
+/// # Example
+///
+/// ```
+/// use noosphere_ns::dht::RecordValidator;
+/// use async_trait::async_trait;
+/// use tokio;
+///
+/// struct MyValidator;
+/// #[async_trait]
+/// impl RecordValidator for MyValidator {
+///     // Ensures value is "hello" in bytes.
+///     async fn validate(&mut self, data: &[u8]) -> bool {
+///         data[..] == [104, 101, 108, 108, 111][..]
+///     }
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let mut validator = MyValidator {};
+///     let data = String::from("hello").into_bytes();
+///     let is_valid = validator.validate(&data).await;
+///     assert!(is_valid);
+/// }
+#[async_trait]
+pub trait RecordValidator: Send + Sync {
+    async fn validate(&mut self, record_value: &[u8]) -> bool;
+}
+
+/// A default implementation of [RecordValidator] that allows all records.
+#[derive(Clone)]
+pub struct DefaultRecordValidator {}
+
+#[async_trait]
+impl RecordValidator for DefaultRecordValidator {
+    async fn validate(&mut self, _record_value: &[u8]) -> bool {
+        true
+    }
+}

--- a/rust/noosphere-ns/src/lib.rs
+++ b/rust/noosphere-ns/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dht;
 mod name_system;
 mod records;
 pub mod utils;
+mod validator;
 
 pub use builder::NameSystemBuilder;
 pub use libp2p::multiaddr;

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -77,7 +77,7 @@ impl NSRecord {
     /// the sphere's owner authorized the publishing of a new
     /// content address. Returns an `Err` if validation fails.
     pub async fn validate<S: Store>(
-        &mut self,
+        &self,
         store: &SphereDb<S>,
         did_parser: &mut DidParser,
     ) -> Result<(), Error> {
@@ -248,7 +248,7 @@ mod test {
             .await
             .unwrap();
 
-        let mut record = NSRecord::new(
+        let record = NSRecord::new(
             UcanBuilder::default()
                 .issued_by(&sphere_key)
                 .for_audience(&sphere_identity)
@@ -282,7 +282,7 @@ mod test {
 
         // First verify that `owner` cannot publish for `sphere`
         // without delegation.
-        let mut record = NSRecord::new(
+        let record = NSRecord::new(
             UcanBuilder::default()
                 .issued_by(&owner_key)
                 .for_audience(&sphere_identity)
@@ -313,7 +313,7 @@ mod test {
         let _ = store.write_token(&delegate_ucan.encode()?).await?;
 
         // Attempt `owner` publishing `sphere` with the proper authorization
-        let mut record = NSRecord::new(
+        let record = NSRecord::new(
             UcanBuilder::default()
                 .issued_by(&owner_key)
                 .for_audience(&sphere_identity)

--- a/rust/noosphere-ns/src/validator.rs
+++ b/rust/noosphere-ns/src/validator.rs
@@ -1,0 +1,39 @@
+use crate::dht::RecordValidator;
+use crate::records::NSRecord;
+use async_trait::async_trait;
+use noosphere_core::authority::SUPPORTED_KEYS;
+use noosphere_storage::{db::SphereDb, interface::Store};
+use ucan::crypto::did::DidParser;
+
+pub struct Validator<S: Store> {
+    store: SphereDb<S>,
+    did_parser: DidParser,
+}
+
+impl<S> Validator<S>
+where
+    S: Store,
+{
+    pub fn new(store: &SphereDb<S>) -> Self {
+        Validator {
+            store: store.to_owned(),
+            did_parser: DidParser::new(SUPPORTED_KEYS),
+        }
+    }
+}
+
+#[async_trait]
+impl<S> RecordValidator for Validator<S>
+where
+    S: Store,
+{
+    async fn validate(&mut self, record_value: &[u8]) -> bool {
+        if let Ok(record) = NSRecord::try_from(record_value) {
+            return record
+                .validate(&self.store, &mut self.did_parser)
+                .await
+                .is_ok();
+        }
+        return false;
+    }
+}

--- a/rust/noosphere-ns/tests/dht_test.rs
+++ b/rust/noosphere-ns/tests/dht_test.rs
@@ -1,8 +1,10 @@
 #![cfg(not(target_arch = "wasm32"))]
 #![cfg(test)]
-use noosphere_ns::dht::{DHTError, DHTNetworkInfo, DHTNode, DHTStatus};
+use async_trait::async_trait;
+use noosphere_ns::dht::{
+    DHTError, DHTNetworkInfo, DHTNode, DHTStatus, DefaultRecordValidator, RecordValidator,
+};
 use std::str;
-
 pub mod utils;
 use noosphere_core::authority::generate_ed25519_key;
 
@@ -11,7 +13,12 @@ use utils::{create_test_config, initialize_network, swarm_command};
 /// Testing a detached DHTNode as a server with no peers.
 #[test_log::test(tokio::test)]
 async fn test_dhtnode_base_case() -> Result<(), DHTError> {
-    let mut node = DHTNode::new(&generate_ed25519_key(), None, &create_test_config())?;
+    let mut node = DHTNode::new(
+        &generate_ed25519_key(),
+        None,
+        DHTNode::<DefaultRecordValidator>::validator(),
+        &create_test_config(),
+    )?;
     assert_eq!(node.status(), DHTStatus::Initialized, "DHT is initialized");
     node.run()?;
     assert_eq!(node.status(), DHTStatus::Active, "DHT is active");
@@ -41,7 +48,12 @@ async fn test_dhtnode_base_case() -> Result<(), DHTError> {
 #[test_log::test(tokio::test)]
 async fn test_dhtnode_bootstrap() -> Result<(), DHTError> {
     let num_clients = 5;
-    let (mut bootstrap_nodes, mut client_nodes) = initialize_network(1, num_clients).await?;
+    let (mut bootstrap_nodes, mut client_nodes) = initialize_network(
+        1,
+        num_clients,
+        DHTNode::<DefaultRecordValidator>::validator(),
+    )
+    .await?;
     let bootstrap = bootstrap_nodes.pop().unwrap();
 
     for info in swarm_command(&mut client_nodes, |c| c.network_info()).await? {
@@ -67,7 +79,12 @@ async fn test_dhtnode_bootstrap() -> Result<(), DHTError> {
 #[test_log::test(tokio::test)]
 async fn test_dhtnode_simple() -> Result<(), DHTError> {
     let num_clients = 2;
-    let (mut _bootstrap_nodes, mut client_nodes) = initialize_network(1, num_clients).await?;
+    let (mut _bootstrap_nodes, mut client_nodes) = initialize_network(
+        1,
+        num_clients,
+        DHTNode::<DefaultRecordValidator>::validator(),
+    )
+    .await?;
 
     let client_a = client_nodes.pop().unwrap();
     let client_b = client_nodes.pop().unwrap();
@@ -93,7 +110,12 @@ async fn test_dhtnode_simple() -> Result<(), DHTError> {
 #[test_log::test(tokio::test)]
 async fn test_dhtnode_providers() -> Result<(), DHTError> {
     let num_clients = 2;
-    let (mut _bootstrap_nodes, mut client_nodes) = initialize_network(1, num_clients).await?;
+    let (mut _bootstrap_nodes, mut client_nodes) = initialize_network(
+        1,
+        num_clients,
+        DHTNode::<DefaultRecordValidator>::validator(),
+    )
+    .await?;
 
     let client_a = client_nodes.pop().unwrap();
     let client_b = client_nodes.pop().unwrap();
@@ -103,5 +125,103 @@ async fn test_dhtnode_providers() -> Result<(), DHTError> {
     println!("{:#?}", providers);
     assert_eq!(providers.len(), 1);
     assert_eq!(&providers[0], client_a.peer_id());
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_dhtnode_validator() -> Result<(), DHTError> {
+    #[derive(Clone)]
+    struct MyValidator {}
+
+    #[async_trait]
+    impl RecordValidator for MyValidator {
+        async fn validate(&mut self, data: &[u8]) -> bool {
+            data == String::from("VALID").into_bytes()
+        }
+    }
+
+    let num_clients = 2;
+    let (bootstrap_nodes, mut client_nodes) =
+        initialize_network(1, num_clients, MyValidator {}).await?;
+
+    let bootstrap_addresses = vec![bootstrap_nodes[0]
+        .p2p_address()
+        .expect("p2p address")
+        .to_owned()];
+    let unfiltered_client: DHTNode<DefaultRecordValidator> = {
+        let key_material = generate_ed25519_key();
+        let config = create_test_config();
+        let mut node: DHTNode<DefaultRecordValidator> = DHTNode::new(
+            &key_material,
+            Some(&bootstrap_addresses),
+            DHTNode::<DefaultRecordValidator>::validator(),
+            &config,
+        )?;
+        node.run()?;
+        node.bootstrap().await?;
+        node.wait_for_peers(1).await?;
+        node
+    };
+
+    let client_a = client_nodes.pop().unwrap();
+    let client_b = client_nodes.pop().unwrap();
+
+    client_a
+        .set_record(
+            String::from("foo_1").into_bytes(),
+            String::from("VALID").into_bytes(),
+        )
+        .await?;
+    let result = client_b
+        .get_record(String::from("foo_1").into_bytes())
+        .await?;
+    assert_eq!(
+        str::from_utf8(result.1.as_ref().unwrap()).expect("parseable"),
+        "VALID",
+        "validation allows valid records through"
+    );
+
+    assert!(
+        client_a
+            .set_record(
+                String::from("foo_2").into_bytes(),
+                String::from("INVALID").into_bytes(),
+            )
+            .await
+            .is_err(),
+        "setting a record validates locally"
+    );
+
+    // set a valid and an invalid record from the unfiltered client
+    unfiltered_client
+        .set_record(
+            String::from("foo_3").into_bytes(),
+            String::from("VALID").into_bytes(),
+        )
+        .await?;
+    unfiltered_client
+        .set_record(
+            String::from("foo_4").into_bytes(),
+            String::from("INVALID").into_bytes(),
+        )
+        .await?;
+
+    let result = client_b
+        .get_record(String::from("foo_3").into_bytes())
+        .await?;
+    assert_eq!(
+        str::from_utf8(result.1.as_ref().unwrap()).expect("parseable"),
+        "VALID",
+        "validation allows valid records through"
+    );
+
+    let result = client_b
+        .get_record(String::from("foo_4").into_bytes())
+        .await?;
+    assert!(
+        result.1.is_none(),
+        "invalid records are not retrieved from the network"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
 dev: Implement a RecordValidator trait for the NameSystem DHT, and wrap NameSystem validation in the NSRecord::validate function. Fixes #126

Lots of noise here due to adding the `<V: RecordValidator + 'static>` generic, and the async validation bubbling up its asyncness