### PR TITLE
feat: Sphere sync and change diff in C FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,6 +3117,7 @@ dependencies = [
  "async-once-cell 0.3.1",
  "async-recursion",
  "async-std",
+ "async-stream",
  "async-trait",
  "base64 0.13.0",
  "byteorder",
@@ -4397,6 +4398,7 @@ dependencies = [
  "proc-macro-hack",
  "require_unsafe_in_body",
  "safer_ffi-proc_macro",
+ "uninit",
 ]
 
 [[package]]
@@ -5516,6 +5518,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "uninit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac20c07bcac4f505f1e4fbd2e55b54f6297a35a27538f107cb3d4254b4514146"
 
 [[package]]
 name = "universal-hash"

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -25,6 +25,7 @@ url = "^2"
 async-trait = "~0.1"
 async-recursion = "^1"
 async-std = "^1"
+async-stream = "~0.3"
 
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage
 async-once-cell = "~0.3"

--- a/rust/noosphere-core/src/view/versioned_map.rs
+++ b/rust/noosphere-core/src/view/versioned_map.rs
@@ -48,15 +48,17 @@ where
 {
     pub async fn try_get_changelog(&self) -> Result<&ChangelogIpld<MapOperation<K, V>>> {
         self.changelog
-            .get_or_try_init(async {
-                let ipld = self
-                    .store
-                    .load::<DagCborCodec, VersionedMapIpld<K, V>>(&self.cid)
-                    .await?;
-                self.store
-                    .load::<DagCborCodec, ChangelogIpld<MapOperation<K, V>>>(&ipld.changelog)
-                    .await
-            })
+            .get_or_try_init(async { self.try_load_changelog().await })
+            .await
+    }
+
+    pub async fn try_load_changelog(&self) -> Result<ChangelogIpld<MapOperation<K, V>>> {
+        let ipld = self
+            .store
+            .load::<DagCborCodec, VersionedMapIpld<K, V>>(&self.cid)
+            .await?;
+        self.store
+            .load::<DagCborCodec, ChangelogIpld<MapOperation<K, V>>>(&ipld.changelog)
             .await
     }
 

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -61,7 +61,7 @@ features = [
 ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-safer-ffi = { version = "~0.0.10", features = ["proc_macros"] }
+safer-ffi = { version = "~0.0.10", features = ["proc_macros", "out-refs"] }
 tokio = { version = "^1", features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/rust/noosphere/src/ffi/error.rs
+++ b/rust/noosphere/src/ffi/error.rs
@@ -1,0 +1,68 @@
+use safer_ffi::prelude::*;
+
+use crate::error::NoosphereError;
+
+impl From<NoosphereError> for repr_c::Box<NsError> {
+    fn from(error: NoosphereError) -> Self {
+        repr_c::Box::new(NsError { inner: error })
+    }
+}
+
+/// A trait to help with late initialization of otherwise uninitialized
+/// out error values.
+pub trait TryOrInitialize<E>: Sized
+where
+    E: From<Self::InnerError>,
+{
+    type InnerError;
+
+    /// Invoke the given closure, returning Some(T) on an Ok result or else
+    /// None. In an Err condition, the late initialization method will be
+    /// invoked with the lazily created value to initialize with.
+    fn try_or_initialize<T>(
+        self,
+        closure: impl FnOnce() -> Result<T, Self::InnerError>,
+    ) -> Option<T> {
+        match closure() {
+            Ok(value) => Some(value),
+            Err(error) => {
+                self.late_initialize(E::from(error));
+                None
+            }
+        }
+    }
+
+    fn late_initialize(self, error: E);
+}
+
+impl TryOrInitialize<repr_c::Box<NsError>> for Option<Out<'_, repr_c::Box<NsError>>> {
+    type InnerError = NoosphereError;
+
+    fn late_initialize(self, error: repr_c::Box<NsError>) {
+        if let Some(out_error) = self {
+            out_error.write(error);
+        }
+    }
+}
+
+#[derive_ReprC]
+#[ReprC::opaque]
+pub struct NsError {
+    inner: NoosphereError,
+}
+
+#[ffi_export]
+/// De-allocate an [NsError]
+pub fn ns_error_free(error: repr_c::Box<NsError>) {
+    drop(error)
+}
+
+#[ffi_export]
+/// Returns a string message that describes the error in greater detail.
+pub fn ns_error_string(error: &NsError) -> char_p::Box {
+    error
+        .inner
+        .to_string()
+        .try_into()
+        .unwrap_or_else(|_| char_p::new("Unknown"))
+}

--- a/rust/noosphere/src/ffi/headers.rs
+++ b/rust/noosphere/src/ffi/headers.rs
@@ -1,10 +1,9 @@
 use safer_ffi::prelude::*;
 
-ReprC! {
-    #[ReprC::opaque]
-    pub struct NsHeaders {
-        inner: Vec<(String, String)>
-    }
+#[derive_ReprC]
+#[ReprC::opaque]
+pub struct NsHeaders {
+    inner: Vec<(String, String)>,
 }
 
 impl NsHeaders {

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,3 +1,4 @@
+mod error;
 mod fs;
 mod headers;
 mod key;
@@ -5,6 +6,7 @@ mod noosphere;
 mod sphere;
 
 pub use crate::ffi::noosphere::*;
+pub use error::*;
 pub use fs::*;
 pub use headers::*;
 pub use key::*;

--- a/rust/noosphere/src/ffi/noosphere.rs
+++ b/rust/noosphere/src/ffi/noosphere.rs
@@ -10,12 +10,11 @@ use crate::{
     NoosphereNetwork, NoosphereSecurity, NoosphereStorage,
 };
 
-ReprC! {
-    #[ReprC::opaque]
-    pub struct NsNoosphereContext {
-        inner: NoosphereContext,
-        async_runtime: Arc<TokioRuntime>
-    }
+#[derive_ReprC]
+#[ReprC::opaque]
+pub struct NsNoosphereContext {
+    inner: NoosphereContext,
+    async_runtime: Arc<TokioRuntime>,
 }
 
 impl NsNoosphereContext {
@@ -60,14 +59,19 @@ impl NsNoosphereContext {
 /// invoke almost all other API functions.
 ///
 /// In order to initialize the [NoosphereContext], you must provide two
-/// namespace strings: one for "global" Noosphere configuration, and another
-/// for sphere storage. Note that at this time "global" configuration is only
-/// used for insecure, on-disk key storage and we will probably deprecate such
+/// namespace strings: one for "global" Noosphere configuration, and another for
+/// sphere storage. Note that at this time "global" configuration is only used
+/// for insecure, on-disk key storage and we will probably deprecate such
 /// configuration at a future date.
 ///
 /// You can also initialize the [NoosphereContext] with an optional third
-/// argument: a URL string that refers to a Noosphere Gateway API somewhere
-/// on the network that one or more local spheres may have access to.
+/// argument: a URL string that refers to a Noosphere Gateway API somewhere on
+/// the network that one or more local spheres may have access to.
+///
+/// For this and all other ns_* functions that return a pointer, the pointer
+/// should be considered to refer to owned data unless specified otherwise in
+/// documentation. This means that you _must_ manually free all data given to
+/// you by the FFI (using the appropriate ns-prefixed "free" function).
 pub fn ns_initialize(
     global_storage_path: char_p::Ref<'_>,
     sphere_storage_path: char_p::Ref<'_>,

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -21,15 +21,17 @@ final class NoosphereTests: XCTestCase {
         print("Sphere identity:", sphere_identity)
         print("Recovery code:", sphere_mnemonic)
 
-        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr)
+        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr, nil)
 
         let file_bytes = "Hello, Subconscious".data(using: .utf8)!
 
-        file_bytes.withUnsafeBytes({ (ptr: UnsafePointer<UInt8>) in
-            let contents = slice_ref_uint8(ptr: ptr, len: file_bytes.count)
-            ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", contents, nil)
-
-            print("File write done")
+        file_bytes.withUnsafeBytes({ rawBufferPointer in
+            let bufferPointer = rawBufferPointer.bindMemory(to: UInt8.self)
+            let pointer = bufferPointer.baseAddress!
+            let bodyRaw = slice_ref_uint8(
+                ptr: pointer, len: file_bytes.count
+            )
+            ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", bodyRaw, nil)
         })
 
         ns_sphere_fs_save(noosphere, sphere_fs, nil)
@@ -69,9 +71,7 @@ final class NoosphereTests: XCTestCase {
         let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt)
         let sphere_mnemonic_ptr = ns_sphere_receipt_mnemonic(sphere_receipt)
 
-        let sphere_identity = String.init(cString: sphere_identity_ptr!)
-
-        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr)
+        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr, nil)
 
         let file_bytes = "Hello, Subconscious".data(using: .utf8)!
         let file_headers_in = ns_headers_create()
@@ -80,11 +80,13 @@ final class NoosphereTests: XCTestCase {
         ns_headers_add(file_headers_in, "hello", "world")
         ns_headers_add(file_headers_in, "hello", "noosphere")
 
-        file_bytes.withUnsafeBytes({ (ptr: UnsafePointer<UInt8>) in
-            let contents = slice_ref_uint8(ptr: ptr, len: file_bytes.count)
-            ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", contents, file_headers_in)
-
-            print("File write done")
+        file_bytes.withUnsafeBytes({ rawBufferPointer in
+            let bufferPointer = rawBufferPointer.bindMemory(to: UInt8.self)
+            let pointer = bufferPointer.baseAddress!
+            let bodyRaw = slice_ref_uint8(
+                ptr: pointer, len: file_bytes.count
+            )
+            ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", bodyRaw, file_headers_in)
         })
 
         ns_sphere_fs_save(noosphere, sphere_fs, nil)
@@ -99,6 +101,12 @@ final class NoosphereTests: XCTestCase {
         // NOTE: "hello" is only given once even though there are two headers with that name
         assert(name_count == 3)
         
+        let expected_headers = [
+            ["foo", "bar"],
+            ["hello", "world"],
+            ["Content-Type", "text/subtext"]
+        ]
+        
         for i in 0..<name_count {
             let name = String.init(cString: pointer.pointee!)
             let first_value_ptr = ns_sphere_file_header_value_first(file, name)
@@ -107,6 +115,10 @@ final class NoosphereTests: XCTestCase {
             
             print("Header name:", name)
             print("First value:", first_value)
+            
+            let expected = expected_headers[i]
+            assert(name == expected[0])
+            assert(first_value == expected[1])
             
             pointer += 1;
         }
@@ -121,5 +133,275 @@ final class NoosphereTests: XCTestCase {
         ns_free(noosphere)
 
         print("fin!")
+    }
+    
+    func testHandlingAnErrorCondition() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil)
+
+        let bad_sphere_identity = "doesnotexist"
+        
+        let maybe_error = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        let sphere_fs = ns_sphere_fs_open(noosphere, bad_sphere_identity, maybe_error)
+        
+        assert(sphere_fs == nil)
+        assert(maybe_error.pointee != nil)
+        
+        let error_message_ptr = ns_error_string(maybe_error.pointee)
+        let error_message = String.init(cString: error_message_ptr!)
+        
+        print(error_message)
+        assert(!error_message.isEmpty)
+        
+        ns_string_free(error_message_ptr)
+        ns_error_free(maybe_error.pointee)
+        ns_free(noosphere)
+    }
+    
+    func testGetAllSlugsInASphere() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil)
+
+        ns_key_create(noosphere, "bob")
+
+        let sphere_receipt = ns_sphere_create(noosphere, "bob")
+
+        let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt)
+
+        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr, nil)
+
+        let changes_to_make = [
+            [
+                ["add", "foo", "bar"],
+                ["add", "hello", "world"]
+            ],
+            [
+                ["add", "bijaz", "tleilax"]
+            ],
+            [
+                ["remove", "foo"],
+                ["add", "hello", "noosphere"],
+                ["add", "fizz", "buzz"]
+            ]
+        ]
+
+        var sphere_versions: [String] = [];
+
+        for i in 0..<changes_to_make.count {
+            let revision = changes_to_make[i]
+            
+            for j in 0..<revision.count {
+                let operation = revision[j]
+                switch operation[0] {
+                  case "add":
+                    let file_bytes = operation[2].data(using: .utf8)!
+                    file_bytes.withUnsafeBytes({ rawBufferPointer in
+                        let bufferPointer = rawBufferPointer.bindMemory(to: UInt8.self)
+                        let pointer = bufferPointer.baseAddress!
+                        let bodyRaw = slice_ref_uint8(
+                            ptr: pointer, len: file_bytes.count
+                        )
+                        
+                        ns_sphere_fs_write(
+                            noosphere,
+                            sphere_fs,
+                            operation[1],
+                            "text/subtext",
+                            bodyRaw,
+                            nil
+                        )
+                    })
+                  case "remove":
+                    ns_sphere_fs_remove(noosphere, sphere_fs, operation[1], nil)
+                  default:
+                    assert(false)
+                }
+            }
+            
+            ns_sphere_fs_save(noosphere, sphere_fs, nil)
+        
+            let sphere_version_ptr = ns_sphere_version_get(noosphere, sphere_identity_ptr, nil)
+            sphere_versions.append(String.init(cString: sphere_version_ptr!))
+            ns_string_free(sphere_version_ptr)
+        }
+        
+        let slugs = ns_sphere_fs_list(noosphere, sphere_fs, nil)
+        let expected_slugs = [
+            "bijaz",
+            "fizz",
+            "hello"
+        ]
+        
+        let slug_count = slugs.len
+        
+        assert(slug_count == expected_slugs.count)
+        
+        var pointer = slugs.ptr!
+        
+        for i in 0..<slug_count {
+            let slug = String.init(cString: pointer.pointee!)
+            
+            print("Slug:", slug)
+            assert(expected_slugs[i] == slug)
+            
+            pointer += 1;
+        }
+        
+        ns_string_array_free(slugs)
+        ns_string_free(sphere_identity_ptr)
+        ns_sphere_receipt_free(sphere_receipt)
+        ns_sphere_fs_free(sphere_fs)
+        ns_free(noosphere)
+    }
+    
+    func testGettingChangedSlugsAcrossRevisions() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil)
+
+        ns_key_create(noosphere, "bob")
+
+        let sphere_receipt = ns_sphere_create(noosphere, "bob")
+
+        let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt)
+
+        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr, nil)
+
+        let changes_to_make = [
+            [
+                ["add", "foo", "bar"],
+                ["add", "hello", "world"]
+            ],
+            [
+                ["add", "bijaz", "tleilax"]
+            ],
+            [
+                ["remove", "foo"],
+                ["add", "hello", "noosphere"],
+                ["add", "fizz", "buzz"]
+            ]
+        ]
+
+        var sphere_versions: [String] = [];
+
+        for i in 0..<changes_to_make.count {
+            let revision = changes_to_make[i]
+            
+            for j in 0..<revision.count {
+                let operation = revision[j]
+                switch operation[0] {
+                  case "add":
+                    let file_bytes = operation[2].data(using: .utf8)!
+                    file_bytes.withUnsafeBytes({ rawBufferPointer in
+                        let bufferPointer = rawBufferPointer.bindMemory(to: UInt8.self)
+                        let pointer = bufferPointer.baseAddress!
+                        let bodyRaw = slice_ref_uint8(
+                            ptr: pointer, len: file_bytes.count
+                        )
+                        
+                        ns_sphere_fs_write(
+                            noosphere,
+                            sphere_fs,
+                            operation[1],
+                            "text/subtext",
+                            bodyRaw,
+                            nil
+                        )
+                    })
+                  case "remove":
+                    ns_sphere_fs_remove(noosphere, sphere_fs, operation[1], nil)
+                  default:
+                    assert(false)
+                }
+            }
+            
+            ns_sphere_fs_save(noosphere, sphere_fs, nil)
+            let sphere_version_ptr = ns_sphere_version_get(noosphere, sphere_identity_ptr, nil)
+            sphere_versions.append(String.init(cString: sphere_version_ptr!))
+            ns_string_free(sphere_version_ptr)
+        }
+        
+        let changes = ns_sphere_fs_changes(noosphere, sphere_fs, sphere_versions[0], nil)
+        let expected_changes = [
+            "bijaz",
+            "fizz",
+            "foo",
+            "hello"
+        ]
+        
+        let change_count = changes.len
+        
+        assert(change_count == expected_changes.count)
+        
+        var pointer = changes.ptr!
+        
+        for i in 0..<change_count {
+            let slug = String.init(cString: pointer.pointee!)
+            
+            print("Changed slug:", slug)
+            assert(expected_changes[i] == slug)
+            
+            pointer += 1;
+        }
+        
+        ns_string_array_free(changes)
+        ns_string_free(sphere_identity_ptr)
+        ns_sphere_receipt_free(sphere_receipt)
+        ns_sphere_fs_free(sphere_fs)
+        ns_free(noosphere)
+    }
+    
+    func testGettingVersionOfSphereFile() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil)
+
+        ns_key_create(noosphere, "bob")
+
+        let sphere_receipt = ns_sphere_create(noosphere, "bob")
+
+        let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt)
+        let sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity_ptr, nil)
+        
+        ns_string_free(sphere_identity_ptr)
+        ns_sphere_receipt_free(sphere_receipt)
+        
+        var file_bytes = "Hello, Subconscious".data(using: .utf8)!
+
+        file_bytes.withUnsafeBytes({ rawBufferPointer in
+            let bufferPointer = rawBufferPointer.bindMemory(to: UInt8.self)
+            let pointer = bufferPointer.baseAddress!
+            let bodyRaw = slice_ref_uint8(
+                ptr: pointer, len: file_bytes.count
+            )
+            ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", bodyRaw, nil)
+        })
+
+        ns_sphere_fs_save(noosphere, sphere_fs, nil)
+
+        var file = ns_sphere_fs_read(noosphere, sphere_fs, "/hello")
+        var version_ptr = ns_sphere_file_version_get(file, nil)
+        let version_one = String.init(cString: version_ptr!)
+        
+        ns_string_free(version_ptr)
+        ns_sphere_file_free(file)
+        
+        file_bytes = "Hello, Noosphere".data(using: .utf8)!
+
+        file_bytes.withUnsafeBytes({ rawBufferPointer in
+            let bufferPointer = rawBufferPointer.bindMemory(to: UInt8.self)
+            let pointer = bufferPointer.baseAddress!
+            let bodyRaw = slice_ref_uint8(
+                ptr: pointer, len: file_bytes.count
+            )
+            ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", bodyRaw, nil)
+        })
+
+        ns_sphere_fs_save(noosphere, sphere_fs, nil)
+
+        file = ns_sphere_fs_read(noosphere, sphere_fs, "/hello")
+        version_ptr = ns_sphere_file_version_get(file, nil)
+        let version_two = String.init(cString: version_ptr!)
+        
+        ns_sphere_file_free(file)
+        
+        assert(version_one != version_two)
+        
+        ns_sphere_fs_free(sphere_fs)
+        ns_free(noosphere)
     }
 }


### PR DESCRIPTION
This change implements a few additional pieces of C FFI:

 - Sync a sphere with a configured gateway
 - Remove (unlink) a slug from the content space
 - Get all changed slugs since some version of the sphere
 - Get all links in the current version of the sphere
 - Get the current CID version of a sphere
 - Get the CID version of a file

Additionally, this change introduces an experimental error handling style for C FFI. An optional uninitialized error pointer can be provided as an "out" parameter, which is conventionally the last parameter of any function that supports this style. On the Rust side of the FFI, we have a helper trait that enables us to lazily initialize the pointer under an error condition while preserving memory safety and enabling use of syntax niceties like `?`.

Fixes #204
Fixes #206