### PR TITLE
feat: Publish `orb` to NPM

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -30,7 +30,7 @@ in order to build these packages. The most reliable way to ensure you have this 
 nvm install --lts
 ```
 
-As an extra step, you can make the versions of Node.js and NPM you just installed:
+As an extra step, you may wish to make the versions of Node.js and NPM you just installed into the default ones available when you open your shell:
 
 ```sh
 nvm alias default lts/hydrogen

--- a/typescript/packages/orb/package.json
+++ b/typescript/packages/orb/package.json
@@ -2,10 +2,16 @@
   "name": "@subconsciousnetwork/orb",
   "author": "Subconscious Inc.",
   "license": "Apache-2.0 OR MIT",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "description": "A batteries-included JavaScript package for accessing the Noosphere",
   "type": "module",
   "main": "lib/index.js",
+  "module": "lib/index.js",
+  "files": [
+    "/lib/index.{d.ts,js,js.map}",
+    "/lib/noosphere.{d.ts,js}",
+    "/lib/noosphere_bg.{wasm.d.ts,wasm}"
+  ],
   "scripts": {
     "build": "wireit",
     "generate_wasm": "wireit",

--- a/typescript/packages/sphere-viewer/package.json
+++ b/typescript/packages/sphere-viewer/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0 OR MIT",
   "version": "0.1.0",
   "description": "A demo of Orb.js that renders Noosphere content from any IPFS gateway",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "wireit",


### PR DESCRIPTION
As of this change, `@subconsciousnetwork/orb` has been published to NPM. This was mainly done to test that publishing works as expected, and that the published package can be used with or without a bundler.

Here is a test page on Glitch that loads up the published package via unpkg.com and initializes a `NoosphereContext` (view source and/or console for proof): https://subconscious-sandbox.glitch.me/orb-test.html