### PR TITLE
chore: Make tests run on Apple hardware

### DIFF
--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -18,6 +18,27 @@ mod inner {
     pub type PlatformKeyMaterial = Ed25519KeyMaterial;
     pub type PlatformKeyStorage = InsecureKeyStorage;
     pub type PlatformStorage = NativeStorage;
+
+    #[cfg(test)]
+    use anyhow::Result;
+
+    #[cfg(test)]
+    use std::path::PathBuf;
+
+    #[cfg(test)]
+    use tempfile::TempDir;
+
+    #[cfg(test)]
+    pub async fn make_temporary_platform_primitives(
+    ) -> Result<(PathBuf, PlatformKeyStorage, (TempDir, TempDir))> {
+        let sphere_dir = TempDir::new().unwrap();
+
+        let key_dir = TempDir::new().unwrap();
+
+        let key_storage = InsecureKeyStorage::new(key_dir.path())?;
+
+        Ok((sphere_dir.path().into(), key_storage, (sphere_dir, key_dir)))
+    }
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
We were not exporting this load-bearing test helper in the Apple conditional compilation case (incidentally, highlighting that we don't run the Rust test suite on Apple hardware).

Fixes #226 