### PR TITLE
chore: Use `tempfile` instead of `temp-dir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,7 +2281,7 @@ dependencies = [
  "rexie",
  "safer-ffi",
  "subtext",
- "temp-dir",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -2341,7 +2341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtext",
- "temp-dir",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "toml_edit",
@@ -2461,7 +2461,7 @@ dependencies = [
  "noosphere-fs",
  "noosphere-storage",
  "subtext",
- "temp-dir",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3889,12 +3889,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "temp-dir"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "tempdir"

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-temp-dir = "0.1"
+tempfile = "^3"
 clap = { version = "^4", features = ["derive", "cargo"] }
 anyhow = "^1"
 

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -526,7 +526,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_chooses_an_ancestor_sphere_directory_as_root_if_one_exists() {
-        let (workspace, temporary_directories) = Workspace::temporary().unwrap();
+        let (workspace, _temporary_directories) = Workspace::temporary().unwrap();
 
         key::key_create("FOO", &workspace).await.unwrap();
 
@@ -540,7 +540,5 @@ mod tests {
             Workspace::new(&subdirectory, workspace.key_directory().parent()).unwrap();
 
         assert_eq!(workspace.root_directory(), new_workspace.root_directory());
-
-        drop(temporary_directories)
     }
 }

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -34,7 +34,7 @@ use noosphere::{
     sphere::{SphereContext, SphereContextBuilder, AUTHORIZATION, GATEWAY_URL, USER_KEY_NAME},
 };
 
-use temp_dir::TempDir;
+use tempfile::TempDir;
 
 const SPHERE_DIRECTORY: &str = ".sphere";
 const NOOSPHERE_DIRECTORY: &str = ".noosphere";

--- a/rust/noosphere-cli/tests/gateway.rs
+++ b/rust/noosphere-cli/tests/gateway.rs
@@ -25,8 +25,8 @@ use noosphere_cli::native::commands::serve::gateway::{start_gateway, GatewayScop
 async fn it_can_be_identified_by_the_client_of_its_owner() {
     initialize_tracing();
 
-    let (gateway_workspace, gateway_temporary_directories) = Workspace::temporary().unwrap();
-    let (client_workspace, client_temporary_directories) = Workspace::temporary().unwrap();
+    let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_workspace, _client_temporary_directories) = Workspace::temporary().unwrap();
 
     let gateway_key_name = "GATEWAY_KEY";
     let client_key_name = "CLIENT_KEY";
@@ -100,17 +100,14 @@ async fn it_can_be_identified_by_the_client_of_its_owner() {
     });
 
     client_task.await.unwrap();
-
-    drop(gateway_temporary_directories);
-    drop(client_temporary_directories);
 }
 
 #[tokio::test]
 async fn it_can_receive_a_newly_initialized_sphere_from_the_client() {
     // initialize_tracing();
 
-    let (gateway_workspace, gateway_temporary_directories) = Workspace::temporary().unwrap();
-    let (client_workspace, client_temporary_directories) = Workspace::temporary().unwrap();
+    let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_workspace, _client_temporary_directories) = Workspace::temporary().unwrap();
 
     let gateway_key_name = "GATEWAY_KEY";
     let client_key_name = "CLIENT_KEY";
@@ -214,17 +211,14 @@ async fn it_can_receive_a_newly_initialized_sphere_from_the_client() {
     });
 
     client_task.await.unwrap();
-
-    drop(gateway_temporary_directories);
-    drop(client_temporary_directories);
 }
 
 #[tokio::test]
 async fn it_can_update_an_existing_sphere_with_changes_from_the_client() {
     // initialize_tracing();
 
-    let (gateway_workspace, gateway_temporary_directories) = Workspace::temporary().unwrap();
-    let (client_workspace, client_temporary_directories) = Workspace::temporary().unwrap();
+    let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_workspace, _client_temporary_directories) = Workspace::temporary().unwrap();
 
     let gateway_key_name = "GATEWAY_KEY";
     let client_key_name = "CLIENT_KEY";
@@ -382,17 +376,14 @@ async fn it_can_update_an_existing_sphere_with_changes_from_the_client() {
     });
 
     client_task.await.unwrap();
-
-    drop(gateway_temporary_directories);
-    drop(client_temporary_directories);
 }
 
 #[tokio::test]
 async fn it_can_serve_sphere_revisions_to_a_client() {
     // initialize_tracing();
 
-    let (gateway_workspace, gateway_temporary_directories) = Workspace::temporary().unwrap();
-    let (client_workspace, client_temporary_directories) = Workspace::temporary().unwrap();
+    let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_workspace, _client_temporary_directories) = Workspace::temporary().unwrap();
 
     let gateway_key_name = "GATEWAY_KEY";
     let client_key_name = "CLIENT_KEY";
@@ -530,7 +521,4 @@ async fn it_can_serve_sphere_revisions_to_a_client() {
     });
 
     client_task.await.unwrap();
-
-    drop(gateway_temporary_directories);
-    drop(client_temporary_directories);
 }

--- a/rust/noosphere-into/Cargo.toml
+++ b/rust/noosphere-into/Cargo.toml
@@ -49,7 +49,7 @@ wasm-bindgen-test = "~0.3"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # Mostly these dependencies are used in the examples
 tokio = { version = "^1", features = ["full"] }
-temp-dir = "~0.1"
+tempfile = "^3"
 axum = "~0.5"
 axum-extra = { version = "~0.3", features = ["spa"] }
 tower-http = { version = "~0.3", features = ["fs", "trace"] }

--- a/rust/noosphere-into/examples/notes-to-html/implementation.rs
+++ b/rust/noosphere-into/examples/notes-to-html/implementation.rs
@@ -3,7 +3,7 @@ use axum::{http::StatusCode, response::IntoResponse, routing::get_service, Route
 use noosphere_fs::SphereFs;
 use noosphere_into::{html::sphere_into_html, write::NativeFs};
 use std::{net::SocketAddr, os::unix::prelude::OsStrExt, path::Path};
-use temp_dir::TempDir;
+use tempfile::TempDir;
 use tokio::fs::{self, File};
 use tower_http::services::ServeDir;
 

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -60,7 +60,7 @@ safer-ffi = { version = "~0.0.10", features = ["proc_macros"] }
 tokio = { version = "^1", features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-temp-dir = "0.1"
+tempfile = "^3"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "~0.3"

--- a/rust/noosphere/src/key/insecure.rs
+++ b/rust/noosphere/src/key/insecure.rs
@@ -125,7 +125,7 @@ mod tests {
     use crate::key::KeyStorage;
 
     use super::InsecureKeyStorage;
-    use temp_dir::TempDir;
+    use tempfile::TempDir;
     use ucan::crypto::KeyMaterial;
 
     #[tokio::test]

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -82,7 +82,7 @@ mod inner {
     use std::path::PathBuf;
 
     #[cfg(test)]
-    use temp_dir::TempDir;
+    use tempfile::TempDir;
 
     #[cfg(test)]
     pub async fn make_temporary_platform_primitives(

--- a/rust/noosphere/tests/integration.rs
+++ b/rust/noosphere/tests/integration.rs
@@ -47,7 +47,7 @@ async fn single_player_single_device_end_to_end_workflow() {
     #[cfg(target_arch = "wasm32")]
     tracing_wasm::set_as_global_default();
 
-    let (configuration, temporary_directories) = platform_configuration();
+    let (configuration, _temporary_directories) = platform_configuration();
     let key_name = "foobar";
 
     // Create the sphere and write a file to it
@@ -108,6 +108,4 @@ async fn single_player_single_device_end_to_end_workflow() {
 
         fs.save(None).await.unwrap();
     };
-
-    drop(temporary_directories)
 }

--- a/rust/noosphere/tests/integration.rs
+++ b/rust/noosphere/tests/integration.rs
@@ -11,25 +11,34 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 use noosphere::{sphere::SphereReceipt, NoosphereContext, NoosphereContextConfiguration};
 
 #[cfg(target_arch = "wasm32")]
-fn platform_configuration() -> NoosphereContextConfiguration {
-    NoosphereContextConfiguration::OpaqueSecurity {
-        sphere_storage_path: "sphere-data".into(),
-        gateway_url: None,
-    }
+fn platform_configuration() -> (NoosphereContextConfiguration, ()) {
+    (
+        NoosphereContextConfiguration::OpaqueSecurity {
+            sphere_storage_path: "sphere-data".into(),
+            gateway_url: None,
+        },
+        (),
+    )
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn platform_configuration() -> NoosphereContextConfiguration {
-    use temp_dir::TempDir;
+fn platform_configuration() -> (
+    NoosphereContextConfiguration,
+    (tempfile::TempDir, tempfile::TempDir),
+) {
+    use tempfile::TempDir;
 
-    let global_storage_path = TempDir::new().unwrap().path().to_path_buf();
-    let sphere_storage_path = TempDir::new().unwrap().path().to_path_buf();
+    let global_storage = TempDir::new().unwrap();
+    let sphere_storage = TempDir::new().unwrap();
 
-    NoosphereContextConfiguration::Insecure {
-        global_storage_path,
-        sphere_storage_path,
-        gateway_url: None,
-    }
+    (
+        NoosphereContextConfiguration::Insecure {
+            global_storage_path: global_storage.path().to_path_buf(),
+            sphere_storage_path: sphere_storage.path().to_path_buf(),
+            gateway_url: None,
+        },
+        (global_storage, sphere_storage),
+    )
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -38,7 +47,7 @@ async fn single_player_single_device_end_to_end_workflow() {
     #[cfg(target_arch = "wasm32")]
     tracing_wasm::set_as_global_default();
 
-    let configuration = platform_configuration();
+    let (configuration, temporary_directories) = platform_configuration();
     let key_name = "foobar";
 
     // Create the sphere and write a file to it
@@ -99,4 +108,6 @@ async fn single_player_single_device_end_to_end_workflow() {
 
         fs.save(None).await.unwrap();
     };
+
+    drop(temporary_directories)
 }


### PR DESCRIPTION
This is an attempt to clean up the way we create an dispose of temporary directories in the hopes it will help with #167 . Our temporary directory crate was deprecated, it turns out, so we update it here to [`tempfile`](https://crates.io/crates/tempfile). And, we fix a leak that caused temporary directories to go undeleted.

Even if this doesn't fix the flakes in `noosphere`, this is a hygienic improvement :shrug: 