### PR TITLE
feat: Syndicate sphere revisions to IPFS Kubo

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -13,7 +13,7 @@ jobs:
     with:
       for-test: true
 
-  run-test-suite-mac-os:
+  run-test-suite-mac-os-swift:
     runs-on: macos-12
     needs: ['build-noosphere-apple-artifacts']
     steps:
@@ -32,6 +32,7 @@ jobs:
 
           swift build
           swift test
+
   run-test-suite-linux:
     runs-on: ubuntu-latest
     steps:
@@ -46,10 +47,31 @@ jobs:
         run: |
           sudo apt-get update -qqy
           sudo apt-get install jq protobuf-compiler cmake
+      - name: 'Install IPFS Kubo'
+        uses: ibnesayeed/setup-ipfs@master
+        with:
+          ipfs_version: v0.17.0
+          run_daemon: true
       - name: 'Run Rust native target tests'
-        working-directory: ./rust
-        run: cargo test
-        shell: bash
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --features test_kubo
+
+  run-test-suite-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          toolchain: stable
+      - name: 'Install environment packages'
+        run: |
+          sudo apt-get update -qqy
+          sudo apt-get install jq protobuf-compiler cmake
       - name: 'Install Rust/WASM test dependencies'
         run: |
           rustup target install wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.8",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -55,6 +55,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -76,10 +85,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "ascii"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
+
+[[package]]
 name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-channel"
@@ -141,11 +166,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
- "autocfg",
+ "autocfg 1.1.0",
  "concurrent-queue",
  "futures-lite",
  "libc",
- "log",
+ "log 0.4.17",
  "parking",
  "polling",
  "slab",
@@ -171,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72faff1fdc615a0199d7bf71e6f389af54d46a66e9beb5d76c39e48eda93ecce"
 
 [[package]]
+name = "async-once-cell"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61305cacf1d0c5c9d3ee283d22f8f1f8c743a18ceb44a1b102bd53476c141de"
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +218,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
+ "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -198,7 +230,7 @@ dependencies = [
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log",
+ "log 0.4.17",
  "memchr",
  "once_cell",
  "pin-project-lite",
@@ -289,6 +321,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -308,12 +349,12 @@ dependencies = [
  "headers",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.22",
  "itoa",
  "matchit",
  "memchr",
- "mime",
- "percent-encoding",
+ "mime 0.3.16",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -337,7 +378,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "mime",
+ "mime 0.3.16",
  "tower-layer",
  "tower-service",
 ]
@@ -352,7 +393,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http",
- "mime",
+ "mime 0.3.16",
  "pin-project-lite",
  "tokio",
  "tower",
@@ -381,9 +422,19 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
@@ -396,6 +447,19 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "serde",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2"
@@ -489,6 +553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +585,16 @@ name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
+name = "cached"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
+dependencies = [
+ "hashbrown 0.11.2",
+ "once_cell",
+]
 
 [[package]]
 name = "cbor4ii"
@@ -559,6 +643,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "chunked_transfer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
+
+[[package]]
 name = "cid"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,10 +671,10 @@ checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
 dependencies = [
  "core2",
  "multibase",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "serde_bytes",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
 ]
 
 [[package]]
@@ -619,6 +724,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +759,22 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "common-multipart-rfc7578"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baee326bc603965b0f26583e1ecd7c111c41b49bd92a344897476a352798869"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime 0.3.16",
+ "mime_guess 2.0.4",
+ "rand 0.8.5",
+ "thiserror",
 ]
 
 [[package]]
@@ -720,7 +869,7 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
@@ -817,6 +966,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1067,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,7 +1138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "hashbrown",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "serde",
@@ -966,7 +1179,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "log",
+ "log 0.4.17",
  "regex",
 ]
 
@@ -1019,7 +1232,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
@@ -1037,6 +1250,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1183,7 +1402,7 @@ checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
- "multihash",
+ "multihash 0.16.3",
 ]
 
 [[package]]
@@ -1196,7 +1415,7 @@ dependencies = [
  "cid",
  "cs_serde_bytes",
  "fvm_ipld_blockstore",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
@@ -1220,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1286,7 +1505,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log",
+ "log 0.4.17",
  "regex",
 ]
 
@@ -1303,6 +1522,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "groupable"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,9 +1542,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
@@ -1336,13 +1567,13 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "bytes",
  "headers-core",
  "http",
  "httpdate",
- "mime",
+ "mime 0.3.16",
  "sha1 0.10.5",
 ]
 
@@ -1453,6 +1684,25 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+dependencies = [
+ "base64 0.9.3",
+ "httparse",
+ "language-tags",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "num_cpus",
+ "time",
+ "traitobject",
+ "typeable",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
+
+[[package]]
+name = "hyper"
 version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
@@ -1476,16 +1726,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-multipart-rfc7578"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb2cf73e96e9925f4bed948e763aa2901c2f1a3a5f713ee41917433ced6671"
+dependencies = [
+ "bytes",
+ "common-multipart-rfc7578",
+ "futures-core",
+ "http",
+ "hyper 0.14.22",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
- "hyper",
+ "hyper 0.14.22",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1531,7 +1829,7 @@ dependencies = [
  "futures",
  "if-addrs",
  "ipnet",
- "log",
+ "log 0.4.17",
  "rtnetlink",
  "system-configuration",
  "windows",
@@ -1543,8 +1841,8 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "autocfg 1.1.0",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1558,6 +1856,16 @@ dependencies = [
  "stdweb",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+dependencies = [
+ "async-trait",
+ "tokio",
 ]
 
 [[package]]
@@ -1595,10 +1903,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipfs-api-prelude"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaf47fa129710ae041d5844a15b1365bdad8551673aee237449ba9dec6bcadc"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "common-multipart-rfc7578",
+ "dirs",
+ "futures",
+ "http",
+ "multibase",
+ "parity-multiaddr",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.6.10",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "iroh-car"
+version = "0.1.0"
+source = "git+https://github.com/n0-computer/iroh?rev=d4c9c6f6a9ce6ebf63abcd1a03fabeb12600d7fb#d4c9c6f6a9ce6ebf63abcd1a03fabeb12600d7fb"
+dependencies = [
+ "cid",
+ "futures",
+ "integer-encoding",
+ "libipld",
+ "libipld-cbor",
+ "multihash 0.16.3",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "iron"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d308ca2d884650a8bf9ed2ff4cb13fbb2207b71f64cda11dc9b892067295e8"
+dependencies = [
+ "hyper 0.10.16",
+ "log 0.3.9",
+ "mime_guess 1.8.8",
+ "modifier",
+ "num_cpus",
+ "plugin",
+ "typemap",
+ "url 1.7.2",
+]
 
 [[package]]
 name = "itertools"
@@ -1636,8 +2000,14 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log",
+ "log 0.4.17",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -1655,6 +2025,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
+name = "libipld"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9c3aa309c260aa2f174bac968901eddc546e9d85950c28eae6a7bec402f926"
+dependencies = [
+ "async-trait",
+ "cached",
+ "fnv",
+ "libipld-cbor",
+ "libipld-cbor-derive",
+ "libipld-core",
+ "libipld-json",
+ "libipld-macro",
+ "libipld-pb",
+ "log 0.4.17",
+ "multihash 0.16.3",
+ "parking_lot 0.12.1",
+ "thiserror",
+]
+
+[[package]]
 name = "libipld-cbor"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +2054,19 @@ dependencies = [
  "byteorder",
  "libipld-core",
  "thiserror",
+]
+
+[[package]]
+name = "libipld-cbor-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ec2f49393a1347a2d95ebcb248ff75d0d47235919b678036c010a8cd927375"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1675,7 +2079,7 @@ dependencies = [
  "cid",
  "core2",
  "multibase",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "thiserror",
 ]
@@ -1687,9 +2091,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18aa481a87f084d98473dd9ece253a9569c762b75f6bbba8217d54e48c9d63b3"
 dependencies = [
  "libipld-core",
- "multihash",
+ "multihash 0.16.3",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "libipld-macro"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852c011562ae5059b67c3a917f9f5945af5a68df8e39ede4444fff33274d25e2"
+dependencies = [
+ "libipld-core",
+]
+
+[[package]]
+name = "libipld-pb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c003be513496578115256a1b4ac7b80d4ece2462c9869dfb736fd30d8bb1d1c0"
+dependencies = [
+ "libipld-core",
+ "prost 0.10.4",
+ "prost-build 0.10.4",
+ "thiserror",
 ]
 
 [[package]]
@@ -1743,20 +2168,20 @@ dependencies = [
  "futures-timer",
  "instant",
  "lazy_static",
- "log",
+ "log 0.4.17",
  "multiaddr",
- "multihash",
+ "multihash 0.16.3",
  "multistream-select",
  "parking_lot 0.12.1",
  "pin-project",
- "prost",
- "prost-build",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "rand 0.8.5",
  "rw-stream-sink",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
  "void",
  "zeroize",
 ]
@@ -1769,7 +2194,7 @@ checksum = "2322c9fb40d99101def6a01612ee30500c89abbbecb6297b3cd252903a4c1720"
 dependencies = [
  "futures",
  "libp2p-core",
- "log",
+ "log 0.4.17",
  "parking_lot 0.12.1",
  "smallvec",
  "trust-dns-resolver",
@@ -1786,10 +2211,10 @@ dependencies = [
  "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.17",
  "lru",
- "prost",
- "prost-build",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "prost-codec",
  "smallvec",
  "thiserror",
@@ -1812,15 +2237,15 @@ dependencies = [
  "instant",
  "libp2p-core",
  "libp2p-swarm",
- "log",
- "prost",
- "prost-build",
+ "log 0.4.17",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "rand 0.8.5",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
  "uint",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
  "void",
 ]
 
@@ -1836,7 +2261,7 @@ dependencies = [
  "if-watch",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.17",
  "rand 0.8.5",
  "smallvec",
  "socket2",
@@ -1867,12 +2292,12 @@ dependencies = [
  "bytes",
  "futures",
  "libp2p-core",
- "log",
+ "log 0.4.17",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
 ]
 
 [[package]]
@@ -1886,9 +2311,9 @@ dependencies = [
  "futures",
  "lazy_static",
  "libp2p-core",
- "log",
- "prost",
- "prost-build",
+ "log 0.4.17",
+ "prost 0.11.0",
+ "prost-build 0.11.1",
  "rand 0.8.5",
  "sha2 0.10.6",
  "snow",
@@ -1909,7 +2334,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
- "log",
+ "log 0.4.17",
  "pin-project",
  "rand 0.8.5",
  "smallvec",
@@ -1939,7 +2364,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "log",
+ "log 0.4.17",
  "socket2",
  "tokio",
 ]
@@ -1952,10 +2377,19 @@ checksum = "30f079097a21ad017fc8139460630286f02488c8c13b26affb46623aa20d8845"
 dependencies = [
  "futures",
  "libp2p-core",
- "log",
+ "log 0.4.17",
  "parking_lot 0.12.1",
  "thiserror",
  "yamux",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1970,8 +2404,17 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -1990,7 +2433,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2047,7 +2490,16 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
 ]
 
 [[package]]
@@ -2058,12 +2510,24 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
+version = "1.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
+dependencies = [
+ "mime 0.2.6",
+ "phf",
+ "phf_codegen",
+ "unicase 1.4.2",
+]
+
+[[package]]
+name = "mime_guess"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
- "mime",
- "unicase",
+ "mime 0.3.16",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -2088,10 +2552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.17",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
+
+[[package]]
+name = "modifier"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 
 [[package]]
 name = "multiaddr"
@@ -2103,12 +2573,12 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
- "percent-encoding",
+ "multihash 0.16.3",
+ "percent-encoding 2.2.0",
  "serde",
  "static_assertions",
- "unsigned-varint",
- "url",
+ "unsigned-varint 0.7.1",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -2124,6 +2594,17 @@ dependencies = [
 
 [[package]]
 name = "multihash"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
+dependencies = [
+ "generic-array",
+ "multihash-derive 0.7.2",
+ "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
@@ -2133,12 +2614,26 @@ dependencies = [
  "blake3",
  "core2",
  "digest 0.10.5",
- "multihash-derive",
+ "multihash-derive 0.8.0",
  "serde",
  "serde-big-array",
  "sha2 0.10.6",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2162,6 +2657,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "hyper 0.10.16",
+ "iron",
+ "log 0.4.17",
+ "mime 0.3.16",
+ "mime_guess 2.0.4",
+ "nickel",
+ "quick-error",
+ "rand 0.8.5",
+ "safemem",
+ "tempfile",
+ "tiny_http",
+ "twoway",
+]
+
+[[package]]
 name = "multistream-select"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,10 +2686,20 @@ checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
 dependencies = [
  "bytes",
  "futures",
- "log",
+ "log 0.4.17",
  "pin-project",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
+name = "mustache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51956ef1c5d20a1384524d91e616fb44dfc7d8f249bf696d49c97dd3289ecab5"
+dependencies = [
+ "log 0.3.9",
+ "serde",
 ]
 
 [[package]]
@@ -2221,7 +2748,7 @@ checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
  "bytes",
  "futures",
- "log",
+ "log 0.4.17",
  "netlink-packet-core",
  "netlink-sys",
  "thiserror",
@@ -2238,7 +2765,7 @@ dependencies = [
  "bytes",
  "futures",
  "libc",
- "log",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -2246,6 +2773,27 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nickel"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5061a832728db2dacb61cefe0ce303b58f85764ec680e71d9138229640a46d9"
+dependencies = [
+ "groupable",
+ "hyper 0.10.16",
+ "lazy_static",
+ "log 0.3.9",
+ "modifier",
+ "mustache",
+ "plugin",
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "typemap",
+ "url 1.7.2",
+]
 
 [[package]]
 name = "nix"
@@ -2288,7 +2836,7 @@ dependencies = [
  "tracing-wasm",
  "ucan",
  "ucan-key-support",
- "url",
+ "url 2.3.1",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
@@ -2312,7 +2860,7 @@ dependencies = [
  "tracing",
  "ucan",
  "ucan-key-support",
- "url",
+ "url 2.3.1",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -2322,15 +2870,21 @@ name = "noosphere-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-compat",
  "async-trait",
  "axum",
  "cid",
  "clap",
  "globset",
  "home",
+ "hyper 0.14.22",
+ "hyper-multipart-rfc7578",
+ "ipfs-api-prelude",
+ "iroh-car",
  "libipld-cbor",
  "libipld-core",
- "mime_guess",
+ "mime_guess 2.0.4",
+ "multipart",
  "noosphere",
  "noosphere-api",
  "noosphere-core",
@@ -2338,6 +2892,7 @@ dependencies = [
  "noosphere-storage",
  "path-absolutize",
  "pathdiff",
+ "reqwest",
  "serde",
  "serde_json",
  "subtext",
@@ -2351,10 +2906,11 @@ dependencies = [
  "tracing-subscriber",
  "ucan",
  "ucan-key-support",
- "url",
+ "url 2.3.1",
  "wasm-bindgen",
  "whoami",
  "witty-phrase-generator",
+ "wnfs",
 ]
 
 [[package]]
@@ -2362,7 +2918,7 @@ name = "noosphere-collections"
 version = "0.1.1-alpha.1"
 dependencies = [
  "anyhow",
- "async-once-cell",
+ "async-once-cell 0.3.1",
  "async-recursion",
  "async-std",
  "async-stream",
@@ -2371,7 +2927,7 @@ dependencies = [
  "forest_hash_utils",
  "libipld-cbor",
  "libipld-core",
- "multihash",
+ "multihash 0.16.3",
  "noosphere-storage",
  "serde",
  "serde_bytes",
@@ -2379,7 +2935,7 @@ dependencies = [
  "sha2 0.10.6",
  "tokio",
  "tokio-stream",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
  "wasm-bindgen-test",
 ]
 
@@ -2388,11 +2944,11 @@ name = "noosphere-core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-once-cell",
+ "async-once-cell 0.3.1",
  "async-recursion",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "byteorder",
  "cid",
  "crdts",
@@ -2403,7 +2959,7 @@ dependencies = [
  "getrandom 0.2.8",
  "libipld-cbor",
  "libipld-core",
- "log",
+ "log 0.4.17",
  "noosphere-collections",
  "noosphere-storage",
  "once_cell",
@@ -2416,7 +2972,7 @@ dependencies = [
  "tokio-stream",
  "ucan",
  "ucan-key-support",
- "url",
+ "url 2.3.1",
  "wasm-bindgen-test",
 ]
 
@@ -2436,7 +2992,7 @@ dependencies = [
  "once_cell",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.4",
  "ucan",
  "ucan-key-support",
  "wasm-bindgen-test",
@@ -2464,7 +3020,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2510,7 +3066,7 @@ dependencies = [
  "async-std",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "cid",
  "js-sys",
  "libipld-cbor",
@@ -2567,7 +3123,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
  "serde",
@@ -2606,7 +3162,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -2616,7 +3172,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -2627,7 +3183,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2640,7 +3196,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "libm",
 ]
 
@@ -2677,6 +3233,24 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.13.2",
+ "percent-encoding 2.2.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.1",
+ "url 2.3.1",
+]
 
 [[package]]
 name = "parking"
@@ -2782,6 +3356,12 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
@@ -2794,6 +3374,45 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+dependencies = [
+ "phf_shared",
+ "rand 0.6.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+dependencies = [
+ "siphasher",
+ "unicase 1.4.2",
 ]
 
 [[package]]
@@ -2851,15 +3470,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugin"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
+dependencies = [
+ "typemap",
+]
+
+[[package]]
 name = "polling"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "libc",
- "log",
+ "log 0.4.17",
  "wepoll-ffi",
  "winapi",
 ]
@@ -2914,7 +3542,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -2925,7 +3553,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -2968,12 +3596,44 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.0",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "cmake",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log 0.4.17",
+ "multimap",
+ "petgraph",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "regex",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -2986,11 +3646,11 @@ dependencies = [
  "heck",
  "itertools",
  "lazy_static",
- "log",
+ "log 0.4.17",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.11.0",
+ "prost-types 0.11.1",
  "regex",
  "tempfile",
  "which",
@@ -3004,9 +3664,22 @@ checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "prost",
+ "prost 0.11.0",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3024,12 +3697,22 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes",
+ "prost 0.10.4",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.11.0",
 ]
 
 [[package]]
@@ -3045,7 +3728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
  "env_logger",
- "log",
+ "log 0.4.17",
  "rand 0.7.3",
  "rand_core 0.5.1",
 ]
@@ -3058,6 +3741,12 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3074,6 +3763,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65e163105a6284f841bd23100a015895f54340e88a5ffc9ca7b8b33827cfce0"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.3.1",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3082,7 +3789,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -3094,6 +3801,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3151,11 +3868,62 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3174,6 +3942,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.8",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -3228,7 +4007,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3236,14 +4015,14 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.22",
  "hyper-rustls",
  "ipnet",
  "js-sys",
- "log",
- "mime",
+ "log 0.4.17",
+ "mime 0.3.16",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "rustls",
  "rustls-pemfile",
@@ -3253,7 +4032,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "url",
+ "url 2.3.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3329,7 +4108,7 @@ checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
  "async-global-executor",
  "futures",
- "log",
+ "log 0.4.17",
  "netlink-packet-route",
  "netlink-proto",
  "nix",
@@ -3366,7 +4145,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
- "log",
+ "log 0.4.17",
  "ring",
  "sct",
  "webpki",
@@ -3378,7 +4157,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3403,6 +4182,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "safer-ffi"
@@ -3431,6 +4216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +4235,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
@@ -3466,6 +4266,9 @@ name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -3630,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
 dependencies = [
  "digest 0.10.5",
  "keccak",
@@ -3663,12 +4466,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "skip_ratchet"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ee41f8a86f13fe0618c3cc9c5d9f7a6173f3449de900595753973c97a25579"
+dependencies = [
+ "base64 0.13.0",
+ "hex",
+ "rand 0.6.3",
+ "serde",
+ "sha3",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3683,7 +4505,7 @@ dependencies = [
  "fs2",
  "fxhash",
  "libc",
- "log",
+ "log 0.4.17",
  "parking_lot 0.11.2",
 ]
 
@@ -3829,7 +4651,7 @@ dependencies = [
  "async-stream",
  "async-utf8-decoder",
  "futures",
- "log",
+ "log 0.4.17",
  "tendril",
  "tokio",
 ]
@@ -3889,6 +4711,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -3975,6 +4803,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4003,6 +4842,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e22cb179b63e5fc2d0b5be237dc107da072e2407809ac70a8ce85b93fe8f562"
+dependencies = [
+ "ascii",
+ "chrono",
+ "chunked_transfer",
+ "log 0.4.17",
+ "url 1.7.2",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,7 +4875,7 @@ version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "memchr",
@@ -4066,6 +4918,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.17",
  "pin-project-lite",
  "tokio",
 ]
@@ -4135,12 +5001,12 @@ dependencies = [
  "http-body",
  "http-range-header",
  "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
+ "mime 0.3.16",
+ "mime_guess 2.0.4",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.4",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4166,7 +5032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
- "log",
+ "log 0.4.17",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4200,7 +5066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
- "log",
+ "log 0.4.17",
  "tracing-core",
 ]
 
@@ -4234,6 +5100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
 name = "trust-dns-proto"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4255,7 +5127,7 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tracing",
- "url",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4285,6 +5157,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+
+[[package]]
+name = "typemap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+dependencies = [
+ "unsafe-any",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4300,21 +5196,21 @@ dependencies = [
  "async-recursion",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "bs58",
  "cid",
  "getrandom 0.2.8",
  "instant",
  "libipld-core",
  "libipld-json",
- "log",
+ "log 0.4.17",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
- "unsigned-varint",
- "url",
+ "unsigned-varint 0.7.1",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4328,7 +5224,7 @@ dependencies = [
  "bs58",
  "ed25519-zebra",
  "js-sys",
- "log",
+ "log 0.4.17",
  "npm_rs",
  "rsa",
  "sha2 0.10.6",
@@ -4352,11 +5248,20 @@ dependencies = [
 
 [[package]]
 name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -4403,6 +5308,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-any"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
+dependencies = [
+ "traitobject",
+]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,13 +5340,24 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
- "percent-encoding",
+ "percent-encoding 2.2.0",
  "serde",
 ]
 
@@ -4449,8 +5380,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
- "version_check",
+ "version_check 0.9.4",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -4471,12 +5408,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log",
+ "log 0.4.17",
  "try-lock",
 ]
 
@@ -4485,6 +5433,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4509,7 +5463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "log",
+ "log 0.4.17",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -4808,6 +5762,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnfs"
+version = "0.1.9"
+source = "git+https://github.com/wnfs-wg/rs-wnfs?rev=9d3b5c2d4357f57919668e3bc31aea497f41b6a4#9d3b5c2d4357f57919668e3bc31aea497f41b6a4"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "async-once-cell 0.4.2",
+ "async-recursion",
+ "async-std",
+ "async-stream",
+ "async-trait",
+ "bitvec",
+ "chrono",
+ "futures",
+ "futures-util",
+ "hashbrown 0.12.3",
+ "lazy_static",
+ "libipld",
+ "log 0.4.17",
+ "multihash 0.16.3",
+ "rand_core 0.6.4",
+ "semver 1.0.14",
+ "serde",
+ "sha3",
+ "skip_ratchet",
+ "thiserror",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4819,13 +5812,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
+
+[[package]]
 name = "yamux"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
  "futures",
- "log",
+ "log 0.4.17",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ members = [
 # See: https://github.com/rust-lang/rust/issues/90148#issuecomment-949194352
 resolver = "2"
 
+[profile.release]
+opt-level = 'z'
+lto = true
+

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -16,13 +16,20 @@ repository = "https://github.com/subconsciousnetwork/noosphere"
 homepage = "https://github.com/subconsciousnetwork/noosphere"
 readme = "README.md"
 
+[features]
+test_kubo = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+reqwest = { version = "~0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tempfile = "^3"
 clap = { version = "^4", features = ["derive", "cargo"] }
 anyhow = "^1"
 
+async-compat = { version = "~0.2" }
 tokio = { version = "^1", features = ["full"] }
 tokio-stream = "~0.1"
 axum = { version = "~0.5", features = ["headers", "macros"] }
@@ -31,6 +38,13 @@ tower-http = { version = "~0.3", features = ["cors", "trace"] }
 async-trait = "~0.1"
 tracing = "~0.1"
 tracing-subscriber = { version = "~0.3", features = ["env-filter"] }
+ipfs-api-prelude = "~0.5"
+hyper = "~0.14"
+hyper-multipart-rfc7578 = "~0.8"
+multipart = "~0.18"
+wnfs = { git = "https://github.com/wnfs-wg/rs-wnfs", package = "wnfs", rev = "9d3b5c2d4357f57919668e3bc31aea497f41b6a4" }
+iroh-car = { git = "https://github.com/n0-computer/iroh", package = "iroh-car", rev = "d4c9c6f6a9ce6ebf63abcd1a03fabeb12600d7fb" }
+
 
 url = { version = "^2", features = [ "serde" ] }
 whoami = "^1"

--- a/rust/noosphere-cli/src/bin/orb.rs
+++ b/rust/noosphere-cli/src/bin/orb.rs
@@ -3,6 +3,7 @@
 pub async fn main() -> anyhow::Result<()> {
     // Call out to an external module for platform-specific compilation purposes
     noosphere_cli::native::main().await?;
+
     Ok(())
 }
 

--- a/rust/noosphere-cli/src/native/commands/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/auth.rs
@@ -20,7 +20,7 @@ use tokio_stream::StreamExt;
 
 use crate::native::workspace::Workspace;
 
-pub async fn auth_add(did: &str, name: Option<String>, workspace: &Workspace) -> Result<()> {
+pub async fn auth_add(did: &str, name: Option<String>, workspace: &Workspace) -> Result<Cid> {
     let sphere_did = workspace.sphere_identity().await?;
     let mut db = workspace.db().await?;
 
@@ -130,7 +130,7 @@ Use this identity when joining the sphere on the other client"#,
         delegation.jwt
     );
 
-    Ok(())
+    Ok(delegation.jwt)
 }
 
 pub async fn auth_list(as_json: bool, workspace: &Workspace) -> Result<()> {

--- a/rust/noosphere-cli/src/native/commands/serve/ipfs/client.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/ipfs/client.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use cid::Cid;
+use tokio::io::AsyncRead;
+
+/// A generic interface for interacting with an IPFS-like backend where it may
+/// be desirable to syndicate sphere data to. Although the interface was
+/// designed after a small subset of the capabilities of IPFS Kubo, it is
+/// intended to be general enough to apply to other IPFS implementations.
+#[async_trait]
+pub trait IpfsClient {
+    /// Returns true if the block (referenced by [Cid]) is pinned by the IPFS
+    /// server
+    async fn block_is_pinned(&self, cid: &Cid) -> Result<bool>;
+
+    /// Returns a string that represents the identity (for example, a
+    /// base64-encoded public key) of a node. This node is used to track
+    /// syndication progress over time, so it should ideally be stable for a
+    /// given server as the client interacts with it over time
+    async fn server_identity(&self) -> Result<String>;
+
+    /// Given some CAR bytes, syndicate that CAR to the IPFS server. Callers
+    /// expect the roots in the CAR to be explicitly pinned, and for their
+    /// descendents to be pinned by association.
+    async fn syndicate_blocks<R>(&self, car: R) -> Result<()>
+    where
+        R: AsyncRead + Send + Sync + 'static;
+}

--- a/rust/noosphere-cli/src/native/commands/serve/ipfs/kubo.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/ipfs/kubo.rs
@@ -1,0 +1,152 @@
+use super::IpfsClient;
+use async_trait::async_trait;
+
+use anyhow::{anyhow, Result};
+use async_compat::CompatExt;
+use cid::Cid;
+use hyper::{
+    client::connect::dns::GaiResolver, client::HttpConnector, Body, Client, Request, StatusCode,
+};
+use hyper_multipart_rfc7578::client::multipart::{Body as MultipartBody, Form};
+use ipfs_api_prelude::response::{IdResponse, PinLsResponse};
+use tokio::io::AsyncRead;
+use url::Url;
+
+/// A high-level HTTP client for accessing IPFS
+/// [Kubo RPC APIs](https://docs.ipfs.tech/reference/kubo/rpc/) and normalizing
+/// their expected payloads to Noosphere-friendly formats
+#[derive(Clone)]
+pub struct KuboClient {
+    client: Client<HttpConnector<GaiResolver>>,
+    api_url: Url,
+}
+
+#[async_trait]
+impl IpfsClient for KuboClient {
+    async fn block_is_pinned(&self, cid: &Cid) -> Result<bool> {
+        let mut api_url = self.api_url.clone();
+        let cid_base64 = cid.to_string();
+
+        api_url.set_path("/api/v0/pin/ls");
+        api_url.set_query(Some(&format!("arg={}", cid_base64)));
+
+        let request = Request::builder()
+            .method("POST")
+            .uri(&api_url.to_string())
+            .body(Body::empty())?;
+        let response = self.client.request(request).await?;
+
+        let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
+        let pin_ls_response: PinLsResponse = serde_json::from_slice(body_bytes.as_ref())?;
+
+        Ok(pin_ls_response.keys.contains_key(&cid_base64))
+    }
+
+    async fn server_identity(&self) -> Result<String> {
+        let mut api_url = self.api_url.clone();
+
+        api_url.set_path("/api/v0/id");
+
+        let request = Request::builder()
+            .method("POST")
+            .uri(&api_url.to_string())
+            .body(Body::empty())?;
+        let response = self.client.request(request).await?;
+
+        let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
+        let id_response: IdResponse = serde_json::from_slice(body_bytes.as_ref())?;
+
+        Ok(id_response.public_key)
+    }
+
+    async fn syndicate_blocks<R>(&self, car: R) -> Result<()>
+    where
+        R: AsyncRead + Send + Sync + 'static,
+    {
+        let mut api_url = self.api_url.clone();
+        let mut form = Form::default();
+
+        form.add_async_reader("file", Box::pin(car).compat());
+
+        api_url.set_path("/api/v0/dag/import");
+
+        let request_builder = Request::builder().method("POST").uri(&api_url.to_string());
+        let request = form.set_body_convert::<Body, MultipartBody>(request_builder)?;
+
+        let response = self.client.request(request).await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(()),
+            other_status => Err(anyhow!("Unexpected status code: {}", other_status)),
+        }
+    }
+}
+
+impl KuboClient {
+    pub fn new(api_url: &Url) -> Result<Self> {
+        let client = hyper::Client::builder().build_http();
+        Ok(KuboClient {
+            client,
+            api_url: api_url.clone(),
+        })
+    }
+}
+
+// Note that these tests require that there is a locally available IPFS Kubo
+// node running with the RPC API enabled
+#[cfg(all(test, feature = "test_kubo"))]
+mod tests {
+    use std::io::Cursor;
+
+    use cid::Cid;
+    use iroh_car::{CarHeader, CarWriter};
+    use libipld_cbor::DagCborCodec;
+    use noosphere_storage::encoding::block_serialize;
+    use serde::{Deserialize, Serialize};
+    use url::Url;
+
+    use super::{IpfsClient, KuboClient};
+
+    #[tokio::test]
+    pub async fn it_can_interact_with_a_kubo_server() {
+        #[derive(Serialize, Deserialize)]
+        struct SomeData {
+            value: String,
+            next: Option<Cid>,
+        }
+
+        let bar = SomeData {
+            value: "bar".into(),
+            next: None,
+        };
+
+        let (bar_cid, bar_block) = block_serialize::<DagCborCodec, _>(bar).unwrap();
+
+        let foo = SomeData {
+            value: "foo".into(),
+            next: Some(bar_cid.clone()),
+        };
+
+        let (foo_cid, foo_block) = block_serialize::<DagCborCodec, _>(foo).unwrap();
+
+        let mut car = Vec::new();
+
+        let car_header = CarHeader::new_v1(vec![foo_cid.clone()]);
+        let mut car_writer = CarWriter::new(car_header, &mut car);
+
+        car_writer.write(foo_cid, foo_block).await.unwrap();
+        car_writer.write(bar_cid, bar_block).await.unwrap();
+
+        let kubo_client = KuboClient::new(&Url::parse("http://127.0.0.1:5001").unwrap()).unwrap();
+
+        kubo_client.server_identity().await.unwrap();
+
+        kubo_client
+            .syndicate_blocks(Cursor::new(car))
+            .await
+            .unwrap();
+
+        assert!(kubo_client.block_is_pinned(&foo_cid).await.unwrap());
+        assert!(kubo_client.block_is_pinned(&bar_cid).await.unwrap());
+    }
+}

--- a/rust/noosphere-cli/src/native/commands/serve/ipfs/mod.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/ipfs/mod.rs
@@ -1,0 +1,13 @@
+///! IPFS integration for various backend implementations. Currently only Kubo
+///! has out-of-the-box support, but integration is based on the generalized
+///! [IpfsClient] trait, which opens the possibility for integration with
+///! alternative backends in the future. Integration is currently only one-way,
+///! but eventually this module will be the entrypoint for pulling blocks out of
+///! IPFS backends as well.
+mod client;
+mod kubo;
+mod syndication;
+
+pub use client::*;
+pub use kubo::*;
+pub use syndication::*;

--- a/rust/noosphere-cli/src/native/commands/serve/ipfs/syndication.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/ipfs/syndication.rs
@@ -1,0 +1,238 @@
+use std::{io::Cursor, sync::Arc};
+
+use anyhow::Result;
+use cid::Cid;
+use libipld_cbor::DagCborCodec;
+use noosphere::sphere::SphereContext;
+use noosphere_core::{
+    data::{ContentType, Did},
+    view::{Sphere, Timeline},
+};
+use noosphere_storage::{
+    encoding::{block_deserialize, block_serialize},
+    interface::{BlockStore, KeyValueStore, Store},
+};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::AsyncReadExt,
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
+    task::JoinHandle,
+};
+use tokio_stream::StreamExt;
+use ucan::crypto::KeyMaterial;
+use url::Url;
+
+use iroh_car::{CarHeader, CarWriter};
+use wnfs::private::BloomFilter;
+
+use crate::native::commands::{config::COUNTERPART, serve::ipfs::IpfsClient};
+
+use super::KuboClient;
+
+/// A [SyndicationJob] is a request to syndicate the blocks of a _counterpart_
+/// sphere to the broader IPFS network.
+pub struct SyndicationJob<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Store,
+{
+    /// The revision of the _local_ sphere to discover the _counterpart_ sphere
+    /// from; the counterpart sphere's revision will need to be derived using
+    /// this checkpoint in local sphere history.
+    pub revision: Cid,
+    /// The [SphereContext] that corresponds to the _local_ sphere.
+    pub context: Arc<Mutex<SphereContext<K, S>>>,
+}
+
+/// A [SyndicationCheckpoint] represents the last spot in the history of a
+/// sphere that was successfully syndicated to an IPFS node. It records a Bloom
+/// filter populated by the CIDs of all blocks that have been syndicated, which
+/// gives us a short-cut to determine if a block should be added.
+#[derive(Serialize, Deserialize)]
+pub struct SyndicationCheckpoint {
+    pub revision: Cid,
+    pub syndicated_blocks: BloomFilter<256, 30>,
+}
+
+/// Start a Tokio task that waits for [SyndicationJob] messages and then
+/// attempts to syndicate to the configured IPFS RPC. Currently only Kubo IPFS
+/// backends are supported.
+pub fn start_ipfs_syndication<K, S>(
+    ipfs_api: Url,
+) -> (
+    UnboundedSender<SyndicationJob<K, S>>,
+    JoinHandle<Result<()>>,
+)
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Store + 'static,
+{
+    let (tx, rx) = unbounded_channel();
+
+    (tx, tokio::task::spawn(ipfs_syndication_task(ipfs_api, rx)))
+}
+
+async fn ipfs_syndication_task<K, S>(
+    ipfs_api: Url,
+    mut receiver: UnboundedReceiver<SyndicationJob<K, S>>,
+) -> Result<()>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Store,
+{
+    debug!("Syndicating sphere revisions to IPFS API at {}", ipfs_api);
+
+    let kubo_client = Arc::new(KuboClient::new(&ipfs_api)?);
+
+    while let Some(SyndicationJob { revision, context }) = receiver.recv().await {
+        let kubo_identity = match kubo_client.server_identity().await {
+            Ok(id) => id,
+            Err(error) => {
+                warn!(
+                    "Failed to identify an IPFS Kubo node at {}: {}",
+                    ipfs_api, error
+                );
+                continue;
+            }
+        };
+        let checkpoint_key = format!("syndication/kubo/{kubo_identity}");
+
+        // Take a lock on the `SphereContext` and look up the most recent
+        // syndication checkpoint for this Kubo node
+        let (sphere_revision, ancestor_revision, mut syndicated_blocks, db) = {
+            let context = context.lock().await;
+            let db = context.db().clone();
+            let counterpart_identity = context.db().require_key::<_, Did>(COUNTERPART).await?;
+
+            let sphere = Sphere::at(&revision, context.db());
+            let links = sphere.try_get_links().await?;
+
+            let counterpart_revision = links
+                .require(&counterpart_identity.to_string())
+                .await?
+                .clone();
+
+            let fs = context.fs().await?;
+
+            let (last_syndicated_revision, syndicated_blocks) =
+                match fs.read(&checkpoint_key).await? {
+                    Some(mut file) => match file.memo.content_type() {
+                        Some(ContentType::Cbor) => {
+                            let mut bytes = Vec::new();
+                            file.contents.read_to_end(&mut bytes).await?;
+                            let SyndicationCheckpoint {
+                                revision,
+                                syndicated_blocks,
+                            } = block_deserialize::<DagCborCodec, _>(&bytes)?;
+                            (Some(revision), syndicated_blocks)
+                        }
+                        _ => (None, BloomFilter::default()),
+                    },
+                    None => (None, BloomFilter::default()),
+                };
+
+            (
+                counterpart_revision,
+                last_syndicated_revision,
+                syndicated_blocks,
+                db,
+            )
+        };
+
+        let timeline = Timeline::new(&db)
+            .slice(&sphere_revision, ancestor_revision.as_ref())
+            .try_to_chronological()
+            .await?;
+
+        // For all CIDs since the last historical checkpoint, syndicate a CAR
+        // of blocks that are unique to that revision to the backing IPFS
+        // implementation
+        for (cid, _) in timeline {
+            // TODO(#175): At each increment, if there are sub-graphs of a
+            // sphere that should *not* be syndicated (e.g., other spheres
+            // referenced by this sphere that are probably syndicated
+            // elsewhere), we should add them to the bloom filter at this spot.
+
+            let stream = db.query_links(&cid, {
+                let filter = Arc::new(syndicated_blocks.clone());
+                let kubo_client = kubo_client.clone();
+
+                move |cid| {
+                    let filter = filter.clone();
+                    let kubo_client = kubo_client.clone();
+                    let cid = cid.clone();
+
+                    async move {
+                        // The Bloom filter probabilistically tells us if we
+                        // have syndicated a block; it is probabilistic because
+                        // `contains` may give us false positives. But, all
+                        // negatives are guaranteed to not have been added. So,
+                        // we can rely on it as a short cut to find unsyndicated
+                        // blocks, and for positives we can verify the pin
+                        // status with the IPFS node.
+                        if !filter.contains(&cid.to_bytes()) {
+                            return Ok(true);
+                        }
+
+                        // This will probably end up being rather noisy for the
+                        // IPFS node, but hopefully checking for a pin is not
+                        // overly costly. We may have to come up with a
+                        // different strategy if this turns out to be too noisy.
+                        Ok(!kubo_client.block_is_pinned(&cid).await?)
+                    }
+                }
+            });
+
+            // TODO(#2): It would be cool to make reading from storage and
+            // writing to an HTTP request body concurrent / streamed; this way
+            // we could send over CARs of arbitrary size (within the limits of
+            // whatever the IPFS receiving implementation can support).
+            let mut car = Vec::new();
+            let car_header = CarHeader::new_v1(vec![cid]);
+            let mut car_writer = CarWriter::new(car_header, &mut car);
+
+            tokio::pin!(stream);
+
+            while let Some(cid) = stream.try_next().await? {
+                // TODO(#176): We need to build-up a list of blocks that aren't
+                // able to be loaded so that we can be resilient to incomplete
+                // data when syndicating to IPFS
+                syndicated_blocks.add(&cid.to_bytes());
+
+                let block = db.require_block(&cid).await?;
+
+                car_writer.write(cid, block).await?;
+            }
+
+            kubo_client.syndicate_blocks(Cursor::new(car)).await?;
+
+            debug!("Syndicated sphere revision {} to IPFS", cid);
+        }
+
+        // At the end, take another lock on the `SphereContext` in order to
+        // update the syndication checkpoint for this particular IPFS server
+        {
+            let context = context.lock().await;
+            let mut fs = context.fs().await?;
+            let (_, bytes) = block_serialize::<DagCborCodec, _>(&SyndicationCheckpoint {
+                revision,
+                syndicated_blocks,
+            })?;
+
+            fs.write(
+                &kubo_identity.to_string(),
+                &ContentType::Cbor.to_string(),
+                Cursor::new(bytes),
+                None,
+            )
+            .await?;
+
+            fs.save(None).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/rust/noosphere-cli/src/native/commands/serve/mod.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/mod.rs
@@ -1,6 +1,7 @@
 pub mod authority;
 pub mod extractor;
 pub mod gateway;
+pub mod ipfs;
 pub mod route;
 pub mod tracing;
 
@@ -17,6 +18,7 @@ use self::gateway::GatewayScope;
 pub async fn serve(
     interface: IpAddr,
     port: u16,
+    ipfs_api: Url,
     cors_origin: Option<Url>,
     workspace: &Workspace,
 ) -> Result<()> {
@@ -33,5 +35,12 @@ pub async fn serve(
 
     let sphere_context = workspace.sphere_context().await?;
 
-    gateway::start_gateway(listener, gateway_scope, sphere_context, cors_origin).await
+    gateway::start_gateway(
+        listener,
+        gateway_scope,
+        sphere_context,
+        ipfs_api,
+        cors_origin,
+    )
+    .await
 }

--- a/rust/noosphere-cli/src/native/commands/serve/route/did.rs
+++ b/rust/noosphere-cli/src/native/commands/serve/route/did.rs
@@ -1,13 +1,9 @@
-use std::sync::Arc;
-
 use axum::{http::StatusCode, Extension};
+use noosphere_core::data::Did;
 use ucan::crypto::KeyMaterial;
 
 pub async fn did_route<K: KeyMaterial>(
-    Extension(gateway_key): Extension<Arc<K>>,
+    Extension(gateway_identity): Extension<Did>,
 ) -> Result<String, StatusCode> {
-    gateway_key.get_did().await.map_err(|error| {
-        error!("{:?}", error);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })
+    Ok(gateway_identity.into())
 }

--- a/rust/noosphere-cli/src/native/commands/sphere.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere.rs
@@ -105,6 +105,7 @@ Type or paste the code here and press enter:"#,
         .join_sphere(sphere_identity)
         .at_storage_path(workspace.root_directory())
         .reading_keys_from(workspace.key_storage().clone())
+        .using_key(local_key)
         .authorized_by(&Authorization::Cid(cid))
         .build()
         .await?;

--- a/rust/noosphere-cli/src/native/commands/status.rs
+++ b/rust/noosphere-cli/src/native/commands/status.rs
@@ -26,6 +26,11 @@ pub fn status_section(
 }
 
 pub async fn status(workspace: &Workspace) -> Result<()> {
+    let identity = workspace.sphere_identity().await?;
+
+    println!("This sphere's identity is {identity}");
+    println!("Here is a summary of the current changes to sphere content:\n");
+
     let mut memory_store = MemoryStore::default();
 
     let (_, mut changes) = match workspace

--- a/rust/noosphere-cli/src/native/commands/sync.rs
+++ b/rust/noosphere-cli/src/native/commands/sync.rs
@@ -19,10 +19,12 @@ pub async fn sync(workspace: &Workspace) -> Result<()> {
         _ => (),
     };
 
-    let context = workspace.sphere_context().await?;
-    let mut context = context.lock().await;
+    {
+        let context = workspace.sphere_context().await?;
+        let mut context = context.lock().await;
 
-    context.sync().await?;
+        context.sync().await?;
+    }
 
     println!("Sync complete, rendering updated workspace...");
 

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -437,6 +437,8 @@ impl Workspace {
                     None => None,
                 }
             }
+            ContentType::Cbor => Some("json".into()),
+            ContentType::Json => Some("cbor".into()),
         }
     }
 
@@ -493,12 +495,10 @@ impl Workspace {
 
         let key_storage = InsecureKeyStorage::new(&noosphere_directory)?;
         let sphere_directory = root_directory.join(SPHERE_DIRECTORY);
-        // let storage_directory = sphere_directory.join(STORAGE_DIRECTORY);
 
         Ok(Workspace {
             root_directory,
             sphere_directory,
-            // storage_directory,
             key_storage,
             sphere_context: OnceCell::new(),
         })

--- a/rust/noosphere-cli/tests/gateway.rs
+++ b/rust/noosphere-cli/tests/gateway.rs
@@ -1,13 +1,20 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use anyhow::anyhow;
+use noosphere::key::KeyStorage;
 use noosphere_storage::interface::BlockStore;
 use std::net::TcpListener;
+use tokio::io::AsyncReadExt;
 use tokio_stream::StreamExt;
+use url::Url;
 
-use noosphere_api::data::{FetchParameters, FetchResponse, PushBody, PushResponse};
+use noosphere_api::{
+    data::{FetchParameters, FetchResponse, PushBody, PushResponse},
+    route::Route,
+};
 use noosphere_core::{
-    data::MemoIpld,
+    authority::Authorization,
+    data::{ContentType, MemoIpld},
     view::{Sphere, SphereMutation},
 };
 
@@ -15,14 +22,93 @@ use libipld_cbor::DagCborCodec;
 use ucan::crypto::KeyMaterial;
 
 use noosphere_cli::native::{
-    commands::{key::key_create, serve::tracing::initialize_tracing, sphere::sphere_create},
+    commands::{
+        auth::auth_add,
+        key::key_create,
+        serve::{
+            gateway::{start_gateway, GatewayScope},
+            tracing::initialize_tracing,
+        },
+        sphere::{sphere_create, sphere_join},
+    },
     workspace::Workspace,
 };
 
-use noosphere_cli::native::commands::serve::gateway::{start_gateway, GatewayScope};
+#[tokio::test]
+async fn gateway_tells_you_its_identity() {
+    let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_workspace, _client_temporary_directories) = Workspace::temporary().unwrap();
+
+    let gateway_key_name = "GATEWAY_KEY";
+    let client_key_name = "CLIENT_KEY";
+
+    key_create(client_key_name, &client_workspace)
+        .await
+        .unwrap();
+    key_create(gateway_key_name, &gateway_workspace)
+        .await
+        .unwrap();
+
+    sphere_create(client_key_name, &client_workspace)
+        .await
+        .unwrap();
+    sphere_create(gateway_key_name, &gateway_workspace)
+        .await
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let gateway_address = listener.local_addr().unwrap();
+
+    let gateway_sphere_identity = gateway_workspace.sphere_identity().await.unwrap();
+    let client_sphere_identity = client_workspace.sphere_identity().await.unwrap();
+
+    let gateway_sphere_context = gateway_workspace.sphere_context().await.unwrap();
+
+    let server_task = tokio::spawn({
+        let gateway_sphere_identity = gateway_sphere_identity.clone();
+        async move {
+            start_gateway(
+                listener,
+                GatewayScope {
+                    identity: gateway_sphere_identity,
+                    counterpart: client_sphere_identity,
+                },
+                gateway_sphere_context,
+                Url::parse("http://127.0.0.1:5001").unwrap(),
+                None,
+            )
+            .await
+            .unwrap()
+        }
+    });
+
+    let gateway_identity = gateway_workspace
+        .key()
+        .await
+        .unwrap()
+        .get_did()
+        .await
+        .unwrap();
+
+    let client = reqwest::Client::new();
+
+    let mut url = Url::parse(&format!(
+        "http://{}:{}",
+        gateway_address.ip(),
+        gateway_address.port()
+    ))
+    .unwrap();
+    url.set_path(&Route::Did.to_string());
+
+    let did_response = client.get(url).send().await.unwrap().text().await.unwrap();
+
+    assert_eq!(gateway_identity, did_response);
+
+    server_task.abort();
+}
 
 #[tokio::test]
-async fn it_can_be_identified_by_the_client_of_its_owner() {
+async fn gateway_identity_can_be_verified_by_the_client_of_its_owner() {
     initialize_tracing();
 
     let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
@@ -63,6 +149,7 @@ async fn it_can_be_identified_by_the_client_of_its_owner() {
                     counterpart: client_sphere_identity,
                 },
                 gateway_sphere_context,
+                Url::parse("http://127.0.0.1:5001").unwrap(),
                 None,
             )
             .await
@@ -103,7 +190,7 @@ async fn it_can_be_identified_by_the_client_of_its_owner() {
 }
 
 #[tokio::test]
-async fn it_can_receive_a_newly_initialized_sphere_from_the_client() {
+async fn gateway_receives_a_newly_initialized_sphere_from_the_client() {
     // initialize_tracing();
 
     let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
@@ -145,6 +232,7 @@ async fn it_can_receive_a_newly_initialized_sphere_from_the_client() {
                     counterpart: client_sphere_identity,
                 },
                 gateway_sphere_context,
+                Url::parse("http://127.0.0.1:5001").unwrap(),
                 None,
             )
             .await
@@ -214,7 +302,7 @@ async fn it_can_receive_a_newly_initialized_sphere_from_the_client() {
 }
 
 #[tokio::test]
-async fn it_can_update_an_existing_sphere_with_changes_from_the_client() {
+async fn gateway_updates_an_existing_sphere_with_changes_from_the_client() {
     // initialize_tracing();
 
     let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
@@ -259,6 +347,7 @@ async fn it_can_update_an_existing_sphere_with_changes_from_the_client() {
                     counterpart: client_sphere_identity,
                 },
                 gateway_sphere_context,
+                Url::parse("http://127.0.0.1:5001").unwrap(),
                 None,
             )
             .await
@@ -379,7 +468,7 @@ async fn it_can_update_an_existing_sphere_with_changes_from_the_client() {
 }
 
 #[tokio::test]
-async fn it_can_serve_sphere_revisions_to_a_client() {
+async fn gateway_serves_sphere_revisions_to_a_client() {
     // initialize_tracing();
 
     let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
@@ -424,6 +513,7 @@ async fn it_can_serve_sphere_revisions_to_a_client() {
                     counterpart: client_sphere_identity,
                 },
                 gateway_sphere_context,
+                Url::parse("http://127.0.0.1:5001").unwrap(),
                 None,
             )
             .await
@@ -515,6 +605,143 @@ async fn it_can_serve_sphere_revisions_to_a_client() {
             _ => Err(anyhow!("Unexpected fetch result")),
         }
         .unwrap();
+
+        server_task.abort();
+        let _ = server_task.await;
+    });
+
+    client_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn gateway_can_sync_an_authorized_sphere_across_multiple_replicas() {
+    // initialize_tracing();
+
+    let (gateway_workspace, _gateway_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_workspace, _client_temporary_directories) = Workspace::temporary().unwrap();
+    let (client_replica_workspace, _client_replica_temporary_directories) =
+        Workspace::temporary().unwrap();
+
+    let gateway_key_name = "GATEWAY_KEY";
+    let client_key_name = "CLIENT_KEY";
+    let client_replica_key_name = "CLIENT_REPLICA_KEY";
+
+    key_create(client_key_name, &client_workspace)
+        .await
+        .unwrap();
+    key_create(gateway_key_name, &gateway_workspace)
+        .await
+        .unwrap();
+    key_create(client_replica_key_name, &client_replica_workspace)
+        .await
+        .unwrap();
+
+    sphere_create(client_key_name, &client_workspace)
+        .await
+        .unwrap();
+    sphere_create(gateway_key_name, &gateway_workspace)
+        .await
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let gateway_address = listener.local_addr().unwrap();
+
+    let gateway_sphere_identity = gateway_workspace.sphere_identity().await.unwrap();
+    let client_sphere_identity = client_workspace.sphere_identity().await.unwrap();
+
+    let gateway_sphere_context = gateway_workspace.sphere_context().await.unwrap();
+
+    let server_task = {
+        let gateway_sphere_context = gateway_sphere_context.clone();
+        let client_sphere_identity = client_sphere_identity.clone();
+        tokio::spawn(async move {
+            start_gateway(
+                listener,
+                GatewayScope {
+                    identity: gateway_sphere_identity,
+                    counterpart: client_sphere_identity,
+                },
+                gateway_sphere_context,
+                Url::parse("http://127.0.0.1:5001").unwrap(),
+                None,
+            )
+            .await
+            .unwrap()
+        })
+    };
+
+    let client_replica_key_storage = client_replica_workspace.key_storage();
+    let client_replica_key = client_replica_key_storage
+        .require_key(client_replica_key_name)
+        .await
+        .unwrap();
+
+    let client_replica_authorization = Authorization::Cid(
+        auth_add(
+            &client_replica_key.get_did().await.unwrap(),
+            None,
+            &client_workspace,
+        )
+        .await
+        .unwrap(),
+    );
+
+    sphere_join(
+        client_replica_key_name,
+        Some(client_replica_authorization.to_string()),
+        &client_sphere_identity,
+        &client_replica_workspace,
+    )
+    .await
+    .unwrap();
+
+    let client_sphere_context = client_workspace.sphere_context().await.unwrap();
+    let client_replica_sphere_context = client_replica_workspace.sphere_context().await.unwrap();
+
+    let client_task = tokio::spawn(async move {
+        let mut client_sphere_context = client_sphere_context.lock().await;
+        let gateway_url: Url =
+            format!("http://{}:{}", gateway_address.ip(), gateway_address.port())
+                .parse()
+                .unwrap();
+
+        client_sphere_context
+            .configure_gateway_url(Some(&gateway_url))
+            .await
+            .unwrap();
+
+        for value in ["one", "two", "three"] {
+            let mut fs = client_sphere_context.fs().await.unwrap();
+
+            fs.write(
+                value,
+                &ContentType::Subtext.to_string(),
+                value.as_ref(),
+                None,
+            )
+            .await
+            .unwrap();
+            fs.save(None).await.unwrap();
+        }
+
+        client_sphere_context.sync().await.unwrap();
+
+        let mut client_replica_sphere_context = client_replica_sphere_context.lock().await;
+        client_replica_sphere_context
+            .configure_gateway_url(Some(&gateway_url))
+            .await
+            .unwrap();
+
+        client_replica_sphere_context.sync().await.unwrap();
+
+        let fs = client_replica_sphere_context.fs().await.unwrap();
+
+        for value in ["one", "two", "three"] {
+            let mut file = fs.read(value).await.unwrap().unwrap();
+            let mut contents = String::new();
+            file.contents.read_to_string(&mut contents).await.unwrap();
+            assert_eq!(value, &contents);
+        }
 
         server_task.abort();
         let _ = server_task.await;

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -25,6 +25,7 @@ url = "^2"
 async-trait = "~0.1"
 async-recursion = "^1"
 async-std = "^1"
+
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage
 async-once-cell = "~0.3"
 anyhow = "^1"

--- a/rust/noosphere-core/src/authority/authorization.rs
+++ b/rust/noosphere-core/src/authority/authorization.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, str::FromStr};
+use std::{convert::TryFrom, fmt::Display, str::FromStr};
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
@@ -83,5 +83,12 @@ impl TryFrom<&Authorization> for Cid {
             }
             Authorization::Cid(cid) => *cid,
         })
+    }
+}
+
+impl Display for Authorization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cid = Cid::try_from(self).map_err(|_| std::fmt::Error)?;
+        cid.fmt(f)
     }
 }

--- a/rust/noosphere-core/src/data/bundle.rs
+++ b/rust/noosphere-core/src/data/bundle.rs
@@ -241,7 +241,10 @@ impl TryBundle for MemoIpld {
         match self.get_first_header(&Header::ContentType.to_string()) {
             Some(value) => {
                 match ContentType::from_str(&value)? {
-                    ContentType::Subtext | ContentType::Bytes => {
+                    ContentType::Subtext
+                    | ContentType::Bytes
+                    | ContentType::Json
+                    | ContentType::Cbor => {
                         bundle.extend::<BodyChunkIpld, _>(&self.body, store).await?;
                     }
                     ContentType::Sphere => {

--- a/rust/noosphere-core/src/data/headers/content_type.rs
+++ b/rust/noosphere-core/src/data/headers/content_type.rs
@@ -5,6 +5,8 @@ pub enum ContentType {
     Subtext,
     Sphere,
     Bytes,
+    Cbor,
+    Json,
     Unknown(String),
 }
 
@@ -14,6 +16,8 @@ impl Display for ContentType {
             ContentType::Subtext => "text/subtext",
             ContentType::Sphere => "noo/sphere",
             ContentType::Bytes => "raw/bytes",
+            ContentType::Cbor => "application/cbor",
+            ContentType::Json => "application/json",
             ContentType::Unknown(header) => header.as_str(),
         };
 
@@ -29,6 +33,8 @@ impl FromStr for ContentType {
             "text/subtext" => ContentType::Subtext,
             "noo/sphere" => ContentType::Sphere,
             "raw/bytes" => ContentType::Bytes,
+            "application/json" => ContentType::Json,
+            "application/cbor" => ContentType::Cbor,
             _ => ContentType::Unknown(String::from(s)),
         })
     }

--- a/rust/noosphere-core/src/data/versioned_map.rs
+++ b/rust/noosphere-core/src/data/versioned_map.rs
@@ -3,7 +3,7 @@ use cid::Cid;
 pub use crdts::{map, Orswot};
 use libipld_cbor::DagCborCodec;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{hash::Hash, marker::PhantomData};
+use std::{fmt::Display, hash::Hash, marker::PhantomData};
 
 use noosphere_collections::hamt::{Hamt, Hash as HamtHash, Sha256};
 use noosphere_storage::interface::BlockStore;
@@ -32,13 +32,19 @@ impl HamtHash for CidKey {
     }
 }
 
+impl Display for CidKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 pub trait VersionedMapKey:
-    Serialize + DeserializeOwned + HamtHash + Clone + Eq + Ord + VersionedMapSendSync
+    Serialize + DeserializeOwned + HamtHash + Clone + Eq + Ord + VersionedMapSendSync + Display
 {
 }
 
 impl<T> VersionedMapKey for T where
-    T: Serialize + DeserializeOwned + HamtHash + Clone + Eq + Ord + VersionedMapSendSync
+    T: Serialize + DeserializeOwned + HamtHash + Clone + Eq + Ord + VersionedMapSendSync + Display
 {
 }
 

--- a/rust/noosphere-storage/Cargo.toml
+++ b/rust/noosphere-storage/Cargo.toml
@@ -31,7 +31,7 @@ ucan = { version = "0.7.0-alpha.1" }
 libipld-core = "~0.14"
 libipld-cbor = "~0.14"
 serde = "^1"
-base64 = "~0.13"
+base64 = "=0.13.0"
 
 [dev-dependencies]
 witty-phrase-generator = "~0.2"

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -15,10 +15,6 @@ readme = "README.md"
 [lib]
 crate-type = ["rlib", "staticlib", "cdylib"]
 
-[profile.release]
-opt-level = 'z'
-lto = true
-
 [features]
 headers = ["safer-ffi/headers"]
 

--- a/rust/noosphere/src/sphere/context.rs
+++ b/rust/noosphere/src/sphere/context.rs
@@ -6,6 +6,7 @@ use noosphere_api::client::Client;
 use noosphere_core::{
     authority::{Author, SUPPORTED_KEYS},
     data::Did,
+    view::Sphere,
 };
 use noosphere_fs::SphereFs;
 use noosphere_storage::{
@@ -106,6 +107,17 @@ where
         SphereFs::latest(&self.sphere_identity, &self.author, &self.db)
             .await
             .map_err(|e| e.into())
+    }
+
+    /// Get a [Sphere] view over the current sphere's latest revision. This view
+    /// offers lower-level access than [SphereFs], but includes affordances to
+    /// help tranversing and manipulating IPLD structures that are more
+    /// convenient than working directly with raw data.
+    pub async fn sphere(&self) -> Result<Sphere<SphereDb<S>>, NoosphereError> {
+        Ok(Sphere::at(
+            &self.db.require_version(self.identity()).await?,
+            self.db(),
+        ))
     }
 
     /// Get a [Client] that will interact with a configured gateway (if a URL

--- a/rust/noosphere/src/sphere/sync.rs
+++ b/rust/noosphere/src/sphere/sync.rs
@@ -9,6 +9,15 @@ use ucan::crypto::KeyMaterial;
 
 use super::SphereContext;
 
+/// The default synchronization strategy is a git-like fetch->rebase->push flow.
+/// It depends on the corresponding history of a "counterpart" sphere that is
+/// owned by a gateway server. As revisions are pushed to the gateway server, it
+/// updates its own sphere to point to the tip of the latest lineage of the
+/// user's. When a new change needs to be synchronized, the latest history of
+/// the counterpart sphere is first fetched, and the local changes are rebased
+/// on the counterpart sphere's reckoning of the authoritative lineage of the
+/// user's sphere. Finally, after the rebase, the reconciled local lineage is
+/// pushed to the gateway.
 pub struct GatewaySyncStrategy<K, S>
 where
     K: KeyMaterial + Clone + 'static,
@@ -50,18 +59,19 @@ where
             .await?;
 
         let result: Result<(), anyhow::Error> = {
-            self.fetch_remote_changes(
-                context,
-                local_sphere_version.as_ref(),
-                &counterpart_sphere_identity,
-                counterpart_sphere_version.as_ref(),
-            )
-            .await?;
+            let (local_sphere_version, counterpart_sphere_version) = self
+                .fetch_remote_changes(
+                    context,
+                    local_sphere_version.as_ref(),
+                    &counterpart_sphere_identity,
+                    counterpart_sphere_version.as_ref(),
+                )
+                .await?;
             self.push_local_changes(
                 context,
                 local_sphere_version.as_ref(),
                 &counterpart_sphere_identity,
-                counterpart_sphere_version.as_ref(),
+                &counterpart_sphere_version,
             )
             .await?;
             Ok(())
@@ -90,7 +100,7 @@ where
         local_sphere_tip: Option<&Cid>,
         counterpart_sphere_identity: &Did,
         counterpart_sphere_base: Option<&Cid>,
-    ) -> Result<()> {
+    ) -> Result<(Option<Cid>, Cid)> {
         let local_sphere_identity = context.identity().clone();
         let client = context.client().await?;
         let fetch_response = client
@@ -103,7 +113,12 @@ where
             FetchResponse::NewChanges { tip, blocks } => (tip, blocks),
             FetchResponse::UpToDate => {
                 println!("Local history is already up to date...");
-                return Ok(());
+                return Ok((
+                    local_sphere_tip.cloned(),
+                    counterpart_sphere_base
+                        .ok_or_else(|| anyhow!("Counterpart sphere history is missing!"))?
+                        .clone(),
+                ));
             }
         };
 
@@ -132,7 +147,7 @@ where
             .await?
             .cloned();
 
-        match (
+        let local_sphere_tip = match (
             local_sphere_tip,
             local_sphere_old_base,
             local_sphere_new_base,
@@ -152,6 +167,8 @@ where
                     .db_mut()
                     .set_version(&local_sphere_identity, &new_tip)
                     .await?;
+
+                Some(new_tip)
             }
             (None, old_base, Some(new_base)) => {
                 println!("Hydrating received local sphere revisions...");
@@ -161,19 +178,22 @@ where
                     .db_mut()
                     .set_version(&local_sphere_identity, &new_base)
                     .await?;
+
+                None
             }
             _ => {
                 println!("Nothing to sync!");
-                return Ok(());
+                local_sphere_tip.cloned()
             }
         };
 
+        debug!("Setting counterpart sphere version to {counterpart_sphere_tip}");
         context
             .db_mut()
             .set_version(counterpart_sphere_identity, &counterpart_sphere_tip)
             .await?;
 
-        Ok(())
+        Ok((local_sphere_tip, counterpart_sphere_tip))
     }
 
     /// Attempts to push the latest local lineage to the gateway, causing the
@@ -183,25 +203,19 @@ where
         context: &mut SphereContext<K, S>,
         local_sphere_tip: Option<&Cid>,
         counterpart_sphere_identity: &Did,
-        counterpart_sphere_tip: Option<&Cid>,
+        counterpart_sphere_tip: &Cid,
     ) -> Result<()> {
         // The base of the changes that must be pushed is the tip of our lineage as
         // recorded by the most recent history of the gateway's sphere. Everything
         // past that point in history represents new changes that the gateway does
         // not yet know about.
-        let local_sphere_tip = local_sphere_tip.ok_or_else(|| {
-            anyhow!(
-                "The history of local sphere {} is missing!",
-                context.identity()
-            )
-        })?;
-
-        let counterpart_sphere_tip = counterpart_sphere_tip.ok_or_else(|| {
-            anyhow!(
-                "No local history for counterpart sphere {}; did you forget to fetch?",
-                counterpart_sphere_identity
-            )
-        })?;
+        let local_sphere_tip = match local_sphere_tip {
+            Some(cid) => cid,
+            None => {
+                println!("No local history for local sphere {}!", context.identity());
+                return Ok(());
+            }
+        };
 
         let local_sphere_base = Sphere::at(counterpart_sphere_tip, context.db())
             .try_get_links()
@@ -257,10 +271,7 @@ where
 
         context
             .db_mut()
-            .set_version(
-                counterpart_sphere_identity,
-                &counterpart_sphere_updated_tip,
-            )
+            .set_version(counterpart_sphere_identity, &counterpart_sphere_updated_tip)
             .await?;
 
         Ok(())


### PR DESCRIPTION
This change is our first step towards syndication of sphere content to IPFS. It implements a task that runs as a background thread in the gateway. The task waits for requests to syndicate a sphere version, and then syndicates all versions of the sphere that have not been syndicated _up to_ the given version. When a version is successfully syndicated, a checkpoint is updated -- any future jobs can start syndication from the last successful checkpoint.

This change implements syndication on every gateway push, but actually syndication should only occur on publish. We don't have a publish route yet, so I've marked this as work to be done when we implement publish in #156. I also filed #175 and #176 as future work that builds on this change.

As part of this change, I've introduced some interesting new dependencies to the `noosphere-cli` crate: one on https://github.com/wnfs-wg/rs-wnfs (for their Bloom filter implementation) and one on https://github.com/n0-computer/iroh (for their `iroh-car` package). Both of these dependencies are provisional; we may wish to explore alternatives for the library code we are using from them. But, we will attempt to use Rust WNFS as a storage backend for #13, so taking the dependency now helps us to test the waters for coherence across our libraries. In the case of Iroh, their CAR package comes close to what I wanted us to build for #2 , so I would like to explore that more in a future change. Note that the bulk of the lines changed here are from the new additions to `Cargo.lock` resulting from taking Git repository dependencies. The Bloom filter from rs-wnfs hasn't made it to a release yet, and after speaking with Iroh folks, it sounds like their packages will finally be published to crates.io next week. So in both cases, we should be able to remove the git dependency shortly.

In addition to the changes mentioned above, I've added an integration test for an end-to-end sync flow between two client spheres and a gateway. I realized that after #162 the CLI sync flow had broken without our tests failing. The new integration test should cover most of the broken cases. I also snuck in a fix for #172 - you can now get the local sphere's identity with `orb status`.

Fixes #172 
Fixes #163 