### PR TITLE
Re-implement `noosphere-cli` in terms of `noosphere`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,6 +2273,7 @@ dependencies = [
  "cid",
  "js-sys",
  "lazy_static",
+ "libipld-core",
  "noosphere-api",
  "noosphere-core",
  "noosphere-fs",
@@ -2291,6 +2292,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
+ "witty-phrase-generator",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,6 +2329,7 @@ dependencies = [
  "libipld-cbor",
  "libipld-core",
  "mime_guess",
+ "noosphere",
  "noosphere-api",
  "noosphere-core",
  "noosphere-fs",

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -50,6 +50,7 @@ noosphere-core = { version = "0.2.0", path = "../noosphere-core" }
 noosphere-fs = { version = "0.1.0", path = "../noosphere-fs" }
 noosphere-storage = { version = "0.1.0", path = "../noosphere-storage" }
 noosphere-api = { version = "0.3.0", path = "../noosphere-api" }
+noosphere = { version = "0.2.0", path = "../noosphere" }
 ucan = { version = "0.7.0-alpha.1" }
 ucan-key-support = { version = "0.7.0-alpha.1" }
 cid = "~0.8"

--- a/rust/noosphere-cli/src/native/commands/config.rs
+++ b/rust/noosphere-cli/src/native/commands/config.rs
@@ -1,23 +1,24 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
+use noosphere::sphere::GATEWAY_URL;
+use noosphere_core::data::Did;
+use noosphere_storage::interface::KeyValueStore;
 use serde::{Deserialize, Serialize};
-use tokio::fs;
 use tokio::sync::OnceCell;
 use url::Url;
 
-use crate::native::{
-    workspace::Workspace,
-    ConfigGetCommand, ConfigSetCommand,
-};
+use crate::native::{workspace::Workspace, ConfigGetCommand, ConfigSetCommand};
+
+pub const COUNTERPART: &str = "counterpart";
+pub const DIFFTOOL: &str = "difftool";
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ConfigContents {
     pub gateway_url: Option<Url>,
-    pub counterpart: Option<String>,
+    pub counterpart: Option<Did>,
     pub difftool: Option<String>,
 }
 
-// TODO: This construct should have the user sign the new config when it is
-// written, and verify the signature when it the config is read
+// TODO: Consider signing configuration values to head-off tampering
 pub struct Config<'a> {
     workspace: &'a Workspace,
     contents: OnceCell<ConfigContents>,
@@ -35,54 +36,57 @@ impl<'a> From<&'a Workspace> for Config<'a> {
 impl<'a> Config<'a> {
     pub async fn read(&self) -> Result<&ConfigContents> {
         self.contents
-            .get_or_try_init(|| {
-                let config_path = self.workspace.config_path().clone();
-                async {
-                    toml_edit::de::from_str(&fs::read_to_string(config_path).await?)
-                        .map_err(|error| anyhow!(error))
-                }
+            .get_or_try_init(|| async {
+                let context = self.workspace.sphere_context().await?;
+                let context = context.lock().await;
+
+                let db = context.db();
+
+                let gateway_url: Option<Url> = db.get_key(GATEWAY_URL).await?;
+                let counterpart: Option<Did> = db.get_key(COUNTERPART).await?;
+                let difftool: Option<String> = db.get_key(DIFFTOOL).await?;
+
+                Ok(ConfigContents {
+                    gateway_url,
+                    counterpart,
+                    difftool,
+                })
             })
             .await
-    }
-
-    pub async fn write(&mut self, contents: &ConfigContents) -> Result<()> {
-        fs::write(
-            self.workspace.config_path(),
-            toml_edit::ser::to_vec(contents)?,
-        )
-        .await?;
-        self.contents = OnceCell::new();
-        Ok(())
     }
 }
 
 pub async fn config_set(command: ConfigSetCommand, workspace: &Workspace) -> Result<()> {
-    workspace.expect_local_directories()?;
+    let context = workspace.sphere_context().await?;
+    let context = context.lock().await;
 
-    let mut config = Config::from(workspace);
-    let mut config_contents = config.read().await?.clone();
+    let mut db = context.db().clone();
 
     match command {
-        ConfigSetCommand::GatewayUrl { url } => config_contents.gateway_url = Some(url),
-        ConfigSetCommand::Counterpart { did } => config_contents.counterpart = Some(did),
-        ConfigSetCommand::Difftool { tool } => config_contents.difftool = Some(tool),
+        ConfigSetCommand::GatewayUrl { url } => db.set_key(GATEWAY_URL, url).await?,
+        ConfigSetCommand::Counterpart { did } => db.set_key(COUNTERPART, did).await?,
+        ConfigSetCommand::Difftool { tool } => db.set_key(DIFFTOOL, tool).await?,
     };
-
-    config.write(&config_contents).await?;
 
     Ok(())
 }
 
 pub async fn config_get(command: ConfigGetCommand, workspace: &Workspace) -> Result<()> {
-    workspace.expect_local_directories()?;
+    let context = workspace.sphere_context().await?;
+    let context = context.lock().await;
 
-    let config = Config::from(workspace);
-    let config_contents = config.read().await?.clone();
+    let db = context.db();
 
     let value = match command {
-        ConfigGetCommand::GatewayUrl => config_contents.gateway_url.map(|url| url.to_string()),
-        ConfigGetCommand::Counterpart => config_contents.counterpart,
-        ConfigGetCommand::Difftool => config_contents.difftool,
+        ConfigGetCommand::GatewayUrl => db
+            .get_key::<_, Url>(GATEWAY_URL)
+            .await?
+            .map(|url| url.to_string()),
+        ConfigGetCommand::Counterpart => db
+            .get_key::<_, Did>(COUNTERPART)
+            .await?
+            .map(|did| did.to_string()),
+        ConfigGetCommand::Difftool => db.get_key::<_, String>(DIFFTOOL).await?,
     };
 
     if let Some(value) = value {

--- a/rust/noosphere-cli/src/native/commands/key.rs
+++ b/rust/noosphere-cli/src/native/commands/key.rs
@@ -1,51 +1,28 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
+use noosphere::key::KeyStorage;
 use serde_json::json;
-use tokio::fs;
 use ucan::crypto::KeyMaterial;
-
-use noosphere_core::authority::{ed25519_key_to_mnemonic, generate_ed25519_key};
 
 use crate::native::workspace::Workspace;
 
 pub static SERVICE_NAME: &str = "noosphere";
 
-pub async fn key_create(name: &str, working_paths: &Workspace) -> Result<()> {
-    working_paths.initialize_global_directories().await?;
+pub async fn key_create(name: &str, workspace: &Workspace) -> Result<()> {
+    let key = workspace.key_storage().create_key(name).await?;
+    let did = key.get_did().await?;
 
-    let key_base_path = working_paths.keys_path().join(&name);
-    let private_key_path = key_base_path.with_extension("private");
-
-    if private_key_path.exists() {
-        return Err(anyhow!("A key called {:?} already exists!", name));
-    }
-
-    let did_path = key_base_path.with_extension("public");
-
-    let key_pair = generate_ed25519_key();
-    let did = key_pair.get_did().await?;
-
-    let mnemonic = ed25519_key_to_mnemonic(&key_pair)?;
-
-    tokio::try_join!(
-        fs::write(private_key_path, mnemonic),
-        fs::write(did_path, &did),
-    )?;
-
-    println!("Created key {:?} in {:?}", name, working_paths.keys_path());
+    println!(
+        "Created key {:?} in {:?}",
+        name,
+        workspace.key_storage().storage_path()
+    );
     println!("Public identity {}", did);
 
     Ok(())
 }
 
-pub async fn key_list(as_json: bool, working_paths: &Workspace) -> Result<()> {
-    if let Err(error) = working_paths.expect_global_directories() {
-        return Err(anyhow!(
-            "{:?}\nTip: you may need to create a key first",
-            error
-        ));
-    }
-
-    let keys = working_paths.get_all_keys().await?;
+pub async fn key_list(as_json: bool, workspace: &Workspace) -> Result<()> {
+    let keys = workspace.key_storage().get_discoverable_keys().await?;
     let max_name_length = keys
         .iter()
         .fold(7, |length, (key_name, _)| key_name.len().max(length));

--- a/rust/noosphere-cli/src/native/commands/serve/route/identify.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/route/identify.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
 use axum::{http::StatusCode, response::IntoResponse, Extension, Json};
+use noosphere::sphere::SphereContext;
 use noosphere_api::data::IdentifyResponse;
-use noosphere_core::authority::{Authorization, SphereAction, SphereReference};
-use noosphere_storage::{db::SphereDb, native::NativeStore};
+use noosphere_core::authority::{SphereAction, SphereReference};
+use noosphere_storage::native::NativeStore;
+use tokio::sync::Mutex;
 use ucan::{
     capability::{Capability, Resource, With},
     crypto::KeyMaterial,
@@ -11,14 +13,13 @@ use ucan::{
 
 use crate::native::commands::serve::{authority::GatewayAuthority, gateway::GatewayScope};
 
-pub async fn identify_route<K: KeyMaterial>(
-    authority: GatewayAuthority,
-    Extension(gateway_key): Extension<Arc<K>>,
-    Extension(gateway_authorization): Extension<Authorization>,
+pub async fn identify_route<K: KeyMaterial + Clone>(
+    authority: GatewayAuthority<K>,
     Extension(scope): Extension<GatewayScope>,
-    Extension(db): Extension<SphereDb<NativeStore>>,
+    Extension(sphere_context): Extension<Arc<Mutex<SphereContext<K, NativeStore>>>>,
 ) -> Result<impl IntoResponse, StatusCode> {
     debug!("Invoking identify route...");
+
     authority.try_authorize(&Capability {
         with: With::Resource {
             kind: Resource::Scoped(SphereReference {
@@ -28,8 +29,20 @@ pub async fn identify_route<K: KeyMaterial>(
         can: SphereAction::Fetch,
     })?;
 
+    let sphere_context = sphere_context.lock().await;
+    let db = sphere_context.db();
+    let gateway_key = &sphere_context.author().key;
+    let gateway_authorization =
+        sphere_context
+            .author()
+            .require_authorization()
+            .map_err(|error| {
+                error!("{:?}", error);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+
     let ucan = gateway_authorization
-        .resolve_ucan(&db)
+        .resolve_ucan(db)
         .await
         .map_err(|error| {
             error!("{:?}", error);
@@ -37,7 +50,7 @@ pub async fn identify_route<K: KeyMaterial>(
         })?;
 
     Ok(Json(
-        IdentifyResponse::sign(&scope.identity, &gateway_key, &ucan)
+        IdentifyResponse::sign(&scope.identity, gateway_key, &ucan)
             .await
             .map_err(|error| {
                 error!("{:?}", error);

--- a/rust/noosphere-cli/src/native/commands/status.rs
+++ b/rust/noosphere-cli/src/native/commands/status.rs
@@ -26,13 +26,10 @@ pub fn status_section(
 }
 
 pub async fn status(workspace: &Workspace) -> Result<()> {
-    workspace.expect_local_directories()?;
-
     let mut memory_store = MemoryStore::default();
-    let db = workspace.get_local_db().await?;
 
     let (_, mut changes) = match workspace
-        .get_local_content_changes(None, &db, &mut memory_store)
+        .get_file_content_changes(&mut memory_store)
         .await?
     {
         Some((content, content_changes)) if !content_changes.is_empty() => {

--- a/rust/noosphere-cli/src/native/commands/sync.rs
+++ b/rust/noosphere-cli/src/native/commands/sync.rs
@@ -1,27 +1,14 @@
 use crate::native::{commands::serve::tracing::initialize_tracing, workspace::Workspace};
 use anyhow::{anyhow, Result};
-use noosphere_api::{
-    client::Client,
-    data::{FetchParameters, FetchResponse, PushBody, PushResponse},
-};
-use noosphere_core::{
-    authority::{Author, SUPPORTED_KEYS},
-    view::Sphere,
-};
-use noosphere_storage::{db::SphereDb, interface::Store, memory::MemoryStore};
-use ucan::crypto::{did::DidParser, KeyMaterial};
+use noosphere_storage::memory::MemoryStore;
 
-// TODO(#104): If we fail before rendering, it will look like we have removed files
-// from the workspace; we should probably roll back in the failure case.
 pub async fn sync(workspace: &Workspace) -> Result<()> {
     initialize_tracing();
-    workspace.expect_local_directories()?;
 
-    let mut db = workspace.get_local_db().await?;
     let mut memory_store = MemoryStore::default();
 
     match workspace
-        .get_local_content_changes(None, &db, &mut memory_store)
+        .get_file_content_changes(&mut memory_store)
         .await?
     {
         Some((_, content_changes)) if !content_changes.is_empty() => {
@@ -32,235 +19,16 @@ pub async fn sync(workspace: &Workspace) -> Result<()> {
         _ => (),
     };
 
-    let gateway_url = workspace.get_local_gateway_url().await?;
+    let context = workspace.sphere_context().await?;
+    let mut context = context.lock().await;
 
-    let author = Author {
-        key: workspace.get_local_key().await?,
-        authorization: Some(workspace.get_local_authorization().await?),
-    };
-
-    let sphere_identity = workspace.get_local_identity().await?;
-
-    let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-
-    println!("Handshaking with gateway at {}...", gateway_url);
-
-    let client = Client::identify(
-        &sphere_identity,
-        &gateway_url,
-        &author,
-        &mut did_parser,
-        db.clone(),
-    )
-    .await?;
-
-    sync_remote_changes(&sphere_identity, &client, &author, &mut db).await?;
-
-    push_local_changes(&sphere_identity, &client, &mut db).await?;
+    context.sync().await?;
 
     println!("Sync complete, rendering updated workspace...");
 
-    workspace.render(&mut db).await?;
+    workspace.render().await?;
 
     println!("Done!");
-
-    Ok(())
-}
-
-/// Attempts to push the latest local lineage to the gateway, causing the
-/// gateway to update its own pointer to the tip of the local sphere's history
-pub async fn push_local_changes<S, K>(
-    local_sphere_identity: &str,
-    client: &Client<K, SphereDb<S>>,
-    db: &mut SphereDb<S>,
-) -> Result<()>
-where
-    K: KeyMaterial + Clone + 'static,
-    S: Store,
-{
-    let local_sphere_identity = local_sphere_identity.to_string();
-    let counterpart_sphere_identity = client.session.sphere_identity.clone();
-
-    // The base of the changes that must be pushed is the tip of our lineage as
-    // recorded by the most recent history of the gateway's sphere. Everything
-    // past that point in history represents new changes that the gateway does
-    // not yet know about.
-    let local_sphere_tip = db
-        .get_version(&local_sphere_identity)
-        .await?
-        .ok_or_else(|| {
-            anyhow!(
-                "The history of local sphere {} is missing!",
-                local_sphere_identity
-            )
-        })?;
-
-    let counterpart_sphere_tip = db
-        .get_version(&counterpart_sphere_identity)
-        .await?
-        .ok_or_else(|| {
-            anyhow!(
-                "No local history for counterpart sphere {}; did you forget to fetch?",
-                counterpart_sphere_identity
-            )
-        })?;
-
-    let local_sphere_base = Sphere::at(&counterpart_sphere_tip, db)
-        .try_get_links()
-        .await?
-        .get(&local_sphere_identity)
-        .await?
-        .cloned();
-
-    if local_sphere_base == Some(local_sphere_tip) {
-        println!("Gateway is already up to date!");
-        return Ok(());
-    }
-
-    println!("Collecting blocks from new local history...");
-
-    let bundle = Sphere::at(&local_sphere_tip, db)
-        .try_bundle_until_ancestor(local_sphere_base.as_ref())
-        .await?;
-
-    println!(
-        "Pushing new local history to gateway {}...",
-        client.session.gateway_identity
-    );
-
-    let result = client
-        .push(&PushBody {
-            sphere: local_sphere_identity,
-            base: local_sphere_base,
-            tip: local_sphere_tip,
-            blocks: bundle,
-        })
-        .await?;
-
-    let (counterpart_sphere_updated_tip, new_blocks) = match result {
-        PushResponse::Accepted { new_tip, blocks } => (new_tip, blocks),
-        PushResponse::NoChange => {
-            return Err(anyhow!("Gateway already up to date!"));
-        }
-    };
-
-    println!("Saving updated counterpart sphere history...");
-
-    new_blocks.load_into(db).await?;
-
-    Sphere::try_hydrate_range(
-        Some(&counterpart_sphere_tip),
-        &counterpart_sphere_updated_tip,
-        db,
-    )
-    .await?;
-
-    db.set_version(
-        &counterpart_sphere_identity,
-        &counterpart_sphere_updated_tip,
-    )
-    .await?;
-
-    Ok(())
-}
-
-/// Fetches the latest changes from a gateway and updates the local lineage
-/// using a conflict-free rebase strategy
-pub async fn sync_remote_changes<K, S>(
-    local_sphere_identity: &str,
-    client: &Client<K, SphereDb<S>>,
-    author: &Author<K>,
-    db: &mut SphereDb<S>,
-) -> Result<()>
-where
-    K: KeyMaterial + Clone + 'static,
-    S: Store,
-{
-    let local_sphere_identity = local_sphere_identity.to_string();
-    let counterpart_sphere_identity = client.session.sphere_identity.clone();
-    let counterpart_sphere_base = db.get_version(&counterpart_sphere_identity).await?;
-
-    println!(
-        "Fetching latest changes from gateway {}...",
-        client.session.gateway_identity
-    );
-
-    let fetch_result = client
-        .fetch(&FetchParameters {
-            since: counterpart_sphere_base,
-        })
-        .await?;
-
-    let (counterpart_sphere_tip, new_blocks) = match fetch_result {
-        FetchResponse::NewChanges { tip, blocks } => (tip, blocks),
-        FetchResponse::UpToDate => {
-            println!("Local history is already up to date...");
-            return Ok(());
-        }
-    };
-
-    println!("Saving blocks to local database...");
-
-    new_blocks.load_into(db).await?;
-
-    println!("Hydrating received counterpart sphere revisions...");
-
-    Sphere::try_hydrate_range(
-        counterpart_sphere_base.as_ref(),
-        &counterpart_sphere_tip,
-        db,
-    )
-    .await?;
-
-    db.set_version(&counterpart_sphere_identity, &counterpart_sphere_tip)
-        .await?;
-
-    let local_sphere_tip = db.get_version(&local_sphere_identity).await?;
-    let local_sphere_old_base = match counterpart_sphere_base {
-        Some(counterpart_sphere_base) => Sphere::at(&counterpart_sphere_base, db)
-            .try_get_links()
-            .await?
-            .get(&local_sphere_identity)
-            .await?
-            .cloned(),
-        None => None,
-    };
-    let local_sphere_new_base = Sphere::at(&counterpart_sphere_tip, db)
-        .try_get_links()
-        .await?
-        .get(&local_sphere_identity)
-        .await?
-        .cloned();
-
-    match (
-        local_sphere_tip,
-        local_sphere_old_base,
-        local_sphere_new_base,
-    ) {
-        (Some(current_tip), Some(old_base), Some(new_base)) => {
-            println!("Syncing received local sphere revisions...");
-            let new_tip = Sphere::at(&current_tip, db)
-                .try_sync(
-                    &old_base,
-                    &new_base,
-                    &author.key,
-                    author.authorization.as_ref(),
-                )
-                .await?;
-
-            db.set_version(&local_sphere_identity, &new_tip).await?;
-        }
-        (None, old_base, Some(new_base)) => {
-            println!("Hydrating received local sphere revisions...");
-            Sphere::try_hydrate_range(old_base.as_ref(), &new_base, db).await?;
-
-            db.set_version(&local_sphere_identity, &new_base).await?;
-        }
-        _ => {
-            println!("Nothing to sync!");
-            return Ok(());
-        }
-    };
 
     Ok(())
 }

--- a/rust/noosphere-core/src/authority/authorization.rs
+++ b/rust/noosphere-core/src/authority/authorization.rs
@@ -6,8 +6,19 @@ use libipld_core::{ipld::Ipld, raw::RawCodec};
 use noosphere_storage::encoding::block_encode;
 use ucan::{store::UcanJwtStore, Ucan};
 
-// TODO(ucan-wg/rs-ucan#32): Maybe swap this out is we get a substantially
-// similar construct to land in rs-ucan
+#[cfg(doc)]
+use ucan::ipld::UcanIpld;
+
+#[cfg(doc)]
+use crate::data::Jwt;
+
+/// An [Authorization] is a wrapper around something that can be resolved into
+/// a [Ucan]. Typically this is a [Cid], but it may also be something like a
+/// [Ucan] itself, or a [UcanIpld], or a [Jwt]. We don't want to deal with each
+/// of these heterogenous types separately, so we move them around as an
+/// [Authorization] instead.
+/// TODO(ucan-wg/rs-ucan#32): Maybe swap this out is we get a substantially
+/// similar construct to land in rs-ucan
 #[derive(Clone)]
 pub enum Authorization {
     /// A fully instantiated UCAN
@@ -43,6 +54,12 @@ impl FromStr for Authorization {
             Some(any_other) => Authorization::Cid(Cid::from_str(any_other)?),
             None => return Err(anyhow!("Authorization had empty value")),
         })
+    }
+}
+
+impl From<Cid> for Authorization {
+    fn from(cid: Cid) -> Self {
+        Authorization::Cid(cid)
     }
 }
 

--- a/rust/noosphere-ns/src/bin/bootstrap-nns/runner/config.rs
+++ b/rust/noosphere-ns/src/bin/bootstrap-nns/runner/config.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Result};
 use futures::future::try_join_all;
 use noosphere::key::InsecureKeyStorage;
 use noosphere_ns::Multiaddr;
-use tokio;
-use toml;
+
+
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
 /// DHT node configuration that contains resolved
@@ -49,7 +49,7 @@ impl RunnerConfig {
             .nodes
             .iter()
             .map(|config_node| {
-                let port = config_node.port.or(Some(0)).unwrap();
+                let port = config_node.port.unwrap_or(0);
                 RunnerNodeConfig::try_from_key_name(key_storage, &config_node.key, port)
             })
             .collect();
@@ -70,7 +70,7 @@ impl RunnerConfig {
                 Some(config_path) => {
                     let toml_str = tokio::fs::read_to_string(&config_path).await?;
                     let config: CLIConfig = toml::from_str(&toml_str)?;
-                    Ok(RunnerConfig::try_from_config(&key_storage, config).await?)
+                    Ok(RunnerConfig::try_from_config(key_storage, config).await?)
                 }
                 None => {
                     let key_name: String =
@@ -82,7 +82,7 @@ impl RunnerConfig {
                             port: port.take(),
                         }],
                     };
-                    Ok(RunnerConfig::try_from_config(&key_storage, config).await?)
+                    Ok(RunnerConfig::try_from_config(key_storage, config).await?)
                 }
             },
             _ => Err(anyhow!(
@@ -160,7 +160,7 @@ mod tests {
         );
         assert_eq!(
             node_config.listening_address,
-            format!("/ip4/127.0.0.1/tcp/6666").parse()?,
+            "/ip4/127.0.0.1/tcp/6666".to_string().parse()?,
             "expected port"
         );
 
@@ -201,7 +201,7 @@ port = 20000
         );
         assert_eq!(
             node_config.listening_address,
-            format!("/ip4/127.0.0.1/tcp/10000").parse()?,
+            "/ip4/127.0.0.1/tcp/10000".to_string().parse()?,
             "expected port"
         );
 
@@ -212,7 +212,7 @@ port = 20000
         );
         assert_eq!(
             node_config.listening_address,
-            format!("/ip4/127.0.0.1/tcp/20000").parse()?,
+            "/ip4/127.0.0.1/tcp/20000".to_string().parse()?,
             "expected port"
         );
 

--- a/rust/noosphere-ns/src/bin/bootstrap-nns/utils.rs
+++ b/rust/noosphere-ns/src/bin/bootstrap-nns/utils.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use home;
+
 use noosphere::key::{InsecureKeyStorage, KeyStorage};
 use noosphere_ns::Multiaddr;
 use std::future::Future;
@@ -14,7 +14,7 @@ pub async fn run_until_abort(future: impl Future<Output = Result<()>>) -> Result
     let mut aborted = false;
     tokio::select! {
         _ = tokio::signal::ctrl_c() => { aborted = true; },
-        result = future => { let _ = result?; }
+        result = future => { result?; }
     };
     if !aborted {
         tokio::signal::ctrl_c().await?;

--- a/rust/noosphere-storage/src/db.rs
+++ b/rust/noosphere-storage/src/db.rs
@@ -186,8 +186,14 @@ where
         K: AsRef<[u8]> + BlockStoreSend,
         V: Serialize + BlockStoreSend,
     {
-        self.metadata_store.set_key(key, value).await?;
-        Ok(())
+        self.metadata_store.set_key(key, value).await
+    }
+
+    async fn unset_key<K>(&mut self, key: K) -> Result<()>
+    where
+        K: AsRef<[u8]> + BlockStoreSend,
+    {
+        self.metadata_store.unset_key(key).await
     }
 
     async fn get_key<K, V>(&self, key: K) -> Result<Option<V>>

--- a/rust/noosphere-storage/src/interface.rs
+++ b/rust/noosphere-storage/src/interface.rs
@@ -193,6 +193,10 @@ pub trait KeyValueStore {
         K: AsRef<[u8]> + BlockStoreSend,
         V: DeserializeOwned + BlockStoreSend;
 
+    async fn unset_key<K>(&mut self, key: K) -> Result<()>
+    where
+        K: AsRef<[u8]> + BlockStoreSend;
+
     async fn require_key<K, V>(&self, key: K) -> Result<V>
     where
         K: AsRef<[u8]> + BlockStoreSend + Display,
@@ -223,6 +227,15 @@ where
         let cbor = codec.encode(&ipld)?;
         let key_bytes = K::as_ref(&key);
         self.write(key_bytes, &cbor).await?;
+        Ok(())
+    }
+
+    async fn unset_key<K>(&mut self, key: K) -> Result<()>
+    where
+        K: AsRef<[u8]> + BlockStoreSend,
+    {
+        let key_bytes = K::as_ref(&key);
+        self.remove(key_bytes).await?;
         Ok(())
     }
 

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -40,7 +40,7 @@ ucan = { version = "0.7.0-alpha.1" }
 ucan-key-support = { version = "0.7.0-alpha.1" }
 
 [dev-dependencies]
-wasm-bindgen-test = "~0.3"
+libipld-core = "~0.14"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "^1", features = ["sync"] }
@@ -61,3 +61,7 @@ tokio = { version = "^1", features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 temp-dir = "0.1"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "~0.3"
+witty-phrase-generator = "~0.2"

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "^1"
 cid = "~0.8"
 async-trait = "~0.1"
 tracing = "~0.1"
-url = "^2"
+url = { version = "^2", features = ["serde"] }
 subtext = { version = "~0.3" }
 
 noosphere-core = { version = "0.2.0", path = "../noosphere-core" }

--- a/rust/noosphere/src/key/insecure.rs
+++ b/rust/noosphere/src/key/insecure.rs
@@ -1,9 +1,13 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use noosphere_core::authority::{
-    ed25519_key_to_mnemonic, generate_ed25519_key, restore_ed25519_key,
+use noosphere_core::{
+    authority::{ed25519_key_to_mnemonic, generate_ed25519_key, restore_ed25519_key},
+    data::Did,
 };
-use std::path::PathBuf;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 use tokio::fs;
 use ucan::crypto::KeyMaterial;
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
@@ -18,6 +22,7 @@ use super::KeyStorage;
 ///
 /// ⚠️ This storage mechanism keeps both public and private key data
 /// stored in clear text on disk. User beware!
+#[derive(Clone)]
 pub struct InsecureKeyStorage {
     storage_path: PathBuf,
 }
@@ -37,6 +42,40 @@ impl InsecureKeyStorage {
 
     fn private_key_path(&self, name: &str) -> PathBuf {
         self.storage_path.join(name).with_extension("private")
+    }
+
+    /// The location on disk where all keys are stored
+    pub fn storage_path(&self) -> &Path {
+        &self.storage_path
+    }
+
+    /// Reads all of the "discoverable" keys and returns a BTreeMap of their
+    /// credential ID (e.g., their "name") to their DID.
+    ///
+    /// TODO: This should eventually be a formal part of the [KeyStorage] trait,
+    /// but for now we aren't certain if we can depend on the ability to
+    /// enumerate keys in general WebAuthn cases.
+    ///
+    /// See: https://www.w3.org/TR/webauthn-3/#client-side-discoverable-credential
+    pub async fn get_discoverable_keys(&self) -> Result<BTreeMap<String, Did>> {
+        let mut discoverable_keys = BTreeMap::<String, Did>::new();
+        let mut directory = fs::read_dir(&self.storage_path).await?;
+
+        while let Some(entry) = directory.next_entry().await? {
+            let key_path = entry.path();
+            let key_name = key_path.file_stem().map(|stem| stem.to_str());
+            let extension = key_path.extension().map(|extension| extension.to_str());
+
+            match (key_name, extension) {
+                (Some(Some(key_name)), Some(Some("public"))) => {
+                    let did = Did(fs::read_to_string(&key_path).await?);
+                    discoverable_keys.insert(key_name.to_string(), did);
+                }
+                _ => continue,
+            };
+        }
+
+        Ok(discoverable_keys)
     }
 }
 

--- a/rust/noosphere/src/key/interface.rs
+++ b/rust/noosphere/src/key/interface.rs
@@ -5,7 +5,7 @@ use ucan::crypto::KeyMaterial;
 /// A trait that represents access to arbitrary key storage backends.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait KeyStorage<K>
+pub trait KeyStorage<K>: Clone
 where
     K: KeyMaterial,
 {

--- a/rust/noosphere/src/noosphere.rs
+++ b/rust/noosphere/src/noosphere.rs
@@ -177,7 +177,7 @@ impl NoosphereContext {
 
         if !contexts.contains_key(sphere_identity) {
             let artifacts = SphereContextBuilder::default()
-                .open_sphere(sphere_identity)
+                .open_sphere(Some(sphere_identity))
                 .at_storage_path(self.sphere_storage_path())
                 .using_scoped_storage_layout()
                 .reading_keys_from(self.key_storage().await?)

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -24,7 +24,9 @@ mod inner {
 #[cfg(target_arch = "wasm32")]
 mod inner {
     use crate::key::WebCryptoKeyStorage;
+    use anyhow::Result;
     use noosphere_storage::web::{WebStorageProvider, WebStore};
+    use std::path::PathBuf;
     use std::sync::Arc;
     use ucan_key_support::web_crypto::WebCryptoRsaKeyMaterial;
 
@@ -32,6 +34,27 @@ mod inner {
     pub type PlatformKeyStorage = WebCryptoKeyStorage;
     pub type PlatformStore = WebStore;
     pub type PlatformStorageProvider = WebStorageProvider;
+
+    #[cfg(test)]
+    pub async fn make_temporary_platform_primitives() -> Result<(PathBuf, PlatformKeyStorage, ())> {
+        let db_name: PathBuf = witty_phrase_generator::WPGen::new()
+            .with_words(3)
+            .unwrap()
+            .into_iter()
+            .map(|word| String::from(word))
+            .collect();
+
+        let key_storage_name: String = witty_phrase_generator::WPGen::new()
+            .with_words(3)
+            .unwrap()
+            .into_iter()
+            .map(|word| String::from(word))
+            .collect();
+
+        let key_storage = WebCryptoKeyStorage::new(&key_storage_name).await?;
+
+        Ok((db_name, key_storage, ()))
+    }
 }
 
 #[cfg(all(
@@ -51,6 +74,27 @@ mod inner {
     pub type PlatformKeyStorage = InsecureKeyStorage;
     pub type PlatformStore = NativeStore;
     pub type PlatformStorageProvider = NativeStorageProvider;
+
+    #[cfg(test)]
+    use anyhow::Result;
+
+    #[cfg(test)]
+    use std::path::PathBuf;
+
+    #[cfg(test)]
+    use temp_dir::TempDir;
+
+    #[cfg(test)]
+    pub async fn make_temporary_platform_primitives(
+    ) -> Result<(PathBuf, PlatformKeyStorage, (TempDir, TempDir))> {
+        let sphere_dir = TempDir::new().unwrap();
+
+        let key_dir = TempDir::new().unwrap();
+
+        let key_storage = InsecureKeyStorage::new(key_dir.path())?;
+
+        Ok((sphere_dir.path().into(), key_storage, (sphere_dir, key_dir)))
+    }
 }
 
 pub use inner::*;

--- a/rust/noosphere/src/sphere/builder.rs
+++ b/rust/noosphere/src/sphere/builder.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
@@ -19,13 +19,14 @@ use crate::{
     sphere::{
         context::SphereContext,
         storage::{StorageLayout, AUTHORIZATION, USER_KEY_NAME},
+        IDENTITY,
     },
 };
 
 enum SphereInitialization {
     Create,
     Join(Did),
-    Open(Did),
+    Open(Option<Did>),
 }
 
 impl Default for SphereInitialization {
@@ -95,9 +96,10 @@ impl SphereContextBuilder {
     }
 
     /// Configure this builder to open an existing sphere that was previously
-    /// created or joined
-    pub fn open_sphere(mut self, sphere_identity: &Did) -> Self {
-        self.initialization = SphereInitialization::Open(sphere_identity.to_owned());
+    /// created or joined; if the sphere uses a scoped layout, you must provide
+    /// the identity of the sphere as well.
+    pub fn open_sphere(mut self, sphere_identity: Option<&Did>) -> Self {
+        self.initialization = SphereInitialization::Open(sphere_identity.cloned());
         self
     }
 
@@ -116,8 +118,8 @@ impl SphereContextBuilder {
 
     /// Specify the local namespace in storage where sphere data should be
     /// initialized
-    pub fn at_storage_path(mut self, path: &PathBuf) -> Self {
-        self.storage_path = Some(path.clone());
+    pub fn at_storage_path(mut self, path: &Path) -> Self {
+        self.storage_path = Some(path.into());
         self
     }
 
@@ -195,22 +197,27 @@ impl SphereContextBuilder {
 
                 db.set_version(&sphere_did, sphere.cid()).await?;
 
+                db.set_key(IDENTITY, &sphere_did).await?;
                 db.set_key(USER_KEY_NAME, key_name).await?;
                 db.set_key(AUTHORIZATION, Cid::try_from(&authorization)?)
                     .await?;
 
-                Ok(SphereContextBuilderArtifacts::SphereCreated {
-                    context: SphereContext::new(
-                        sphere_did,
-                        Author {
-                            key: owner_key,
-                            authorization: Some(authorization),
-                        },
-                        db,
-                        self.gateway_url,
-                    ),
-                    mnemonic,
-                })
+                let mut context = SphereContext::new(
+                    sphere_did,
+                    Author {
+                        key: owner_key,
+                        authorization: Some(authorization),
+                    },
+                    db,
+                );
+
+                if self.gateway_url.is_some() {
+                    context
+                        .configure_gateway_url(self.gateway_url.as_ref())
+                        .await?;
+                }
+
+                Ok(SphereContextBuilderArtifacts::SphereCreated { context, mnemonic })
             }
             SphereInitialization::Join(sphere_identity) => {
                 let key_storage = match self.key_storage {
@@ -239,46 +246,62 @@ impl SphereContextBuilder {
 
                 let mut db = SphereDb::new(&storage_provider).await?;
 
+                db.set_key(IDENTITY, &sphere_identity).await?;
                 db.set_key(USER_KEY_NAME, key_name).await?;
                 db.set_key(AUTHORIZATION, Cid::try_from(&authorization)?)
                     .await?;
 
-                Ok(SphereContextBuilderArtifacts::SphereOpened(
-                    SphereContext::new(
-                        sphere_identity,
-                        Author {
-                            key: user_key,
-                            authorization: Some(authorization),
-                        },
-                        db,
-                        self.gateway_url,
-                    ),
-                ))
+                let mut context = SphereContext::new(
+                    sphere_identity,
+                    Author {
+                        key: user_key,
+                        authorization: Some(authorization),
+                    },
+                    db,
+                );
+
+                if self.gateway_url.is_some() {
+                    context
+                        .configure_gateway_url(self.gateway_url.as_ref())
+                        .await?;
+                }
+
+                Ok(SphereContextBuilderArtifacts::SphereOpened(context))
             }
             SphereInitialization::Open(sphere_identity) => {
                 let storage_layout = match self.scoped_storage_layout {
-                    true => StorageLayout::Scoped(storage_path, sphere_identity.clone()),
+                    true => StorageLayout::Scoped(
+                        storage_path,
+                        sphere_identity
+                            .ok_or_else(|| anyhow!("A sphere identity must be provided!"))?,
+                    ),
                     false => StorageLayout::Unscoped(storage_path),
                 };
 
                 let storage_provider = storage_layout.to_storage_provider().await?;
                 let db = SphereDb::new(&storage_provider).await?;
 
-                let author = match (
-                    self.key_storage,
-                    db.get_key(USER_KEY_NAME).await? as Option<String>,
-                    db.get_key(AUTHORIZATION).await?,
-                ) {
-                    (Some(key_storage), Some(user_key_name), Some(cid)) => Author {
+                let user_key_name: String = db.require_key(USER_KEY_NAME).await?;
+                let authorization_cid: Cid = db.require_key(AUTHORIZATION).await?;
+
+                let author = match self.key_storage {
+                    Some(key_storage) => Author {
                         key: key_storage.require_key(&user_key_name).await?,
-                        authorization: Some(Authorization::Cid(cid)),
+                        authorization: Some(Authorization::Cid(authorization_cid)),
                     },
                     _ => return Err(anyhow!("Unable to resolve sphere author")),
                 };
 
-                Ok(SphereContextBuilderArtifacts::SphereOpened(
-                    SphereContext::new(sphere_identity, author, db, self.gateway_url),
-                ))
+                let sphere_identity = db.require_key(IDENTITY).await?;
+                let mut context = SphereContext::new(sphere_identity, author, db);
+
+                if self.gateway_url.is_some() {
+                    context
+                        .configure_gateway_url(self.gateway_url.as_ref())
+                        .await?;
+                }
+
+                Ok(SphereContextBuilderArtifacts::SphereOpened(context))
             }
         }
     }

--- a/rust/noosphere/src/sphere/context.rs
+++ b/rust/noosphere/src/sphere/context.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 use crate::error::NoosphereError;
 
-use super::{GatewaySyncStrategy, GATEWAY_URL};
+use super::{metadata::GATEWAY_URL, GatewaySyncStrategy};
 
 /// A [SphereContext] is an accessor construct over locally replicated sphere
 /// data. It embodies both the storage layer that contains the sphere's data

--- a/rust/noosphere/src/sphere/context.rs
+++ b/rust/noosphere/src/sphere/context.rs
@@ -8,12 +8,17 @@ use noosphere_core::{
     data::Did,
 };
 use noosphere_fs::SphereFs;
-use noosphere_storage::{db::SphereDb, interface::Store};
+use noosphere_storage::{
+    db::SphereDb,
+    interface::{KeyValueStore, Store},
+};
 use tokio::sync::OnceCell;
 use ucan::crypto::{did::DidParser, KeyMaterial};
 use url::Url;
 
 use crate::error::NoosphereError;
+
+use super::{GatewaySyncStrategy, GATEWAY_URL};
 
 /// A [SphereContext] is an accessor construct over locally replicated sphere
 /// data. It embodies both the storage layer that contains the sphere's data
@@ -30,7 +35,6 @@ where
     S: Store,
 {
     sphere_identity: Did,
-    gateway_url: Option<Url>,
     author: Author<K>,
     db: SphereDb<S>,
     did_parser: DidParser,
@@ -42,17 +46,11 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Store,
 {
-    pub fn new(
-        sphere_identity: Did,
-        author: Author<K>,
-        db: SphereDb<S>,
-        gateway_url: Option<Url>,
-    ) -> Self {
+    pub fn new(sphere_identity: Did, author: Author<K>, db: SphereDb<S>) -> Self {
         SphereContext {
             sphere_identity,
             author,
             db,
-            gateway_url,
             did_parser: DidParser::new(SUPPORTED_KEYS),
             client: OnceCell::new(),
         }
@@ -61,6 +59,44 @@ where
     /// The identity of the sphere
     pub fn identity(&self) -> &Did {
         &self.sphere_identity
+    }
+
+    /// The [Author] who is currently accessing the sphere
+    pub fn author(&self) -> &Author<K> {
+        &self.author
+    }
+
+    pub fn did_parser_mut(&mut self) -> &mut DidParser {
+        &mut self.did_parser
+    }
+
+    /// Sets or unsets the gateway URL that points to the gateway API that the
+    /// sphere will use when it is syncing.
+    pub async fn configure_gateway_url(&mut self, url: Option<&Url>) -> Result<()> {
+        self.client = OnceCell::new();
+
+        match url {
+            Some(url) => {
+                self.db.set_key(GATEWAY_URL, url.to_string()).await?;
+            }
+            None => {
+                self.db.unset_key(GATEWAY_URL).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the [SphereDb] instance that manages the current sphere's block
+    /// space and persisted configuration.
+    pub fn db(&self) -> &SphereDb<S> {
+        &self.db
+    }
+
+    /// Get a mutable reference to the [SphereDb] instance that manages the
+    /// current sphere's block space and persisted configuration.
+    pub fn db_mut(&mut self) -> &mut SphereDb<S> {
+        &mut self.db
     }
 
     /// Get a [SphereFs] instance over the current sphere's content; note that
@@ -80,10 +116,7 @@ where
         let client = self
             .client
             .get_or_try_init::<anyhow::Error, _, _>(|| async {
-                let gateway_url = self
-                    .gateway_url
-                    .clone()
-                    .ok_or(NoosphereError::MissingConfiguration("gateway URL"))?;
+                let gateway_url: Url = self.db.require_key(GATEWAY_URL).await?;
 
                 Ok(Arc::new(
                     Client::identify(
@@ -99,5 +132,16 @@ where
             .await?;
 
         Ok(client.clone())
+    }
+
+    /// If a gateway URL has been configured, attempt to synchronize local
+    /// sphere data with the gateway. Changes on the gateway will first be
+    /// fetched to local storage. Then, the local changes will be replayed on
+    /// top of those changes. Finally, the synchronized local history will be
+    /// pushed up to the gateway.
+    pub async fn sync(&mut self) -> Result<()> {
+        let sync_strategy = GatewaySyncStrategy::default();
+        sync_strategy.sync(self).await?;
+        Ok(())
     }
 }

--- a/rust/noosphere/src/sphere/metadata.rs
+++ b/rust/noosphere/src/sphere/metadata.rs
@@ -1,0 +1,33 @@
+///! These constants represent the metadata keys used when a [SphereContext] is
+///! is initialized or created with [SphereContextBuilder]. Since these
+///! represent somewhat free-form key/values in the storage layer, we are make a
+///! best effort to document them here.
+
+#[cfg(doc)]
+use crate::sphere::{SphereContext, SphereContextBuilder};
+
+#[cfg(doc)]
+use noosphere_core::data::Did;
+
+#[cfg(doc)]
+use cid::Cid;
+
+#[cfg(doc)]
+use url::Url;
+
+/// A key that corresponds to the sphere's identity, which is represented by a
+/// [Did] when it is set.
+pub const IDENTITY: &str = "identity";
+
+/// A name that corresponds to the locally available key. This name is
+/// represented as a string, and should match a credential ID for a key in
+/// whatever the supported platform key storage is.
+pub const USER_KEY_NAME: &str = "user_key_name";
+
+/// The [Cid] of a UCAN JWT that authorizes the configured user key to access
+/// the sphere.
+pub const AUTHORIZATION: &str = "authorization";
+
+/// The base [Url] of a Noosphere Gateway API that will allow this sphere to
+/// sync with it.
+pub const GATEWAY_URL: &str = "gateway_url";

--- a/rust/noosphere/src/sphere/mod.rs
+++ b/rust/noosphere/src/sphere/mod.rs
@@ -1,11 +1,13 @@
 mod builder;
 mod context;
+mod metadata;
 mod receipt;
 mod storage;
 mod sync;
 
 pub use builder::*;
 pub use context::*;
+pub use metadata::*;
 pub use receipt::*;
 pub use storage::*;
 pub use sync::*;

--- a/rust/noosphere/src/sphere/mod.rs
+++ b/rust/noosphere/src/sphere/mod.rs
@@ -2,8 +2,10 @@ mod builder;
 mod context;
 mod receipt;
 mod storage;
+mod sync;
 
 pub use builder::*;
 pub use context::*;
 pub use receipt::*;
 pub use storage::*;
+pub use sync::*;

--- a/rust/noosphere/src/sphere/storage.rs
+++ b/rust/noosphere/src/sphere/storage.rs
@@ -4,11 +4,6 @@ use crate::platform::PlatformStorageProvider;
 use anyhow::Result;
 use noosphere_core::data::Did;
 
-pub const IDENTITY: &str = "identity";
-pub const USER_KEY_NAME: &str = "user_key_name";
-pub const AUTHORIZATION: &str = "authorization";
-pub const GATEWAY_URL: &str = "gateway_url";
-
 /// [StorageLayout] represents the namespace that should be used depending on
 /// whether or not a sphere's DID should be included in the namespace. The enum
 /// is a convenience that can be directly transformed into a

--- a/rust/noosphere/src/sphere/storage.rs
+++ b/rust/noosphere/src/sphere/storage.rs
@@ -4,8 +4,10 @@ use crate::platform::PlatformStorageProvider;
 use anyhow::Result;
 use noosphere_core::data::Did;
 
+pub const IDENTITY: &str = "identity";
 pub const USER_KEY_NAME: &str = "user_key_name";
 pub const AUTHORIZATION: &str = "authorization";
+pub const GATEWAY_URL: &str = "gateway_url";
 
 /// [StorageLayout] represents the namespace that should be used depending on
 /// whether or not a sphere's DID should be included in the namespace. The enum
@@ -29,7 +31,7 @@ impl From<&StorageLayout> for PathBuf {
     fn from(layout: &StorageLayout) -> Self {
         match layout {
             StorageLayout::Scoped(path, scope) => path.join(scope.as_str()),
-            StorageLayout::Unscoped(path) => path.clone(),
+            StorageLayout::Unscoped(path) => path.join(".sphere/storage"),
         }
     }
 }

--- a/rust/noosphere/src/sphere/sync.rs
+++ b/rust/noosphere/src/sphere/sync.rs
@@ -1,0 +1,287 @@
+use std::marker::PhantomData;
+
+use anyhow::{anyhow, Result};
+use cid::Cid;
+use noosphere_api::data::{FetchParameters, FetchResponse, PushBody, PushResponse};
+use noosphere_core::{data::Did, view::Sphere};
+use noosphere_storage::{db::SphereDb, interface::Store};
+use ucan::crypto::KeyMaterial;
+
+use super::SphereContext;
+
+pub struct GatewaySyncStrategy<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Store,
+{
+    key_type: PhantomData<K>,
+    store_type: PhantomData<S>,
+}
+
+impl<K, S> Default for GatewaySyncStrategy<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Store,
+{
+    fn default() -> Self {
+        Self {
+            key_type: Default::default(),
+            store_type: Default::default(),
+        }
+    }
+}
+
+impl<K, S> GatewaySyncStrategy<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Store,
+{
+    /// Synchronize a local sphere's data with the data in a gateway, and rollback
+    /// if there is an error.
+    pub async fn sync(&self, context: &mut SphereContext<K, S>) -> Result<()> {
+        let client = context.client().await?;
+        let counterpart_sphere_identity = client.session.sphere_identity.clone();
+        let local_sphere_identity = context.identity().clone();
+
+        let local_sphere_version = context.db().get_version(&local_sphere_identity).await?;
+        let counterpart_sphere_version = context
+            .db()
+            .get_version(&counterpart_sphere_identity)
+            .await?;
+
+        let result: Result<(), anyhow::Error> = {
+            self.fetch_remote_changes(
+                context,
+                local_sphere_version.as_ref(),
+                &counterpart_sphere_identity,
+                counterpart_sphere_version.as_ref(),
+            )
+            .await?;
+            self.push_local_changes(
+                context,
+                local_sphere_version.as_ref(),
+                &counterpart_sphere_identity,
+                counterpart_sphere_version.as_ref(),
+            )
+            .await?;
+            Ok(())
+        };
+
+        // Rollback if there is an error while syncing
+        if result.is_err() {
+            self.rollback(
+                context.db_mut(),
+                &local_sphere_identity,
+                local_sphere_version.as_ref(),
+                &counterpart_sphere_identity,
+                counterpart_sphere_version.as_ref(),
+            )
+            .await?
+        }
+
+        result
+    }
+
+    /// Fetches the latest changes from a gateway and updates the local lineage
+    /// using a conflict-free rebase strategy
+    async fn fetch_remote_changes(
+        &self,
+        context: &mut SphereContext<K, S>,
+        local_sphere_tip: Option<&Cid>,
+        counterpart_sphere_identity: &Did,
+        counterpart_sphere_base: Option<&Cid>,
+    ) -> Result<()> {
+        let local_sphere_identity = context.identity().clone();
+        let client = context.client().await?;
+        let fetch_response = client
+            .fetch(&FetchParameters {
+                since: counterpart_sphere_base.cloned(),
+            })
+            .await?;
+
+        let (counterpart_sphere_tip, new_blocks) = match fetch_response {
+            FetchResponse::NewChanges { tip, blocks } => (tip, blocks),
+            FetchResponse::UpToDate => {
+                println!("Local history is already up to date...");
+                return Ok(());
+            }
+        };
+
+        new_blocks.load_into(context.db_mut()).await?;
+
+        Sphere::try_hydrate_range(
+            counterpart_sphere_base,
+            &counterpart_sphere_tip,
+            context.db_mut(),
+        )
+        .await?;
+
+        let local_sphere_old_base = match counterpart_sphere_base {
+            Some(counterpart_sphere_base) => Sphere::at(counterpart_sphere_base, context.db())
+                .try_get_links()
+                .await?
+                .get(&local_sphere_identity)
+                .await?
+                .cloned(),
+            None => None,
+        };
+        let local_sphere_new_base = Sphere::at(&counterpart_sphere_tip, context.db())
+            .try_get_links()
+            .await?
+            .get(&local_sphere_identity)
+            .await?
+            .cloned();
+
+        match (
+            local_sphere_tip,
+            local_sphere_old_base,
+            local_sphere_new_base,
+        ) {
+            (Some(current_tip), Some(old_base), Some(new_base)) => {
+                println!("Syncing received local sphere revisions...");
+                let new_tip = Sphere::at(current_tip, context.db())
+                    .try_sync(
+                        &old_base,
+                        &new_base,
+                        &context.author().key,
+                        context.author().authorization.as_ref(),
+                    )
+                    .await?;
+
+                context
+                    .db_mut()
+                    .set_version(&local_sphere_identity, &new_tip)
+                    .await?;
+            }
+            (None, old_base, Some(new_base)) => {
+                println!("Hydrating received local sphere revisions...");
+                Sphere::try_hydrate_range(old_base.as_ref(), &new_base, context.db_mut()).await?;
+
+                context
+                    .db_mut()
+                    .set_version(&local_sphere_identity, &new_base)
+                    .await?;
+            }
+            _ => {
+                println!("Nothing to sync!");
+                return Ok(());
+            }
+        };
+
+        context
+            .db_mut()
+            .set_version(counterpart_sphere_identity, &counterpart_sphere_tip)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Attempts to push the latest local lineage to the gateway, causing the
+    /// gateway to update its own pointer to the tip of the local sphere's history
+    async fn push_local_changes(
+        &self,
+        context: &mut SphereContext<K, S>,
+        local_sphere_tip: Option<&Cid>,
+        counterpart_sphere_identity: &Did,
+        counterpart_sphere_tip: Option<&Cid>,
+    ) -> Result<()> {
+        // The base of the changes that must be pushed is the tip of our lineage as
+        // recorded by the most recent history of the gateway's sphere. Everything
+        // past that point in history represents new changes that the gateway does
+        // not yet know about.
+        let local_sphere_tip = local_sphere_tip.ok_or_else(|| {
+            anyhow!(
+                "The history of local sphere {} is missing!",
+                context.identity()
+            )
+        })?;
+
+        let counterpart_sphere_tip = counterpart_sphere_tip.ok_or_else(|| {
+            anyhow!(
+                "No local history for counterpart sphere {}; did you forget to fetch?",
+                counterpart_sphere_identity
+            )
+        })?;
+
+        let local_sphere_base = Sphere::at(counterpart_sphere_tip, context.db())
+            .try_get_links()
+            .await?
+            .get(context.identity())
+            .await?
+            .cloned();
+
+        if local_sphere_base.as_ref() == Some(local_sphere_tip) {
+            println!("Gateway is already up to date!");
+            return Ok(());
+        }
+
+        println!("Collecting blocks from new local history...");
+
+        let bundle = Sphere::at(local_sphere_tip, context.db())
+            .try_bundle_until_ancestor(local_sphere_base.as_ref())
+            .await?;
+
+        let client = context.client().await?;
+
+        println!(
+            "Pushing new local history to gateway {}...",
+            client.session.gateway_identity
+        );
+
+        let result = client
+            .push(&PushBody {
+                sphere: context.identity().to_string(),
+                base: local_sphere_base,
+                tip: *local_sphere_tip,
+                blocks: bundle,
+            })
+            .await?;
+
+        let (counterpart_sphere_updated_tip, new_blocks) = match result {
+            PushResponse::Accepted { new_tip, blocks } => (new_tip, blocks),
+            PushResponse::NoChange => {
+                return Err(anyhow!("Gateway already up to date!"));
+            }
+        };
+
+        println!("Saving updated counterpart sphere history...");
+
+        new_blocks.load_into(context.db_mut()).await?;
+
+        Sphere::try_hydrate_range(
+            Some(counterpart_sphere_tip),
+            &counterpart_sphere_updated_tip,
+            context.db_mut(),
+        )
+        .await?;
+
+        context
+            .db_mut()
+            .set_version(
+                counterpart_sphere_identity,
+                &counterpart_sphere_updated_tip,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn rollback(
+        &self,
+        db: &mut SphereDb<S>,
+        sphere_identity: &Did,
+        original_sphere_version: Option<&Cid>,
+        counterpart_identity: &Did,
+        original_counterpart_version: Option<&Cid>,
+    ) -> Result<()> {
+        if let Some(version) = original_sphere_version {
+            db.set_version(sphere_identity, version).await?;
+        }
+
+        if let Some(version) = original_counterpart_version {
+            db.set_version(counterpart_identity, version).await?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
When we introduced the `noosphere-cli` crate in #71 we were in the thick of discovering how to tie our various APIs together into an ergonomic high-level interface for the purpose of vending a user-legible `orb` binary. (

As we began to expose an FFI in the high-level `noosphere` crate in #123 and #131 , we carried over our insight gleaned from implementing `noosphere-cli` and began to generalize the high-level implementation in a way that could be re-used on other platforms (such as the web).

This change connects that thread of work back to `noosphere-cli`. Now, `noosphere-cli` is implemented in terms of `noosphere`. The most significant change involved is that all of `noosphere-cli` works around the `SphereContext` that was introduced by `noosphere`. This simplifies the function and method signatures used throughout the `noosphere-cli` crate substantially. Another big change is that synchronization with a gateway has been generalized and relocated from `noosphere-cli` to `noosphere`, with the intention that the same synchronization flow can be re-used across platforms.

In addition to the above work, a bunch of missing docs have been added and a handful of much-needed tests introduced to the `noosphere` crate.

Fixes #104