### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Follow along with the daily development process on the
   a JavaScript API for accessing Noosphere.
 - **[`./swift`](/swift)**: implementation of our Swift package, also wrapping the
   same core Rust impelementation (via a C-compatible FFI), suitable for
-  incorporating Noosphere as an XCode dependency.
+  incorporating Noosphere as an Xcode dependency.
 - **[`./design`](/design)**: documents describing Noosphere data
   structures and protocols in generalized terms.
 


### PR DESCRIPTION
correct spelling of Xcode IDE (not XCode)

https://developer.apple.com/xcode/