### PR TITLE
feat: Initial integration of orb-ns CLI into the Name System's operator API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,17 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,14 +940,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.18"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -966,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1629,6 +1618,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2544,18 @@ dependencies = [
  "plugin",
  "typemap",
  "url 1.7.2",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.0",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3136,6 +3174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,7 +3356,7 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3867,6 +3911,7 @@ dependencies = [
  "test-log",
  "tokio",
  "toml",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "ucan",
@@ -4035,7 +4080,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -4172,7 +4217,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5114,6 +5159,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7063,19 +7122,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7085,9 +7168,9 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7097,9 +7180,9 @@ checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7109,9 +7192,9 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7121,15 +7204,15 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7139,9 +7222,9 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/rust/noosphere-ns/Cargo.toml
+++ b/rust/noosphere-ns/Cargo.toml
@@ -37,13 +37,16 @@ ucan-key-support = { version = "0.1.0" }
 tokio = { version = "1.15", features = ["io-util", "io-std", "sync", "macros", "rt", "rt-multi-thread"] }
 noosphere-storage = { version = "0.4.1", path = "../noosphere-storage" }
 noosphere-core = { version = "0.6.1", path = "../noosphere-core" }
+# noosphere_ns::bin
 noosphere = { version = "0.6.1", path = "../noosphere", optional = true }
-clap = { version = "^4", features = ["derive"], optional = true }
+clap = { version = "^4.1", features = ["derive"], optional = true }
 home = { version = "~0.5", optional = true }
 toml = { version = "~0.5", optional = true }
 # noosphere_ns::server
 axum = { version = "~0.5", features = ["json", "headers", "macros"], optional = true }
 reqwest = { version = "~0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
+tracing-subscriber = { version = "~0.3", features = ["env-filter"], optional = true }
+tower-http = { version = "~0.3", features = ["trace"], optional = true }
 url = { version = "^2", features = [ "serde" ], optional = true }
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "d344406235c779922e6ffec85f0a94181f3efecc", default-features = false, features = [ "identify", "dns", "kad", "macros", "mplex", "noise", "serde", "tcp", "tokio", "yamux" ] }
 
@@ -52,13 +55,12 @@ libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "d344406235c7799
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 rand = { version = "0.8.5" }
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tracing-subscriber = { version = "~0.3", features = ["env-filter"] }
 libipld-cbor = "~0.15"
 tempdir = { version = "~0.3" }
 
 [features]
 default = ["orb-ns", "api-server"]
-api-server = ["axum", "reqwest", "url"]
+api-server = ["axum", "reqwest", "url", "tracing-subscriber", "tower-http"]
 orb-ns = ["clap", "noosphere", "home", "toml"]
 
 [[bin]]

--- a/rust/noosphere-ns/src/bin/orb-ns/cli.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/cli.rs
@@ -1,14 +1,18 @@
 #![cfg(not(target_arch = "wasm32"))]
 
+use crate::cli_address::{deserialize_multiaddr, deserialize_socket_addr, parse_cli_address};
 use clap::{Parser, Subcommand};
-use noosphere_ns::{DHTConfig, Multiaddr};
+use noosphere_core::data::Did;
+use noosphere_ns::{DHTConfig, Multiaddr, NSRecord};
 use serde::Deserialize;
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use url::Url;
 
 #[derive(Parser)]
-#[clap(name = "orb-ns")]
+#[command(author, version, about, long_about=None, name = "orb-ns")]
 pub struct CLI {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: CLICommand,
 }
 
@@ -18,34 +22,79 @@ pub enum CLICommand {
     Run {
         /// The path to the bootstrap configuration, a TOML file, containing
         /// entries for keyname/port pairs.
-        #[clap(short, long)]
+        #[arg(short, long)]
         config: Option<PathBuf>,
 
         /// If no configuration path provided, the name of the Noosphere keypair to use
         /// stored in `~/.noosphere/keys/`.
-        #[clap(short, long)]
+        #[arg(short, long)]
         key: Option<String>,
 
-        /// If no configuration path provided, the listening port of this DHT node.
-        #[clap(short, long)]
-        port: Option<u16>,
+        /// If no configuration path provided, the listening address of this DHT node.
+        #[arg(
+            short,
+            long,
+            value_parser = parse_cli_address::<Multiaddr>
+        )]
+        listening_address: Option<Multiaddr>,
 
         /// If no configuration path provided, the HTTP listening port of the
         /// API web server associated with this DHT node.
-        #[clap(long)]
-        api_port: Option<u16>,
+        #[arg(
+            long,
+            value_parser = parse_cli_address::<SocketAddr>
+        )]
+        api_address: Option<SocketAddr>,
 
         /// If no configuration path provided, a list of bootstrap peers to connect to
         /// instead of the default bootstrap peers.
-        #[clap(short, long)]
+        #[arg(short, long)]
         bootstrap: Option<Vec<Multiaddr>>,
     },
 
     /// Utility to create keys compatible with Noosphere.
     KeyGen {
         /// The name of the key to be stored in `~/.noosphere/keys/`.
-        #[clap(short, long)]
+        #[arg(short, long)]
         key: String,
+    },
+
+    Status {
+        #[arg(short, long, value_parser = parse_cli_address::<Url>)]
+        api_url: Url,
+    },
+
+    #[command(subcommand)]
+    Records(CLIRecords),
+
+    #[command(subcommand)]
+    Peers(CLIPeers),
+}
+
+#[derive(Subcommand)]
+pub enum CLIRecords {
+    Get {
+        identity: Did,
+        #[arg(short, long, value_parser = parse_cli_address::<Url>)]
+        api_url: Url,
+    },
+    Put {
+        record: NSRecord,
+        #[arg(short, long, value_parser = parse_cli_address::<Url>)]
+        api_url: Url,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CLIPeers {
+    Ls {
+        #[arg(short, long, value_parser = parse_cli_address::<Url>)]
+        api_url: Url,
+    },
+    Add {
+        peer: Multiaddr,
+        #[arg(short, long, value_parser = parse_cli_address::<Url>)]
+        api_url: Url,
     },
 }
 
@@ -58,8 +107,10 @@ pub struct CLIConfigFile {
 #[derive(Debug, Deserialize)]
 pub struct CLIConfigFileNode {
     pub key: String,
-    pub port: Option<u16>,
-    pub api_port: Option<u16>,
+    #[serde(default, deserialize_with = "deserialize_multiaddr")]
+    pub listening_address: Option<Multiaddr>,
+    #[serde(default, deserialize_with = "deserialize_socket_addr")]
+    pub api_address: Option<SocketAddr>,
     #[serde(default)]
     pub peers: Vec<Multiaddr>,
     #[serde(default)]

--- a/rust/noosphere-ns/src/bin/orb-ns/cli_address.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/cli_address.rs
@@ -1,0 +1,414 @@
+//! Conversions between the metatype [CLIAddress] and
+//! their destination types ([Url], [SocketAddr], [Multiaddr])
+//! for both `clap` (as CLI flags) and `serde` (when parsing a config
+//! file) to allow [SocketAddr], [IpAddr], TCP port, [Multiaddr], and
+//! [Url] representations where appropriate.
+use noosphere_ns::Multiaddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use url::Url;
+
+use libp2p::multiaddr::Protocol;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+/// Used in clap parsers, parses a string in [CLIAddress] form into
+/// a [Multiaddr] or [SocketAddr].
+pub fn parse_cli_address<T: TryFrom<CLIAddress>>(input: &str) -> Result<T, String> {
+    let addr: CLIAddress = input
+        .parse()
+        .map_err(|_| String::from("invalid conversion"))?;
+
+    addr.try_into()
+        .map_err(|_| String::from("invalid conversion"))
+}
+
+/// Parses a string in [CLIAddress] form into a [SocketAddr] for
+/// serde deserialization.
+pub fn deserialize_socket_addr<'de, D>(deserializer: D) -> Result<Option<SocketAddr>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Option::<CLIAddress>::deserialize(deserializer) {
+        Ok(address) => match address {
+            Some(addr) => match addr.try_into() {
+                Ok(socket) => Ok(Some(socket)),
+                Err(e) => Err(de::Error::custom(e.to_string())),
+            },
+            None => Ok(None),
+        },
+        Err(e) => Err(de::Error::custom(e.to_string())),
+    }
+}
+
+/// Parses a string in [CLIAddress] form into a [Multiaddr] for
+/// serde deserialization.
+pub fn deserialize_multiaddr<'de, D>(deserializer: D) -> Result<Option<Multiaddr>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Option::<CLIAddress>::deserialize(deserializer) {
+        Ok(address) => match address {
+            Some(addr) => match addr.try_into() {
+                Ok(maddr) => Ok(Some(maddr)),
+                Err(e) => Err(de::Error::custom(e.to_string())),
+            },
+            None => Ok(None),
+        },
+        Err(e) => Err(de::Error::custom(e.to_string())),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CLIAddress {
+    Port(u16),
+    Ip(IpAddr),
+    Socket(SocketAddr),
+    Url(Url),
+    Multiaddr(Multiaddr),
+}
+
+impl Serialize for CLIAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            CLIAddress::Port(port) => {
+                serializer.serialize_newtype_variant("CLIAddress", 0, "Port", &port)
+            }
+            CLIAddress::Ip(ip) => serializer.serialize_newtype_variant("CLIAddress", 1, "Ip", &ip),
+            CLIAddress::Socket(socket) => {
+                serializer.serialize_newtype_variant("CLIAddress", 2, "Socket", &socket)
+            }
+            CLIAddress::Url(ref url) => {
+                serializer.serialize_newtype_variant("CLIAddress", 3, "Url", url)
+            }
+            CLIAddress::Multiaddr(ref addr) => {
+                serializer.serialize_newtype_variant("CLIAddress", 4, "Multiaddr", addr)
+            }
+        }
+    }
+}
+
+/// While we don't directly store structs with [CLIAddress] directly, as we want
+/// to coerce to a "goal" type, like [Multiaddr] or [SocketAddr], the deserialization
+/// is still used via `deserialize_multiaddr` and `deserialize_socket_addr`,
+/// with some care to parse both integers (u16 ports) and strings.
+impl<'de> Deserialize<'de> for CLIAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CLIAddressVisitor;
+        impl<'de> de::Visitor<'de> for CLIAddressVisitor {
+            type Value = CLIAddress;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(
+                    formatter,
+                    "a string parseable as a u16 port, IpAddr, SocketAddr, Url, or Multiaddr."
+                )
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if let Ok(addr) = s.parse() {
+                    Ok(addr)
+                } else {
+                    Err(de::Error::custom("Could not parse as CLIAddress."))
+                }
+            }
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value >= i64::from(u16::MIN) && value <= i64::from(u16::MAX) {
+                    Ok(CLIAddress::Port(value as u16))
+                } else {
+                    Err(E::custom(format!("u16 out of range: {}", value)))
+                }
+            }
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value >= u64::from(u16::MIN) && value <= u64::from(u16::MAX) {
+                    Ok(CLIAddress::Port(value as u16))
+                } else {
+                    Err(E::custom(format!("u16 out of range: {}", value)))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(CLIAddressVisitor {})
+    }
+}
+
+impl FromStr for CLIAddress {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(port) = <u16>::from_str(s) {
+            return Ok(CLIAddress::Port(port));
+        }
+        if let Ok(ip) = <IpAddr>::from_str(s) {
+            return Ok(CLIAddress::Ip(ip));
+        }
+        if let Ok(socket) = <SocketAddr>::from_str(s) {
+            return Ok(CLIAddress::Socket(socket));
+        }
+        if let Ok(url) = <Url>::from_str(s) {
+            return Ok(CLIAddress::Url(url));
+        }
+        if let Ok(maddr) = <Multiaddr>::from_str(s) {
+            return Ok(CLIAddress::Multiaddr(maddr));
+        }
+        Err(anyhow::anyhow!("invalid conversion"))
+    }
+}
+
+impl TryFrom<CLIAddress> for SocketAddr {
+    type Error = anyhow::Error;
+
+    fn try_from(value: CLIAddress) -> anyhow::Result<Self> {
+        match value {
+            CLIAddress::Port(port) => Ok(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                port,
+            )),
+            CLIAddress::Ip(addr) => Ok(SocketAddr::new(addr, 0)),
+            CLIAddress::Socket(addr) => Ok(addr),
+            _ => Err(anyhow::anyhow!("invalid conversion")),
+        }
+    }
+}
+
+impl TryFrom<CLIAddress> for Url {
+    type Error = anyhow::Error;
+    fn try_from(value: CLIAddress) -> anyhow::Result<Self> {
+        match value {
+            addr @ CLIAddress::Port(..)
+            | addr @ CLIAddress::Ip(..)
+            | addr @ CLIAddress::Socket(..) => {
+                let socket = <CLIAddress as TryInto<SocketAddr>>::try_into(addr)?;
+                let url = if socket.port() == 0 {
+                    Url::parse(&format!("http://{}", socket.ip()))?
+                } else {
+                    Url::parse(&format!("http://{}:{}", socket.ip(), socket.port()))?
+                };
+                Ok(url)
+            }
+            CLIAddress::Url(url) => Ok(url),
+            _ => Err(anyhow::anyhow!("invalid conversion")),
+        }
+    }
+}
+
+impl TryFrom<CLIAddress> for Multiaddr {
+    type Error = anyhow::Error;
+    fn try_from(value: CLIAddress) -> anyhow::Result<Self> {
+        match value {
+            addr @ CLIAddress::Port(..)
+            | addr @ CLIAddress::Ip(..)
+            | addr @ CLIAddress::Socket(..) => {
+                let socket = <CLIAddress as TryInto<SocketAddr>>::try_into(addr)?;
+                let mut multiaddr = Multiaddr::empty();
+                Ok(match socket {
+                    SocketAddr::V4(addr) => {
+                        multiaddr.push(Protocol::Ip4(*addr.ip()));
+                        multiaddr.push(Protocol::Tcp(addr.port()));
+                        multiaddr
+                    }
+                    SocketAddr::V6(addr) => {
+                        multiaddr.push(Protocol::Ip6(*addr.ip()));
+                        multiaddr.push(Protocol::Tcp(addr.port()));
+                        multiaddr
+                    }
+                })
+            }
+            CLIAddress::Multiaddr(addr) => Ok(addr),
+            _ => Err(anyhow::anyhow!("invalid conversion")),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use anyhow::Result;
+    //use serde::Deserialize;
+
+    #[test]
+    fn cli_address_to_socket_addr() -> Result<()> {
+        for (base, expectation) in vec![
+            (CLIAddress::Port(1234), "127.0.0.1:1234"),
+            (CLIAddress::Ip("0.0.0.0".parse()?), "0.0.0.0:0"),
+            (
+                CLIAddress::Socket("10.0.0.1:5555".parse()?),
+                "10.0.0.1:5555",
+            ),
+        ] {
+            let socket: SocketAddr = base.try_into()?;
+            assert_eq!(&socket.to_string(), expectation);
+        }
+
+        for failure_addr in vec![
+            CLIAddress::Url("http://127.0.0.1:6666".parse()?),
+            CLIAddress::Multiaddr("/ip4/127.0.0.1/tcp/6666".parse()?),
+        ] {
+            let result: Result<SocketAddr> = failure_addr.try_into();
+            assert!(result.is_err());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cli_address_to_multiaddr() -> Result<()> {
+        for (base, expectation) in vec![
+            (CLIAddress::Port(1234), "/ip4/127.0.0.1/tcp/1234"),
+            (CLIAddress::Ip("0.0.0.0".parse()?), "/ip4/0.0.0.0/tcp/0"),
+            (CLIAddress::Ip("::1".parse()?), "/ip6/::1/tcp/0"),
+            (
+                CLIAddress::Socket("10.0.0.1:1234".parse()?),
+                "/ip4/10.0.0.1/tcp/1234",
+            ),
+            (
+                CLIAddress::Socket("[::1]:1234".parse()?),
+                "/ip6/::1/tcp/1234",
+            ),
+            (
+                CLIAddress::Multiaddr("/ip4/10.0.0.1/tcp/1234".parse()?),
+                "/ip4/10.0.0.1/tcp/1234",
+            ),
+        ] {
+            let maddr: Multiaddr = base.try_into()?;
+            assert_eq!(
+                &maddr.to_string(),
+                expectation,
+                "expect {} to parse as {}",
+                maddr,
+                expectation
+            );
+        }
+
+        for failure_addr in vec![CLIAddress::Url("http://127.0.0.1:6666".parse()?)] {
+            let result: Result<Multiaddr> = failure_addr.try_into();
+            assert!(result.is_err());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cli_address_to_url() -> Result<()> {
+        for (base, expectation) in vec![
+            (CLIAddress::Port(1234), "http://127.0.0.1:1234/"),
+            (CLIAddress::Ip("0.0.0.0".parse()?), "http://0.0.0.0/"),
+            (
+                CLIAddress::Socket("10.0.0.1:5555".parse()?),
+                "http://10.0.0.1:5555/",
+            ),
+            (
+                CLIAddress::Url("http://10.0.0.1:5555".parse()?),
+                "http://10.0.0.1:5555/",
+            ),
+        ] {
+            let url: Url = base.try_into()?;
+            assert_eq!(&url.to_string(), expectation);
+        }
+
+        for failure_addr in vec![CLIAddress::Multiaddr("/ip4/127.0.0.1/tcp/6666".parse()?)] {
+            let result: Result<Url> = failure_addr.try_into();
+            assert!(result.is_err());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_cli_address() -> Result<()> {
+        assert_eq!(
+            "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>()?,
+            parse_cli_address::<Multiaddr>("1234").unwrap(),
+        );
+        assert_eq!(
+            "127.0.0.1:1234".parse::<SocketAddr>()?,
+            parse_cli_address::<SocketAddr>("1234").unwrap(),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_cliaddress() -> Result<()> {
+        #[derive(PartialEq, Debug, Deserialize)]
+        pub struct TestDeserialize {
+            pub port_str: CLIAddress,
+            pub port_u16: CLIAddress,
+            pub ip: CLIAddress,
+            pub socket: CLIAddress,
+            pub url: CLIAddress,
+            pub multiaddr: CLIAddress,
+        }
+
+        assert_eq!(
+            serde_json::from_str::<TestDeserialize>(
+                r#"{
+            "port_str": "1234",
+            "port_u16": 25000, 
+            "ip": "10.0.0.1",
+            "socket": "10.0.0.1:1234",
+            "url": "http://10.0.0.1:1234",
+            "multiaddr": "/ip4/10.0.0.1/tcp/1234"
+        }"#
+            )?,
+            TestDeserialize {
+                port_str: CLIAddress::Port(1234),
+                port_u16: CLIAddress::Port(25000),
+                ip: CLIAddress::Ip("10.0.0.1".parse().unwrap()),
+                socket: CLIAddress::Socket("10.0.0.1:1234".parse().unwrap()),
+                url: CLIAddress::Url("http://10.0.0.1:1234".parse().unwrap()),
+                multiaddr: CLIAddress::Multiaddr("/ip4/10.0.0.1/tcp/1234".parse().unwrap()),
+            },
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_socket_addr() -> Result<()> {
+        #[derive(Deserialize)]
+        pub struct TestDeserialize {
+            #[serde(default, deserialize_with = "deserialize_socket_addr")]
+            pub addr: Option<SocketAddr>,
+        }
+        let obj: TestDeserialize = serde_json::from_str(
+            r#"{
+            "addr": "1234"
+        }"#,
+        )?;
+        assert_eq!(obj.addr.unwrap(), "127.0.0.1:1234".parse::<SocketAddr>()?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_multiaddr() -> Result<()> {
+        #[derive(Deserialize)]
+        pub struct TestDeserialize {
+            #[serde(default, deserialize_with = "deserialize_multiaddr")]
+            pub addr: Option<Multiaddr>,
+        }
+        let obj: TestDeserialize = serde_json::from_str(
+            r#"{
+            "addr": "1234"
+        }"#,
+        )?;
+        assert_eq!(
+            obj.addr.unwrap(),
+            "/ip4/127.0.0.1/tcp/1234".parse::<Multiaddr>()?
+        );
+        Ok(())
+    }
+}

--- a/rust/noosphere-ns/src/bin/orb-ns/main.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/main.rs
@@ -6,18 +6,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(not(target_arch = "wasm32"))]
 mod cli;
 #[cfg(not(target_arch = "wasm32"))]
+mod cli_address;
+#[cfg(not(target_arch = "wasm32"))]
 mod runner;
 #[cfg(not(target_arch = "wasm32"))]
 mod utils;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod inner {
-    pub use crate::cli::{CLICommand, CLI};
+    pub use crate::cli::{CLICommand, CLIPeers, CLIRecords, CLI};
     pub use crate::runner::{run, RunnerConfig};
     pub use anyhow::{anyhow, Result};
     pub use clap::Parser;
     pub use noosphere::key::{InsecureKeyStorage, KeyStorage};
+    pub use noosphere_ns::server::HTTPClient;
     pub use tokio;
+    pub use tracing::*;
+    pub use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -26,6 +31,12 @@ use inner::*;
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+    use noosphere_ns::NameSystemClient;
+
     let key_storage = InsecureKeyStorage::new(&utils::get_keys_dir()?)?;
 
     match CLI::parse().command {
@@ -36,11 +47,45 @@ async fn main() -> Result<()> {
         }
         CLICommand::KeyGen { key } => {
             if key_storage.require_key(&key).await.is_ok() {
-                println!("Key \"{}\" already exists in `~/.noosphere/keys/`.", &key);
+                info!("Key \"{}\" already exists in `~/.noosphere/keys/`.", &key);
             } else {
                 key_storage.create_key(&key).await?;
-                println!("Key \"{}\" created in `~/.noosphere/keys/`.", &key);
+                info!("Key \"{}\" created in `~/.noosphere/keys/`.", &key);
             }
+            Ok(())
+        }
+        CLICommand::Status { api_url } => {
+            let client = HTTPClient::new(api_url).await?;
+            let info = client.network_info().await?;
+            info!("{:#?}", info);
+            Ok(())
+        }
+        CLICommand::Records(CLIRecords::Get { identity, api_url }) => {
+            let client = HTTPClient::new(api_url).await?;
+            let maybe_record = client.get_record(&identity).await?;
+            if let Some(record) = maybe_record {
+                info!("{}", record.try_to_string()?);
+            } else {
+                info!("No record found.");
+            }
+            Ok(())
+        }
+        CLICommand::Records(CLIRecords::Put { record, api_url }) => {
+            let client = HTTPClient::new(api_url).await?;
+            client.put_record(record).await?;
+            info!("success");
+            Ok(())
+        }
+        CLICommand::Peers(CLIPeers::Ls { api_url }) => {
+            let client = HTTPClient::new(api_url).await?;
+            let peers = client.peers().await?;
+            info!("{:#?}", peers);
+            Ok(())
+        }
+        CLICommand::Peers(CLIPeers::Add { peer, api_url }) => {
+            let client = HTTPClient::new(api_url).await?;
+            client.add_peers(vec![peer]).await?;
+            info!("success");
             Ok(())
         }
     }

--- a/rust/noosphere-ns/src/client.rs
+++ b/rust/noosphere-ns/src/client.rs
@@ -71,7 +71,7 @@ macro_rules! ns_client_tests {
         #[tokio::test]
         async fn name_system_client_network_info() -> Result<()> {
             let (_data, client) = $before_each().await?;
-            crate::client::test::test_network_info::<$type>(client).await
+            $crate::client::test::test_network_info::<$type>(client).await
         }
 
         #[tokio::test]
@@ -134,7 +134,7 @@ pub mod test {
                 .key_material(&key_material)
                 .store(&store)
                 .listening_port(0)
-                .bootstrap_peers(&vec![listener_address.clone()])
+                .bootstrap_peers(&[listener_address.clone()])
                 .use_test_config()
                 .build()
                 .await
@@ -169,7 +169,6 @@ pub mod test {
             .parse()
             .unwrap();
         let record = NSRecord::from_issuer(&sphere_key, &sphere_id, &link, None).await?;
-
         client.put_record(record).await?;
 
         let retrieved = client

--- a/rust/noosphere-ns/src/dht/node.rs
+++ b/rust/noosphere-ns/src/dht/node.rs
@@ -75,7 +75,7 @@ impl DHTNode {
         let channels = message_channel::<DHTRequest, DHTResponse, DHTError>();
         let thread_handle = DHTProcessor::spawn(
             &keypair,
-            peer_id.clone(),
+            peer_id,
             validator,
             config.clone(),
             channels.1,

--- a/rust/noosphere-ns/src/dht/processor.rs
+++ b/rust/noosphere-ns/src/dht/processor.rs
@@ -263,7 +263,7 @@ where
 
                 if matches_pending {
                     let pending = self.pending_listener_request.take().unwrap();
-                    let mut address = new_address.clone();
+                    let mut address = new_address;
                     address.push(Protocol::P2p(self.peer_id.into()));
                     pending.respond(Ok(DHTResponse::Address(address)));
                 }
@@ -390,7 +390,7 @@ where
                 QueryResult::GetProviders(Ok(result)) => match result {
                     kad::GetProvidersOk::FoundProviders { providers, .. } => {
                         // Respond once we find any providers for now.
-                        if providers.len() > 0 {
+                        if !providers.is_empty() {
                             if let Some(message) = self.requests.remove(&id) {
                                 message.respond(Ok(DHTResponse::GetProviders {
                                     providers: providers.into_iter().collect(),
@@ -538,7 +538,7 @@ where
 
     /// Stops listening on the provided address.
     fn stop_listening(&mut self) -> Result<(), DHTError> {
-        dht_event_trace(self, &format!("Stop listening"));
+        dht_event_trace(self, &"Stop listening".to_string());
         if let Some(active_listener) = self.active_listener.take() {
             assert!(self.swarm.remove_listener(active_listener));
         }

--- a/rust/noosphere-ns/src/name_system.rs
+++ b/rust/noosphere-ns/src/name_system.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use tokio::sync::{Mutex, MutexGuard};
 
 pub static BOOTSTRAP_PEERS_ADDRESSES: [&str; 1] =
-    ["/ip4/134.122.20.28/tcp/6666/p2p/12D3KooWAKxaCWsSGauqhCZXyeYjDSQ6jna2SmVhLn4J7uQFdvot"];
+    ["/ip4/134.122.20.28/tcp/6666/p2p/12D3KooWPyjAB3XWUboGmLLPkR53fTyj4GaNi65RvQ61BVwqV4HG"];
 
 lazy_static! {
     /// Noosphere Name System's maintained list of peers to
@@ -198,8 +198,8 @@ impl NameSystemClient for NameSystem {
             .dht
             .addresses()
             .await
-            .map_err(|e| <DHTError as Into<anyhow::Error>>::into(e))?;
-        if addresses.len() >= 1 {
+            .map_err(<DHTError as Into<anyhow::Error>>::into)?;
+        if !addresses.is_empty() {
             let peer_id = self.peer_id().to_owned();
             let address = make_p2p_address(addresses.swap_remove(0), peer_id);
             Ok(Some(address))
@@ -298,7 +298,7 @@ mod test {
             let ns = NameSystemBuilder::default()
                 .key_material(&key_material)
                 .store(&store)
-                .bootstrap_peers(&vec![bootstrap_address.clone()])
+                .bootstrap_peers(&[bootstrap_address.clone()])
                 .use_test_config()
                 .build()
                 .await

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -104,7 +104,7 @@ impl NSRecord {
         link: &Cid,
         proofs: Option<&Vec<Ucan>>,
     ) -> Result<NSRecord, AnyhowError> {
-        let capability = generate_capability(&sphere_id);
+        let capability = generate_capability(sphere_id);
         let fact = generate_fact(&link.to_string());
 
         let mut builder = UcanBuilder::default()
@@ -419,7 +419,7 @@ mod test {
                 .for_audience(&sphere_identity)
                 .with_lifetime(1000)
                 .claiming_capability(&capability)
-                .with_fact(generate_fact(&cid_address))
+                .with_fact(generate_fact(cid_address))
                 .build()?
                 .sign()
                 .await?,
@@ -436,7 +436,7 @@ mod test {
                 .for_audience(&sphere_identity)
                 .with_lifetime(1000)
                 .claiming_capability(&sphere_capability)
-                .with_fact(generate_fact(&cid_address))
+                .with_fact(generate_fact(cid_address))
                 .build()?
                 .sign()
                 .await?,
@@ -452,7 +452,7 @@ mod test {
         let sphere_identity = Did::from(sphere_key.get_did().await?);
         let capability = generate_capability(&sphere_identity);
         let cid_address = "bafy2bzacec4p5h37mjk2n6qi6zukwyzkruebvwdzqpdxzutu4sgoiuhqwne72";
-        let fact = generate_fact(&cid_address);
+        let fact = generate_fact(cid_address);
 
         let ucan = UcanBuilder::default()
             .issued_by(&sphere_key)

--- a/rust/noosphere-ns/src/server/client.rs
+++ b/rust/noosphere-ns/src/server/client.rs
@@ -73,7 +73,7 @@ impl NameSystemClient for HTTPClient {
         Ok(self.client.post(url).send().await?.json().await?)
     }
 
-    /// Stops listening for connections on provided address.
+    /// Stops listening for connections.
     async fn stop_listening(&self) -> Result<()> {
         let mut url = self.api_base.clone();
         let path = Route::StopListening.to_string();

--- a/rust/noosphere-ns/src/server/server.rs
+++ b/rust/noosphere-ns/src/server/server.rs
@@ -6,6 +6,7 @@ use axum::{Extension, Router, Server};
 use std::net::TcpListener;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tower_http::trace::TraceLayer;
 
 pub struct APIServer {
     _handle: tokio::task::JoinHandle<Result<()>>,
@@ -36,7 +37,8 @@ async fn run(ns: Arc<Mutex<NameSystem>>, listener: TcpListener) -> Result<()> {
         .route(&Route::GetRecord.to_string(), get(handlers::get_record))
         .route(&Route::PostRecord.to_string(), post(handlers::post_record))
         .route(&Route::Bootstrap.to_string(), post(handlers::bootstrap))
-        .layer(Extension(ns));
+        .layer(Extension(ns))
+        .layer(TraceLayer::new_for_http());
 
     Server::from_tcp(listener)?
         .serve(app.into_make_service())


### PR DESCRIPTION

* Implements `orb-ns status`
* Implements `orb-ns records [(get $DID)|(put $RECORD)]`
* Implements `orb-ns peers [ls|(add $ADDR)]`
* Synchronizes orb-ns flags with the config file variant for bootstrap nodes
* Allow SocketAddr/Url/Multiaddr to be represented by SocketAddr/IpAddr/u16 Ports in orb-ns flags and configs.