### PR TITLE
chore: Minimum viable container builds

### DIFF
--- a/.github/workflows/container_images.yaml
+++ b/.github/workflows/container_images.yaml
@@ -4,22 +4,62 @@ on:
     inputs:
       image-tag:
         type: string
-      # default: ${{ github.sha }}
   workflow_dispatch:
     inputs:
       image-tag:
         type: string
-        # default: ${{ github.sha }}
 
 name: 'Container images'
 
 jobs:
+  determine-image-tags:
+    name: 'Determine image tags'
+    outputs:
+      tags: ${{ steps.determine-image-tags.outputs.tags }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: determine-image-tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.number }}
+          CUSTOM_TAG: ${{ inputs.image-tag }}
+        run: |
+          tags=()
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            tags+=("pr-$PR_NUMBER")
+          fi
+
+          if [[ "$IMAGE_TAG" != "" ]]; then
+            tags+=("$IMAGE_TAG")
+          fi
+
+          tags_out=""
+
+          for tag in "${tags[@]}"; do
+            if [ -z "$tags_out" ]; then
+              tags_out="\"$tag\""
+            else
+              tags_out="$tags_out,\"$tag\""
+            fi
+          done
+
+          echo "TAGS: $tags_out"
+
+          echo -n "tags=[$tags_out]" >> $GITHUB_OUTPUT
+
   build-and-push:
     name: 'Build and push'
     runs-on: ubuntu-latest
+    needs: ['determine-image-tags']
+    concurrency: 'docker-build'
     permissions:
       contents: 'read'
       id-token: 'write'
+    strategy:
+      matrix:
+        image: [{ name: 'orb', file: 'images/orb/Dockerfile' }]
+        tag: ${{ fromJSON(needs.determine-image-tags.outputs.tags) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
@@ -43,49 +83,12 @@ jobs:
           registry: 'us-central1-docker.pkg.dev'
           username: 'oauth2accesstoken'
           password: '${{ steps.authenticate.outputs.access_token }}'
-      - name: 'Determine image tags'
-        id: determine-image-tags
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.number }}
-          BRANCH: ${{ github.branch }}
-          IMAGE_TAG: ${{ inputs.image-tag }}
-        run: |
-          images=(
-            "us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/subconscious/orb"
-          )
-
-          tags=()
-
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            tags+=("pr-$PR_NUMBER")
-          fi
-
-          if [[ "$IMAGE_TAG" != "" ]]; then
-            tags+=("$IMAGE_TAG")
-          fi
-
-          tags_out=""
-
-          for image in "${images[@]}"; do
-            for tag in "${tags[@]}"; do
-              if [ -z "$tags_out" ]; then
-                tags_out="\"$image:$tag\""
-              else
-                tags_out="$tags_out,\"$image:$tag\""
-              fi
-            done
-          done
-
-          echo "TAGS: $tags_out"
-
-          echo -n "tags=$tags_out" >> $GITHUB_OUTPUT
       - name: Build and push container images
         uses: docker/build-push-action@v4
         with:
-          file: images/orb/Dockerfile
+          file: ${{ matrix.image.file }}
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          tags: ${{ steps.determine-image-tags.outputs.tags }}
+          tags: 'us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/subconscious/${{ matrix.image.name }}:${{matrix.tag}}'

--- a/.github/workflows/container_images.yaml
+++ b/.github/workflows/container_images.yaml
@@ -1,0 +1,91 @@
+on:
+  pull_request:
+  workflow_call:
+    inputs:
+      image-tag:
+        type: string
+      # default: ${{ github.sha }}
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        type: string
+        # default: ${{ github.sha }}
+
+name: 'Container images'
+
+jobs:
+  build-and-push:
+    name: 'Build and push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - id: 'authenticate'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/build-pipeline/providers/build-pipeline-provider'
+          service_account: 'build-pipeline@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
+      - name: 'Set up Google Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          version: '>= 413.0.0'
+      - name: 'Set up Google Cloud Docker auth helper'
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+      - name: 'Log Docker in to Google Artifact Registry'
+        uses: 'docker/login-action@v1'
+        with:
+          registry: 'us-central1-docker.pkg.dev'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.authenticate.outputs.access_token }}'
+      - name: 'Determine image tags'
+        id: determine-image-tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.number }}
+          BRANCH: ${{ github.branch }}
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          images=(
+            "us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/subconscious/orb"
+          )
+
+          tags=()
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            tags+=("pr-$PR_NUMBER")
+          fi
+
+          if [[ "$IMAGE_TAG" != "" ]]; then
+            tags+=("$IMAGE_TAG")
+          fi
+
+          tags_out=""
+
+          for image in "${images[@]}"; do
+            for tag in "${tags[@]}"; do
+              if [ -z "$tags_out" ]; then
+                tags_out="\"$image:$tag\""
+              else
+                tags_out="$tags_out,\"$image:$tag\""
+              fi
+            done
+          done
+
+          echo "TAGS: $tags_out"
+
+          echo -n "tags=$tags_out" >> $GITHUB_OUTPUT
+      - name: Build and push container images
+        uses: docker/build-push-action@v4
+        with:
+          file: images/orb/Dockerfile
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ${{ steps.determine-image-tags.outputs.tags }}

--- a/images/orb/Dockerfile
+++ b/images/orb/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:1.65 as builder
 
-RUN mkdir -p /workspace/rust
-WORKDIR /workspace
+WORKDIR /noosphere
 
 COPY "./Cargo.toml" "./Cargo.lock" .
 COPY ./rust ./rust
@@ -17,7 +16,7 @@ RUN mkdir -p /root/sphere
 VOLUME ["/root/.noosphere", "/root/sphere"]
 EXPOSE 4433
 
-COPY --from=builder /workspace/rust/target/release/orb /usr/bin/orb
+COPY --from=builder /noosphere/target/release/orb /usr/bin/orb
 COPY ./images/orb/start.sh /start.sh
 
 RUN chmod +x /start.sh

--- a/images/orb/Dockerfile
+++ b/images/orb/Dockerfile
@@ -1,0 +1,25 @@
+FROM rust:1.65 as builder
+
+RUN mkdir -p /workspace/rust
+WORKDIR /workspace
+
+COPY "./Cargo.toml" "./Cargo.lock" .
+COPY ./rust ./rust
+
+RUN apt-get update && apt-get install -y libssl-dev protobuf-compiler cmake jq binaryen
+RUN cargo build --release
+
+FROM ubuntu:latest
+
+RUN mkdir -p /root/.noosphere
+RUN mkdir -p /root/sphere
+
+VOLUME ["/root/.noosphere", "/root/sphere"]
+EXPOSE 4433
+
+COPY --from=builder /workspace/rust/target/release/orb /usr/bin/orb
+COPY ./images/orb/start.sh /start.sh
+
+RUN chmod +x /start.sh
+
+ENTRYPOINT ["/start.sh"]

--- a/images/orb/start.sh
+++ b/images/orb/start.sh
@@ -5,6 +5,8 @@ COUNTERPART=$2
 
 cd /root/sphere
 
+orb key create $KEY
+
 if ! [ -d "./.sphere" ]; then
   orb sphere create --owner-key $KEY
 fi

--- a/images/orb/start.sh
+++ b/images/orb/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+KEY=$1
+COUNTERPART=$2
+
+cd /root/sphere
+
+if ! [ -d "./.sphere" ]; then
+  orb sphere create --owner-key $KEY
+fi
+
+orb config set counterpart $COUNTERPART
+orb serve -i 0.0.0.0


### PR DESCRIPTION
This change is small but several weeks in the making. It implements a Github workflow for building and pushing containers to a private registry on GCP, from which we may deploy them as part of a managed service for the benefit of our users.

Containers are automatically built and pushed for each PR, and are available via the tag `pr-$PR_NUMBER`. The same workflow may be dispatched (manually or via a caller workflow) to build and push containers against arbitrary tag names. So, eventually we can integrate this with our release workflow.