### PR TITLE
fix: Limit delegated UCAN's lifetime to authorization token's lifetime where appropriate

### DIFF
--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -602,7 +602,7 @@ mod tests {
             SphereReference, SUPPORTED_KEYS,
         },
         data::{AddressIpld, Bundle, CidKey, DelegationIpld, RevocationIpld},
-        view::{Sphere, SphereMutation, Timeline, SPHERE_LIFETIME},
+        view::{Sphere, SphereMutation, Timeline},
     };
 
     use noosphere_storage::{BlockStore, MemoryStore, Store, UcanStore};
@@ -776,7 +776,6 @@ mod tests {
             UcanBuilder::default()
                 .issued_by(&owner_key)
                 .for_audience(&next_owner_did)
-                .with_lifetime(SPHERE_LIFETIME)
                 .claiming_capability(&Capability {
                     with: With::Resource {
                         kind: Resource::Scoped(SphereReference {
@@ -786,6 +785,7 @@ mod tests {
                     can: SphereAction::Publish,
                 })
                 .witnessed_by(&ucan)
+                .with_expiration(*ucan.expires_at())
                 .build()
                 .unwrap()
                 .sign()

--- a/rust/noosphere-ns/tests/ns_test.rs
+++ b/rust/noosphere-ns/tests/ns_test.rs
@@ -106,10 +106,10 @@ async fn test_name_system_peer_propagation() -> Result<()> {
             UcanBuilder::default()
                 .issued_by(&ns_1.owner_key)
                 .for_audience(&ns_1.sphere_id)
-                .with_lifetime(SPHERE_LIFETIME - 1000)
                 .claiming_capability(&generate_capability(&ns_1.sphere_id))
                 .with_fact(generate_fact(&sphere_1_cid_1.to_string()))
                 .witnessed_by(&ns_1.delegation)
+                .with_expiration(*ns_1.delegation.expires_at())
                 .build()?
                 .sign()
                 .await?
@@ -141,10 +141,10 @@ async fn test_name_system_peer_propagation() -> Result<()> {
             UcanBuilder::default()
                 .issued_by(&ns_1.owner_key)
                 .for_audience(&ns_1.sphere_id)
-                .with_lifetime(SPHERE_LIFETIME - 1000)
                 .claiming_capability(&generate_capability(&ns_1.sphere_id))
                 .with_fact(generate_fact(&sphere_1_cid_2.to_string()))
                 .witnessed_by(&ns_1.delegation)
+                .with_expiration(*ns_1.delegation.expires_at())
                 .build()?
                 .sign()
                 .await?
@@ -172,10 +172,10 @@ async fn test_name_system_peer_propagation() -> Result<()> {
         UcanBuilder::default()
             .issued_by(&ns_2.owner_key)
             .for_audience(&ns_2.sphere_id)
-            .with_expiration(now() - 1000) // already expired
             .claiming_capability(&generate_capability(&ns_2.sphere_id))
             .with_fact(generate_fact(&sphere_2_cid_1.to_string()))
             .witnessed_by(&ns_2.delegation)
+            .with_expiration(now() - 1000) // already expired
             .build()?
             .sign()
             .await?
@@ -188,10 +188,10 @@ async fn test_name_system_peer_propagation() -> Result<()> {
             UcanBuilder::default()
                 .issued_by(&ns_2.owner_key)
                 .for_audience(&ns_2.sphere_id)
-                .with_lifetime(SPHERE_LIFETIME - 1000)
                 .claiming_capability(&generate_capability(&ns_2.sphere_id))
                 .with_fact(generate_fact(&sphere_2_cid_2.to_string()))
                 .witnessed_by(&ns_2.delegation)
+                .with_expiration(*ns_2.delegation.expires_at())
                 .build()?
                 .sign()
                 .await?
@@ -229,10 +229,10 @@ async fn test_name_system_validation() -> Result<()> {
                 UcanBuilder::default()
                     .issued_by(&ns_1.owner_key)
                     .for_audience(&ns_1.sphere_id)
-                    .with_expiration(now() - 1000) // already expired
                     .claiming_capability(&generate_capability(&ns_1.sphere_id))
                     .with_fact(generate_fact(&sphere_1_cid_1.to_string()))
                     .witnessed_by(&ns_1.delegation)
+                    .with_expiration(now() - 1000) // already expired
                     .build()?
                     .sign()
                     .await?
@@ -254,10 +254,10 @@ async fn it_is_thread_safe() -> Result<()> {
     let ucan_record: NSRecord = UcanBuilder::default()
         .issued_by(&ns_1.owner_key)
         .for_audience(&ns_1.sphere_id)
-        .with_lifetime(SPHERE_LIFETIME)
         .claiming_capability(&generate_capability(&ns_1.sphere_id))
         .with_fact(generate_fact(&address.to_string()))
         .witnessed_by(&ns_1.delegation)
+        .with_expiration(*ns_1.delegation.expires_at())
         .build()?
         .sign()
         .await?


### PR DESCRIPTION
In some scenarios, both authorization and delegated tokens set their expiration time to be (NOW + 10000 years). If the delegated and auth tokens aren't created within the same timestamp-second, then the delegated token's lifetime exceeds its attenuation. This occurs intermittently (Fixes #248).