### PR TITLE
chore: cleanups on some older DHT code and docs

### DIFF
--- a/rust/noosphere-ns/src/builder.rs
+++ b/rust/noosphere-ns/src/builder.rs
@@ -5,6 +5,9 @@ use noosphere_storage::{db::SphereDb, interface::Store};
 use std::net::Ipv4Addr;
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
+#[cfg(doc)]
+use libp2p::kad::KademliaConfig;
+
 /// [NameSystemBuilder] is the primary external interface for
 /// creating a new [NameSystem]. `key_material` and `store`
 /// must be provided.
@@ -89,7 +92,7 @@ where
 
     /// How long, in seconds, published records are replicated to
     /// peers. Should be significantly shorter than `record_ttl`.
-    /// See [KademliaConfig::set_publication_interval](https://docs.rs/libp2p/latest/libp2p/kad/struct.KademliaConfig.html#method.set_publication_interval).
+    /// See [KademliaConfig::set_publication_interval] and [KademliaConfig::set_provider_publication_interval].
     pub fn publication_interval(mut self, interval: u32) -> Self {
         self.dht_config.publication_interval = interval;
         self
@@ -103,7 +106,7 @@ where
 
     /// How long, in seconds, records remain valid for. Should be significantly
     /// longer than `publication_interval`.
-    /// See [KademliaConfig::set_record_ttl](https://docs.rs/libp2p/latest/libp2p/kad/struct.KademliaConfig.html#method.set_record_ttl).
+    /// See [KademliaConfig::set_record_ttl] and [KademliaConfig::set_provider_record_ttl].
     pub fn record_ttl(mut self, interval: u32) -> Self {
         self.dht_config.record_ttl = interval;
         self
@@ -111,7 +114,7 @@ where
 
     /// How long, in seconds, stored records are replicated to
     /// peers. Should be significantly shorter than `publication_interval`.
-    /// See [KademliaConfig::set_replication_interval](https://docs.rs/libp2p/latest/libp2p/kad/struct.KademliaConfig.html#method.set_replication_interval).
+    /// See [KademliaConfig::set_replication_interval].
     pub fn replication_interval(mut self, interval: u32) -> Self {
         self.dht_config.replication_interval = interval;
         self

--- a/rust/noosphere-ns/src/dht/config.rs
+++ b/rust/noosphere-ns/src/dht/config.rs
@@ -1,5 +1,8 @@
 use libp2p::Multiaddr;
 
+#[cfg(doc)]
+use libp2p::kad::KademliaConfig;
+
 #[derive(Clone, Debug)]
 pub struct DHTConfig {
     /// If bootstrap peers are provided, how often,
@@ -16,19 +19,19 @@ pub struct DHTConfig {
     pub peer_dialing_interval: u64,
     /// How long, in seconds, published records are replicated to
     /// peers. Should be significantly shorter than `record_ttl`.
-    /// See [KademliaConfig::set_publication_interval](https://docs.rs/libp2p/latest/libp2p/kad/struct.KademliaConfig.html#method.set_publication_interval).
+    /// See [KademliaConfig::set_publication_interval] and [KademliaConfig::set_provider_publication_interval].
     pub publication_interval: u32,
     /// How long, in seconds, until an unsuccessful
     /// DHT query times out.
     pub query_timeout: u32,
     /// How long, in seconds, stored records are replicated to
     /// peers. Should be significantly shorter than `publication_interval`.
-    /// See [KademliaConfig::set_replication_interval](https://docs.rs/libp2p/latest/libp2p/kad/struct.KademliaConfig.html#method.set_replication_interval).
+    /// See [KademliaConfig::set_replication_interval].
     /// Only applies to value records.
     pub replication_interval: u32,
     /// How long, in seconds, records remain valid for. Should be significantly
     /// longer than `publication_interval`.
-    /// See [KademliaConfig::set_record_ttl](https://docs.rs/libp2p/latest/libp2p/kad/struct.KademliaConfig.html#method.set_record_ttl).
+    /// See [KademliaConfig::set_record_ttl] and [KademliaConfig::set_provider_record_ttl].
     pub record_ttl: u32,
 }
 

--- a/rust/noosphere-ns/src/dht/mod.rs
+++ b/rust/noosphere-ns/src/dht/mod.rs
@@ -11,5 +11,5 @@ mod validator;
 pub use config::DHTConfig;
 pub use errors::DHTError;
 pub use node::{DHTNode, DHTStatus};
-pub use types::DHTNetworkInfo;
+pub use types::{DHTNetworkInfo, DHTRecord};
 pub use validator::{DefaultRecordValidator, RecordValidator};

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -9,17 +9,17 @@ use ucan::{chain::ProofChain, crypto::did::DidParser, Ucan};
 
 /// An [NSRecord] is the internal representation of a mapping from a
 /// sphere's identity (DID key) to a sphere's revision as a
-/// content address ([cid::Cid]). The record wraps a [ucan::Ucan] token,
+/// content address ([Cid]). The record wraps a [Ucan] token,
 /// providing de/serialization for transmitting in the NS network,
 /// and validates data ensuring the sphere's owner authorized the publishing
 /// of a new content address.
 ///
 /// When transmitting through the distributed NS network, the record is
-/// represented as the base64 encoded Ucan token.
+/// represented as the base64 encoded UCAN token.
 ///
 /// # Ucan Semantics
 ///
-/// An [NSRecord] is a small interface over a [ucan::Ucan] token,
+/// An [NSRecord] is a small interface over a [Ucan] token,
 /// with the following semantics:
 ///
 /// ```json
@@ -34,7 +34,7 @@ use ucan::{chain::ProofChain, crypto::did::DidParser, Ucan};
 ///     "with": "sphere:did:key:z6MkkVfktAC5rVNRmmTjkKPapT3bAyVkYH8ZVCF1UBNUfazp",
 ///     "can": "sphere/publish"
 ///   }],
-///   // Additional Ucan proofs needed to validate.
+///   // Additional UCAN proofs needed to validate.
 ///   "prf": [],
 ///   // Facts contain a single entry with an "address" field containing
 ///   // the content address of a sphere revision (CID) associated with
@@ -46,7 +46,7 @@ use ucan::{chain::ProofChain, crypto::did::DidParser, Ucan};
 /// ```
 #[derive(Debug, Clone)]
 pub struct NSRecord {
-    /// The wrapped Ucan token describing this record.
+    /// The wrapped UCAN token describing this record.
     pub(crate) token: Ucan,
     /// The resolved sphere revision this record maps to.
     pub(crate) address: Option<Cid>,
@@ -73,7 +73,7 @@ impl NSRecord {
         Self { token, address }
     }
 
-    /// Validates the underlying [ucan::Ucan] token, ensuring that
+    /// Validates the underlying [Ucan] token, ensuring that
     /// the sphere's owner authorized the publishing of a new
     /// content address. Returns an `Err` if validation fails.
     pub async fn validate<S: Store>(
@@ -122,17 +122,18 @@ impl NSRecord {
         self.token.audience()
     }
 
-    /// The sphere revision ([cid::Cid]) that the sphere's identity maps to.
+    /// The sphere revision ([Cid]) that the sphere's identity maps to.
     pub fn address(&self) -> Option<&Cid> {
         self.address.as_ref()
     }
 
-    /// Returns true if the UCAN token is past its expiration.
+    /// Returns true if the [Ucan] token is past its expiration.
     pub fn is_expired(&self) -> bool {
         self.token.is_expired()
     }
 }
 
+/// Create a new [NSRecord] taking a [Ucan] token.
 impl From<Ucan> for NSRecord {
     fn from(ucan: Ucan) -> Self {
         Self::new(ucan)
@@ -157,21 +158,21 @@ impl TryFrom<NSRecord> for Vec<u8> {
     }
 }
 
+/// Serialize a [NSRecord] reference into an encoded UCAN token byte vec.
+impl TryFrom<&NSRecord> for Vec<u8> {
+    type Error = anyhow::Error;
+
+    fn try_from(record: &NSRecord) -> Result<Vec<u8>, Self::Error> {
+        Ok(Vec::from(record.token.encode()?))
+    }
+}
+
 /// Deserialize an encoded UCAN token byte vec reference into a [NSRecord].
 impl TryFrom<&[u8]> for NSRecord {
     type Error = anyhow::Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         NSRecord::try_from(str::from_utf8(bytes)?)
-    }
-}
-
-/// Serialize a [NSRecord] reference into an encoded UCAN token byte vec.
-impl TryFrom<&NSRecord> for Vec<u8> {
-    type Error = anyhow::Error;
-
-    fn try_from(record: &NSRecord) -> Result<Self, Self::Error> {
-        Ok(Vec::from(record.token.encode()?))
     }
 }
 

--- a/rust/noosphere-ns/src/utils.rs
+++ b/rust/noosphere-ns/src/utils.rs
@@ -2,6 +2,9 @@ use noosphere_core::authority::{SphereAction, SphereReference};
 use serde_json;
 use ucan::capability::{Capability, Resource, With};
 
+#[cfg(doc)]
+use cid::Cid;
+
 /// Generates a [Capability] struct representing permission to
 /// publish a sphere.
 ///
@@ -33,7 +36,7 @@ pub fn generate_capability(sphere_did: &str) -> Capability<SphereReference, Sphe
 }
 
 /// Generates a UCAN `"fct"` struct for the NS network, representing
-/// the resolved sphere's revision as a [cid::Cid].
+/// the resolved sphere's revision as a [Cid].
 ///
 /// ```
 /// use noosphere_ns::utils::generate_fact;

--- a/rust/noosphere-ns/tests/ns_test.rs
+++ b/rust/noosphere-ns/tests/ns_test.rs
@@ -104,7 +104,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
 
     // Test propagating records from ns_1 to ns_2
     ns_1.ns
-        .set_record(
+        .put_record(
             UcanBuilder::default()
                 .issued_by(&ns_1.owner_key)
                 .for_audience(&ns_1.sphere_id)
@@ -139,7 +139,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
 
     // Flush records by identity and fetch latest value from network.
     ns_1.ns
-        .set_record(
+        .put_record(
             UcanBuilder::default()
                 .issued_by(&ns_1.owner_key)
                 .for_audience(&ns_1.sphere_id)
@@ -186,7 +186,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
 
     // Publish an updated record for sphere_2
     ns_2.ns
-        .set_record(
+        .put_record(
             UcanBuilder::default()
                 .issued_by(&ns_2.owner_key)
                 .for_audience(&ns_2.sphere_id)
@@ -227,7 +227,7 @@ async fn test_name_system_validation() -> Result<()> {
     // Test propagating records from ns_1 to ns_2
     assert!(
         ns_1.ns
-            .set_record(
+            .put_record(
                 UcanBuilder::default()
                     .issued_by(&ns_1.owner_key)
                     .for_audience(&ns_1.sphere_id)


### PR DESCRIPTION
Some cleanups from earlier DHT work, now with a clearer understanding of the system as a whole (and tidying up docs)

* Rename `set_record` terms to `put_record` to align with the underlying DHT methods -- similarly, use `key` instead of `name` for records.
* Use `&[u8]` interfaces for the DHT module
* `#[cfg(doc)]` some modules to cleanup references in docs
* Simplify DHT tests (thanks to above changes) with some util cleanups so we can start to splice together stranger network in tests.