### PR TITLE
Make transclude font size same as body font size

### DIFF
--- a/typescript/packages/sphere-viewer/src/styles/subtext.ts
+++ b/typescript/packages/sphere-viewer/src/styles/subtext.ts
@@ -27,8 +27,6 @@ export const subtextStyles = css`
   }
 
   .subtext .transclude {
-    font-size: var(--text-caption-size);
-    line-height: var(--text-caption-line);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     display: block;


### PR DESCRIPTION
Removes CSS that made transclude text smaller than body text. This looks better, in practice.