### PR TITLE
dev: Introduce interior mutability for the NameSystem client

### DIFF
--- a/rust/noosphere-core/src/data/names.rs
+++ b/rust/noosphere-core/src/data/names.rs
@@ -1,5 +1,3 @@
-use cid::Cid;
-
 use crate::data::VersionedMapIpld;
 
 use super::AddressIpld;

--- a/rust/noosphere-core/src/data/strings.rs
+++ b/rust/noosphere-core/src/data/strings.rs
@@ -41,6 +41,12 @@ macro_rules! string_coherent {
             }
         }
 
+        impl<'a> From<&'a $wrapper> for &'a str {
+            fn from(value: &'a $wrapper) -> Self {
+                &value.0
+            }
+        }
+
         impl PartialEq<String> for $wrapper {
             fn eq(&self, other: &String) -> bool {
                 &self.0 == other
@@ -50,6 +56,30 @@ macro_rules! string_coherent {
         impl PartialEq<$wrapper> for String {
             fn eq(&self, other: &$wrapper) -> bool {
                 self == &other.0
+            }
+        }
+
+        impl PartialEq<str> for $wrapper {
+            fn eq(&self, other: &str) -> bool {
+                &self.0 == other
+            }
+        }
+
+        impl PartialEq<$wrapper> for str {
+            fn eq(&self, other: &$wrapper) -> bool {
+                self == &other.0
+            }
+        }
+
+        impl PartialEq<&str> for $wrapper {
+            fn eq(&self, other: &&str) -> bool {
+                &self.0 == *other
+            }
+        }
+
+        impl<'a> PartialEq<$wrapper> for &'a str {
+            fn eq(&self, other: &$wrapper) -> bool {
+                **self == *other.0
             }
         }
 
@@ -138,5 +168,28 @@ mod tests {
 
         assert_eq!(did_from_string.foo, Did(string_value.clone()));
         assert_eq!(string_from_did.foo, string_value);
+    }
+
+    #[test]
+    fn it_enables_comparison_to_string_types() {
+        let did_str = "did:key:z6MkoE19WHXJzpLqkxbGP7uXdJX38sWZNUWwyjcuCmjhPpUP";
+        let did_string = String::from(did_str);
+        let did = Did::from(did_str);
+
+        // Did <-> &str
+        assert_eq!(did, did_str);
+        assert_eq!(did_str, did);
+
+        // Did <-> String
+        assert_eq!(did, did_string);
+        assert_eq!(did_string, did);
+
+        // &Did <-> &str
+        assert_eq!(&did, did_str);
+        assert_eq!(did_str, &did);
+
+        // &Did <-> &String
+        assert_eq!(&did, &did_string);
+        assert_eq!(&did_string, &did);
     }
 }

--- a/rust/noosphere-ns/src/dht/keys.rs
+++ b/rust/noosphere-ns/src/dht/keys.rs
@@ -26,9 +26,7 @@ mod tests {
     #[test]
     fn it_converts_to_libp2p_keypair() -> anyhow::Result<()> {
         let zebra_keys = generate_ed25519_key();
-        let keypair = match zebra_keys.to_dht_keypair()? {
-            libp2p::identity::Keypair::Ed25519(k) => k,
-        };
+        let libp2p::identity::Keypair::Ed25519(keypair) = zebra_keys.to_dht_keypair()?;
         let zebra_private_key = zebra_keys.1.expect("Has private key");
         let dalek_public_key = keypair.public().encode();
         let dalek_private_key = keypair.secret();

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -209,7 +209,10 @@ impl FromStr for NSRecord {
 #[cfg(test)]
 mod test {
     use super::*;
-    use noosphere_core::authority::{generate_ed25519_key, SUPPORTED_KEYS};
+    use noosphere_core::{
+        authority::{generate_ed25519_key, SUPPORTED_KEYS},
+        data::Did,
+    };
     use noosphere_storage::{
         db::SphereDb,
         memory::{MemoryStorageProvider, MemoryStore},
@@ -240,7 +243,7 @@ mod test {
     #[tokio::test]
     async fn test_nsrecord_self_signed() -> Result<(), Error> {
         let sphere_key = generate_ed25519_key();
-        let sphere_identity = sphere_key.get_did().await?;
+        let sphere_identity = Did::from(sphere_key.get_did().await?);
         let mut did_parser = DidParser::new(SUPPORTED_KEYS);
         let capability = generate_capability(&sphere_identity);
         let cid_address = "bafy2bzacec4p5h37mjk2n6qi6zukwyzkruebvwdzqpdxzutu4sgoiuhqwne72";
@@ -261,7 +264,7 @@ mod test {
                 .await?,
         );
 
-        assert_eq!(record.identity(), &sphere_identity);
+        assert_eq!(&Did::from(record.identity()), &sphere_identity);
         assert_eq!(record.address(), Some(&Cid::from_str(cid_address).unwrap()));
         record.validate(&store, &mut did_parser).await?;
         Ok(())
@@ -270,9 +273,9 @@ mod test {
     #[tokio::test]
     async fn test_nsrecord_delegated() -> Result<(), Error> {
         let owner_key = generate_ed25519_key();
-        let owner_identity = owner_key.get_did().await?;
+        let owner_identity = Did::from(owner_key.get_did().await?);
         let sphere_key = generate_ed25519_key();
-        let sphere_identity = sphere_key.get_did().await?;
+        let sphere_identity = Did::from(sphere_key.get_did().await?);
         let mut did_parser = DidParser::new(SUPPORTED_KEYS);
         let capability = generate_capability(&sphere_identity);
         let cid_address = "bafy2bzacec4p5h37mjk2n6qi6zukwyzkruebvwdzqpdxzutu4sgoiuhqwne72";
@@ -336,7 +339,7 @@ mod test {
     #[tokio::test]
     async fn test_nsrecord_failures() -> Result<(), Error> {
         let sphere_key = generate_ed25519_key();
-        let sphere_identity = sphere_key.get_did().await?;
+        let sphere_identity = Did::from(sphere_key.get_did().await?);
         let mut did_parser = DidParser::new(SUPPORTED_KEYS);
         let cid_address = "bafy2bzacec4p5h37mjk2n6qi6zukwyzkruebvwdzqpdxzutu4sgoiuhqwne72";
         let store = SphereDb::new(&MemoryStorageProvider::default())
@@ -360,7 +363,7 @@ mod test {
         )
         .await;
 
-        let capability = generate_capability(&generate_ed25519_key().get_did().await?);
+        let capability = generate_capability(&Did(generate_ed25519_key().get_did().await?));
         expect_failure(
             "fails when capability resource does not match sphere identity",
             &store,
@@ -400,7 +403,7 @@ mod test {
     #[tokio::test]
     async fn test_nsrecord_convert() -> Result<(), Error> {
         let sphere_key = generate_ed25519_key();
-        let sphere_identity = sphere_key.get_did().await?;
+        let sphere_identity = Did::from(sphere_key.get_did().await?);
         let capability = generate_capability(&sphere_identity);
         let cid_address = "bafy2bzacec4p5h37mjk2n6qi6zukwyzkruebvwdzqpdxzutu4sgoiuhqwne72";
         let fact = json!({ "address": cid_address });

--- a/rust/noosphere-ns/src/utils.rs
+++ b/rust/noosphere-ns/src/utils.rs
@@ -10,7 +10,7 @@ use cid::Cid;
 ///
 /// ```
 /// use noosphere_ns::utils::generate_capability;
-/// use noosphere_core::authority::{SphereAction, SphereReference};
+/// use noosphere_core::{authority::{SphereAction, SphereReference}};
 /// use ucan::capability::{Capability, Resource, With};
 ///
 /// let identity = "did:key:z6MkoE19WHXJzpLqkxbGP7uXdJX38sWZNUWwyjcuCmjhPpUP";
@@ -22,13 +22,13 @@ use cid::Cid;
 ///     },
 ///     can: SphereAction::Publish,
 /// };
-/// assert_eq!(generate_capability(identity), expected_capability);
+/// assert_eq!(generate_capability(&identity), expected_capability);
 /// ```
-pub fn generate_capability(sphere_did: &str) -> Capability<SphereReference, SphereAction> {
+pub fn generate_capability(identity: &str) -> Capability<SphereReference, SphereAction> {
     Capability {
         with: With::Resource {
             kind: Resource::Scoped(SphereReference {
-                did: sphere_did.to_owned(),
+                did: identity.to_owned(),
             }),
         },
         can: SphereAction::Publish,

--- a/rust/noosphere-ns/tests/ns_test.rs
+++ b/rust/noosphere-ns/tests/ns_test.rs
@@ -1,31 +1,68 @@
 #![cfg(not(target_arch = "wasm32"))]
 #![cfg(test)]
 pub mod utils;
-use anyhow::{anyhow, Result};
-use futures::future::try_join_all;
-use libipld_cbor::DagCborCodec;
-use noosphere_core::{authority::generate_ed25519_key, view::SPHERE_LIFETIME};
+use anyhow::Result;
+use noosphere_core::{authority::generate_ed25519_key, data::Did, view::SPHERE_LIFETIME};
 use noosphere_ns::{
-    dht::{DHTNode, DefaultRecordValidator},
     utils::{generate_capability, generate_fact},
-    NameSystem, NameSystemBuilder,
+    Multiaddr, NSRecord, NameSystem, NameSystemBuilder,
 };
 use noosphere_storage::{
     db::SphereDb, encoding::derive_cid, memory::MemoryStorageProvider, memory::MemoryStore,
 };
 
+use futures::future::try_join_all;
+use libipld_cbor::DagCborCodec;
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
 use ucan::{builder::UcanBuilder, crypto::KeyMaterial, store::UcanJwtStore, time::now, Ucan};
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
-use utils::create_bootstrap_nodes;
 
 /// Data related to an owner sphere and a NameSystem running
 /// on its behalf in it's corresponding gateway.
 struct NSData {
     pub ns: NameSystem<MemoryStore, Ed25519KeyMaterial>,
     pub owner_key: Ed25519KeyMaterial,
-    pub owner_id: String,
-    pub sphere_id: String,
+    pub owner_id: Did,
+    pub sphere_id: Did,
     pub delegation: Ucan,
+}
+
+async fn generate_name_system(
+    store: &mut SphereDb<MemoryStore>,
+    bootstrap_addresses: &[Multiaddr],
+) -> Result<NSData> {
+    let owner_key = generate_ed25519_key();
+    let owner_id = Did(owner_key.get_did().await?);
+    let sphere_key = generate_ed25519_key();
+    let sphere_id = Did(sphere_key.get_did().await?);
+
+    // Delegate `sphere_key`'s publishing authority to `owner_key`
+    let delegate_capability = generate_capability(&sphere_id);
+    let delegation = UcanBuilder::default()
+        .issued_by(&sphere_key)
+        .for_audience(&owner_id)
+        .with_lifetime(SPHERE_LIFETIME)
+        .claiming_capability(&delegate_capability)
+        .build()?
+        .sign()
+        .await?;
+    let _ = store.write_token(&delegation.encode()?).await?;
+
+    let ns_key = generate_ed25519_key();
+    let ns: NameSystem<MemoryStore, Ed25519KeyMaterial> = NameSystemBuilder::default()
+        .key_material(&ns_key)
+        .store(store)
+        .peer_dialing_interval(1)
+        .bootstrap_peers(bootstrap_addresses)
+        .build()?;
+    Ok(NSData {
+        ns,
+        owner_key,
+        owner_id,
+        sphere_id,
+        delegation,
+    })
 }
 
 /// Generates a DHT network bootstrap node with `ns_count`
@@ -33,51 +70,29 @@ struct NSData {
 async fn generate_name_systems_network(
     ns_count: usize,
 ) -> Result<(
-    DHTNode<DefaultRecordValidator>,
+    NameSystem<MemoryStore, Ed25519KeyMaterial>,
     SphereDb<MemoryStore>,
     Vec<NSData>,
 )> {
-    let bootstrap_node = create_bootstrap_nodes(1, DHTNode::<DefaultRecordValidator>::validator())
-        .map_err(|e| anyhow!(e.to_string()))?
-        .pop()
-        .unwrap();
+    let mut name_systems: Vec<NSData> = vec![];
+    let mut store = SphereDb::new(&MemoryStorageProvider::default()).await?;
+
+    let bootstrap_node = {
+        let key = generate_ed25519_key();
+        let mut node: NameSystem<MemoryStore, Ed25519KeyMaterial> = NameSystemBuilder::default()
+            .key_material(&key)
+            .store(&store)
+            .listening_port(thread_rng().gen_range(49152..65525))
+            .peer_dialing_interval(1)
+            .build()?;
+        node.connect().await?;
+        node
+    };
     let bootstrap_addresses = vec![bootstrap_node.p2p_address().unwrap().to_owned()];
 
-    let mut store = SphereDb::new(&MemoryStorageProvider::default()).await?;
-    let mut name_systems: Vec<NSData> = vec![];
-
     for _ in 0..ns_count {
-        let owner_key = generate_ed25519_key();
-        let owner_id = owner_key.get_did().await?;
-        let sphere_key = generate_ed25519_key();
-        let sphere_id = sphere_key.get_did().await?;
-
-        // Delegate `sphere_key`'s publishing authority to `owner_key`
-        let delegate_capability = generate_capability(&sphere_id);
-        let delegation = UcanBuilder::default()
-            .issued_by(&sphere_key)
-            .for_audience(&owner_id)
-            .with_lifetime(SPHERE_LIFETIME)
-            .claiming_capability(&delegate_capability)
-            .build()?
-            .sign()
-            .await?;
-        let _ = &store.write_token(&delegation.encode()?).await?;
-
-        let ns_key = generate_ed25519_key();
-        let ns: NameSystem<MemoryStore, Ed25519KeyMaterial> = NameSystemBuilder::default()
-            .key_material(&ns_key)
-            .store(&store)
-            .peer_dialing_interval(1)
-            .bootstrap_peers(&bootstrap_addresses)
-            .build()?;
-        name_systems.push(NSData {
-            ns,
-            owner_key,
-            owner_id,
-            sphere_id,
-            delegation,
-        });
+        let ns_data = generate_name_system(&mut store, &bootstrap_addresses).await?;
+        name_systems.push(ns_data);
     }
 
     let futures: Vec<_> = name_systems
@@ -100,7 +115,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
     let sphere_2_cid_1 = derive_cid::<DagCborCodec>(b"99999999");
     let sphere_2_cid_2 = derive_cid::<DagCborCodec>(b"88888888");
 
-    let [mut ns_1, mut ns_2] = [ns_data.remove(0), ns_data.remove(0)];
+    let [ns_1, ns_2] = [ns_data.remove(0), ns_data.remove(0)];
 
     // Test propagating records from ns_1 to ns_2
     ns_1.ns
@@ -121,7 +136,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
 
     // `None` for a record that cannot be found
     assert!(
-        ns_2.ns.get_record("unknown").await?.is_none(),
+        ns_2.ns.get_record(&Did::from("unknown")).await?.is_none(),
         "no record found"
     );
 
@@ -153,10 +168,10 @@ async fn test_name_system_peer_propagation() -> Result<()> {
                 .into(),
         )
         .await?;
-    assert!(!ns_2
-        .ns
-        .flush_records_for_identity(&generate_ed25519_key().get_did().await?));
-    assert!(ns_2.ns.flush_records_for_identity(&ns_1.sphere_id));
+
+    let temp_identity = Did(generate_ed25519_key().get_did().await?);
+    assert!(!ns_2.ns.flush_records_for_identity(&temp_identity).await);
+    assert!(ns_2.ns.flush_records_for_identity(&ns_1.sphere_id).await);
     assert_eq!(
         ns_2.ns
             .get_record(&ns_1.sphere_id)
@@ -169,7 +184,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
     );
 
     // Store an expired record in ns_1's cache
-    ns_1.ns.get_cache_mut().insert(
+    ns_1.ns.get_cache().await.insert(
         ns_2.owner_id.clone(),
         UcanBuilder::default()
             .issued_by(&ns_2.owner_key)
@@ -220,7 +235,7 @@ async fn test_name_system_peer_propagation() -> Result<()> {
 #[test_log::test(tokio::test)]
 async fn test_name_system_validation() -> Result<()> {
     let (_bootstrap_node, _store, mut ns_data) = generate_name_systems_network(1).await?;
-    let [mut ns_1] = [ns_data.remove(0)];
+    let [ns_1] = [ns_data.remove(0)];
 
     let sphere_1_cid_1 = derive_cid::<DagCborCodec>(b"00000000");
 
@@ -244,5 +259,47 @@ async fn test_name_system_validation() -> Result<()> {
             .is_err(),
         "invalid (expired) records cannot be propagated"
     );
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn it_is_thread_safe() -> Result<()> {
+    let (_bootstrap_node, _store, mut ns_data) = generate_name_systems_network(1).await?;
+    let [ns_1] = [ns_data.remove(0)];
+    let address = derive_cid::<DagCborCodec>(b"00000000");
+
+    let ucan_record: NSRecord = UcanBuilder::default()
+        .issued_by(&ns_1.owner_key)
+        .for_audience(&ns_1.sphere_id)
+        .with_lifetime(SPHERE_LIFETIME)
+        .claiming_capability(&generate_capability(&ns_1.sphere_id))
+        .with_fact(generate_fact(&address.to_string()))
+        .witnessed_by(&ns_1.delegation)
+        .build()?
+        .sign()
+        .await?
+        .into();
+
+    // Store a dummy record for this name system's own owner sphere
+    ns_1.ns
+        .get_cache()
+        .await
+        .insert(ns_1.owner_id.clone(), ucan_record.clone());
+
+    let arc_ns = Arc::new(ns_1.ns);
+    let mut join_handles = vec![];
+    for _ in 0..10 {
+        let ns = arc_ns.clone();
+        let identity = ns_1.owner_id.clone();
+        let record = ucan_record.clone();
+        join_handles.push(tokio::spawn(async move {
+            ns.put_record(record).await?;
+            ns.get_record(&identity).await
+        }));
+    }
+    for result in try_join_all(join_handles).await? {
+        assert_eq!(result.unwrap().unwrap().address().unwrap(), &address);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
dev: Introduce interior mutability for the NameSystem client for querying from multiple threads, and introduce noosphere_core::data::Did in the NameSystem where appropriate, with additional PartialEq implementations for string comparison.

Some precursor work during the CLI integration of the NameSystem.