### PR TITLE
Introduce pet names to spheres

### DIFF
--- a/rust/noosphere-core/src/authority/author.rs
+++ b/rust/noosphere-core/src/authority/author.rs
@@ -131,7 +131,7 @@ mod tests {
         let (sphere, _, _) = Sphere::try_generate("did:key:foo", &mut db).await.unwrap();
 
         let access = author
-            .access_to(&Did(sphere.try_get_identity().await.unwrap()), &db)
+            .access_to(&sphere.try_get_identity().await.unwrap(), &db)
             .await
             .unwrap();
 
@@ -154,7 +154,7 @@ mod tests {
         };
 
         let access = author
-            .access_to(&Did(sphere.try_get_identity().await.unwrap()), &db)
+            .access_to(&sphere.try_get_identity().await.unwrap(), &db)
             .await
             .unwrap();
 

--- a/rust/noosphere-core/src/authority/verification.rs
+++ b/rust/noosphere-core/src/authority/verification.rs
@@ -70,7 +70,7 @@ pub async fn verify_sphere_cid<S: Store>(
         let desired_capability = Capability {
             with: With::Resource {
                 kind: Resource::Scoped(SphereReference {
-                    did: sphere.identity.clone(),
+                    did: sphere.identity.to_string(),
                 }),
             },
             can: SphereAction::Push,
@@ -78,7 +78,9 @@ pub async fn verify_sphere_cid<S: Store>(
 
         for capability_info in proof.reduce_capabilities(&SPHERE_SEMANTICS) {
             let capability = capability_info.capability;
-            if capability_info.originators.contains(&sphere.identity)
+            if capability_info
+                .originators
+                .contains(sphere.identity.as_str())
                 && capability.enables(&desired_capability)
             {
                 return Ok(());

--- a/rust/noosphere-core/src/data/address.rs
+++ b/rust/noosphere-core/src/data/address.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use super::{Did, Jwt};
+
+/// An [AddressIpld] represents an entry in a user's pet name address book.
+/// It is intended to be associated with a human readable name, and enables the
+/// user to resolve the name to a DID. Eventually the DID will be resolved by
+/// some mechanism to a UCAN, so this struct also records the last resolved
+/// value if one has ever been resolved.
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Hash)]
+pub struct AddressIpld {
+    pub identity: Did,
+    pub last_known_record: Option<Jwt>,
+}

--- a/rust/noosphere-core/src/data/mod.rs
+++ b/rust/noosphere-core/src/data/mod.rs
@@ -1,3 +1,4 @@
+mod address;
 mod authority;
 mod body_chunk;
 mod bundle;
@@ -10,6 +11,7 @@ mod sphere;
 mod strings;
 mod versioned_map;
 
+pub use address::*;
 pub use authority::*;
 pub use body_chunk::*;
 pub use bundle::*;

--- a/rust/noosphere-core/src/data/sphere.rs
+++ b/rust/noosphere-core/src/data/sphere.rs
@@ -12,16 +12,16 @@ pub struct SphereIpld {
     /// A DID that is the identity of the originating key that owns the sphere
     pub identity: Did,
 
-    /// The public links for the sphere (LinksIpld)
+    /// The public links for the sphere
     pub links: Option<Cid>,
 
-    /// The public pet names for the sphere (NamesIpld)
+    /// The public pet names for the sphere
     pub names: Option<Cid>,
 
-    /// The non-public content of the sphere (SealedIpld)
+    /// The non-public content of the sphere
     pub sealed: Option<Cid>,
 
-    /// Authorization and revocation state for non-owner keys (AuthorizationIpld)
+    /// Authorization and revocation state for non-owner keys
     pub authorization: Option<Cid>,
 }
 

--- a/rust/noosphere-core/src/data/sphere.rs
+++ b/rust/noosphere-core/src/data/sphere.rs
@@ -15,6 +15,9 @@ pub struct SphereIpld {
     /// The public links for the sphere (LinksIpld)
     pub links: Option<Cid>,
 
+    /// The public pet names for the sphere (NamesIpld)
+    pub names: Option<Cid>,
+
     /// The non-public content of the sphere (SealedIpld)
     pub sealed: Option<Cid>,
 
@@ -66,6 +69,7 @@ mod tests {
         let sphere = SphereIpld {
             identity: identity_did.clone(),
             links: None,
+            names: None,
             sealed: None,
             authorization: None,
         };
@@ -144,6 +148,7 @@ mod tests {
         let sphere = SphereIpld {
             identity: identity_did.clone(),
             links: None,
+            names: None,
             sealed: None,
             authorization: None,
         };

--- a/rust/noosphere-core/src/data/strings.rs
+++ b/rust/noosphere-core/src/data/strings.rs
@@ -2,6 +2,62 @@ use std::{fmt::Display, ops::Deref};
 
 use serde::{Deserialize, Serialize};
 
+/// A helper to stamp out trait implementations that promote coherence between
+/// Rust strings and a given wrapper type
+macro_rules! string_coherent {
+    ($wrapper:ty) => {
+        impl Deref for $wrapper {
+            type Target = String;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl From<&str> for $wrapper {
+            fn from(value: &str) -> Self {
+                Self(value.to_owned())
+            }
+        }
+
+        impl From<String> for $wrapper {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<$wrapper> for String {
+            fn from(value: $wrapper) -> Self {
+                value.0
+            }
+        }
+
+        impl PartialEq<String> for $wrapper {
+            fn eq(&self, other: &String) -> bool {
+                &self.0 == other
+            }
+        }
+
+        impl PartialEq<$wrapper> for String {
+            fn eq(&self, other: &$wrapper) -> bool {
+                self == &other.0
+            }
+        }
+
+        impl Display for $wrapper {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                Display::fmt(&self.0, f)
+            }
+        }
+
+        impl AsRef<[u8]> for $wrapper {
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref()
+            }
+        }
+    };
+}
+
 /// A DID, aka a Decentralized Identifier, is a string that can be parsed and
 /// resolved into a so-called DID Document, usually in order to obtain PKI
 /// details related to a particular user or process.
@@ -12,55 +68,27 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Did(pub String);
 
-impl Deref for Did {
-    type Target = String;
+string_coherent!(Did);
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+/// A JWT, aka a JSON Web Token, is a specialized string-encoding of a
+/// particular format of JSON and an associated signature, commonly used for
+/// authorization flows on the web, but notably also used by the UCAN spec.
+///
+/// See: https://jwt.io/
+/// See: https://ucan.xyz/
+#[repr(transparent)]
+#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct Jwt(pub String);
 
-impl From<&str> for Did {
-    fn from(value: &str) -> Self {
-        Did(value.to_owned())
-    }
-}
+string_coherent!(Jwt);
 
-impl From<String> for Did {
-    fn from(value: String) -> Self {
-        Did(value)
-    }
-}
-
-impl From<Did> for String {
-    fn from(value: Did) -> Self {
-        value.0
-    }
-}
-
-impl PartialEq<String> for Did {
-    fn eq(&self, other: &String) -> bool {
-        &self.0 == other
-    }
-}
-
-impl PartialEq<Did> for String {
-    fn eq(&self, other: &Did) -> bool {
-        self == &other.0
-    }
-}
-
-impl Display for Did {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, f)
-    }
-}
-
-impl AsRef<[u8]> for Did {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
+/// A BIP39-compatible mnemonic phrase that represents the data needed to
+/// recover the private half of a cryptographic key pair.
+///
+/// See: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+#[repr(transparent)]
+#[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct Mnemonic(pub String);
 
 #[cfg(test)]
 mod tests {

--- a/rust/noosphere-core/src/data/strings.rs
+++ b/rust/noosphere-core/src/data/strings.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, ops::Deref};
+use std::{fmt::Display, hash::Hash, ops::Deref};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +11,15 @@ macro_rules! string_coherent {
 
             fn deref(&self) -> &Self::Target {
                 &self.0
+            }
+        }
+
+        impl Hash for $wrapper {
+            fn hash<H>(&self, hasher: &mut H)
+            where
+                H: std::hash::Hasher,
+            {
+                self.0.hash(hasher)
             }
         }
 

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -24,7 +24,7 @@ use crate::{
 
 use noosphere_storage::{interface::BlockStore, ucan::UcanStore};
 
-use super::{AllowedUcans, Authority, RevokedUcans};
+use super::{AllowedUcans, Authority, Names, RevokedUcans};
 
 pub const SPHERE_LIFETIME: u64 = 315360000000; // 10,000 years (arbitrarily high)
 
@@ -85,6 +85,12 @@ impl<S: BlockStore> Sphere<S> {
         let sphere = self.try_as_body().await?;
 
         Authority::try_at_or_empty(sphere.authorization.as_ref(), &mut self.store.clone()).await
+    }
+
+    pub async fn try_get_names(&self) -> Result<Names<S>> {
+        let sphere = self.try_as_body().await?;
+
+        Names::try_at_or_empty(sphere.names.as_ref(), &mut self.store.clone()).await
     }
 
     pub async fn try_get_identity(&self) -> Result<Did> {

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -341,6 +341,7 @@ impl<S: BlockStore> Sphere<S> {
             &SphereIpld {
                 identity: sphere_did.clone(),
                 links: None,
+                names: None,
                 sealed: None,
                 authorization: None,
             },

--- a/rust/noosphere-core/src/view/versioned_map.rs
+++ b/rust/noosphere-core/src/view/versioned_map.rs
@@ -7,7 +7,7 @@ use futures::Stream;
 use libipld_cbor::DagCborCodec;
 
 use crate::data::{
-    ChangelogIpld, CidKey, DelegationIpld, LinksIpld, MapOperation, RevocationIpld,
+    AddressIpld, ChangelogIpld, CidKey, DelegationIpld, LinksIpld, MapOperation, RevocationIpld,
     VersionedMapIpld, VersionedMapKey, VersionedMapValue,
 };
 
@@ -17,6 +17,7 @@ use noosphere_storage::interface::BlockStore;
 use super::VersionedMapMutation;
 
 pub type Links<S> = VersionedMap<String, Cid, S>;
+pub type Names<S> = VersionedMap<String, AddressIpld, S>;
 pub type AllowedUcans<S> = VersionedMap<CidKey, DelegationIpld, S>;
 pub type RevokedUcans<S> = VersionedMap<CidKey, RevocationIpld, S>;
 

--- a/rust/noosphere-fs/src/fs.rs
+++ b/rust/noosphere-fs/src/fs.rs
@@ -134,7 +134,7 @@ where
             sphere_identity: sphere_identity.clone(),
             author: author.clone(),
             db: db.clone(),
-            sphere_revision: sphere_revision.clone(),
+            sphere_revision: *sphere_revision,
             access,
             mutation: OnceCell::new(),
         })
@@ -307,7 +307,7 @@ where
 pub mod tests {
     use noosphere_core::{
         authority::{generate_ed25519_key, Author},
-        data::{ContentType, Did, Header},
+        data::{ContentType, Header},
         view::Sphere,
     };
     use noosphere_storage::db::SphereDb;
@@ -333,7 +333,7 @@ pub mod tests {
 
         let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(proof),
@@ -377,7 +377,7 @@ pub mod tests {
 
         let (sphere, _, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: None,
@@ -414,7 +414,7 @@ pub mod tests {
 
         let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(proof),
@@ -465,7 +465,7 @@ pub mod tests {
 
         let (sphere, authorization, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(authorization),
@@ -543,7 +543,7 @@ pub mod tests {
 
         let (sphere, authorization, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(authorization),
@@ -574,7 +574,7 @@ pub mod tests {
 
         let (sphere, authorization, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(authorization),

--- a/rust/noosphere-into/examples/notes-to-html/implementation.rs
+++ b/rust/noosphere-into/examples/notes-to-html/implementation.rs
@@ -9,7 +9,7 @@ use tower_http::services::ServeDir;
 
 use noosphere_core::{
     authority::{generate_ed25519_key, Author},
-    data::{ContentType, Did, Header},
+    data::{ContentType, Header},
     view::Sphere,
 };
 use noosphere_storage::{db::SphereDb, memory::MemoryStorageProvider};
@@ -24,7 +24,7 @@ pub async fn main() -> Result<()> {
 
     let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut db).await?;
 
-    let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+    let sphere_identity = sphere.try_get_identity().await.unwrap();
     let author = Author {
         key: owner_key,
         authorization: Some(proof),

--- a/rust/noosphere-into/src/html/into.rs
+++ b/rust/noosphere-into/src/html/into.rs
@@ -167,7 +167,7 @@ pub mod tests {
 
     use noosphere_core::{
         authority::{generate_ed25519_key, Author},
-        data::{ContentType, Did, Header},
+        data::{ContentType, Header},
         view::Sphere,
     };
     use noosphere_fs::SphereFs;
@@ -197,7 +197,7 @@ pub mod tests {
 
         let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(proof),
@@ -282,7 +282,7 @@ pub mod tests {
 
         let (sphere, proof, _) = Sphere::try_generate(&owner_did, &mut db).await.unwrap();
 
-        let sphere_identity = Did(sphere.try_get_identity().await.unwrap());
+        let sphere_identity = sphere.try_get_identity().await.unwrap();
         let author = Author {
             key: owner_key,
             authorization: Some(proof),

--- a/rust/noosphere/src/noosphere.rs
+++ b/rust/noosphere/src/noosphere.rs
@@ -126,7 +126,7 @@ impl NoosphereContext {
         sphere_contexts.insert(sphere_identity.clone(), Arc::new(Mutex::new(context)));
 
         Ok(SphereReceipt {
-            identity: sphere_identity.into(),
+            identity: sphere_identity,
             mnemonic,
         })
     }
@@ -157,7 +157,7 @@ impl NoosphereContext {
 
         let sphere_identity = context.identity().to_owned();
         let mut sphere_contexts = self.sphere_contexts.lock().await;
-        sphere_contexts.insert(sphere_identity.into(), Arc::new(Mutex::new(context)));
+        sphere_contexts.insert(sphere_identity, Arc::new(Mutex::new(context)));
 
         Ok(())
     }

--- a/rust/noosphere/src/sphere/builder.rs
+++ b/rust/noosphere/src/sphere/builder.rs
@@ -180,7 +180,7 @@ impl SphereContextBuilder {
                         .await
                         .unwrap();
 
-                let sphere_did = Did(sphere.try_get_identity().await.unwrap());
+                let sphere_did = sphere.try_get_identity().await.unwrap();
 
                 let storage_layout = match self.scoped_storage_layout {
                     true => StorageLayout::Scoped(storage_path, sphere_did.clone()),

--- a/rust/noosphere/tests/integration.rs
+++ b/rust/noosphere/tests/integration.rs
@@ -26,8 +26,8 @@ fn platform_configuration() -> NoosphereContextConfiguration {
     let sphere_storage_path = TempDir::new().unwrap().path().to_path_buf();
 
     NoosphereContextConfiguration::Insecure {
-        global_storage_path: global_storage_path,
-        sphere_storage_path: sphere_storage_path,
+        global_storage_path,
+        sphere_storage_path,
         gateway_url: None,
     }
 }


### PR DESCRIPTION
This is a small-ish change to get our feet in the water with pet names. It introduces a new `VersionedMap` for pet names, where we are mapping a human-readable name to what we call an `AddressIpld`. The address records a DID, and optionally a last known resolved value (which is represented as a JWT).

I also threw in some cleanup: I wrote a declarative macro for enhancing a string-wrapper struct with trait implementations to make the wrappers coherent with strings, and then added string-wrapper structs for JWTs and BIP-39 mnemonics. I also started propagating these structs a bit more.

Fixes #153 