### PR TITLE
feat!: Implement C FFI for petname management

### DIFF
--- a/.github/workflows/container_images.yaml
+++ b/.github/workflows/container_images.yaml
@@ -39,6 +39,8 @@ jobs:
             concurrency="$concurrency-$IMAGE_TAG"
           fi
 
+          concurrency="$concurrency-$GITHUB_SHA"
+
           tags_out=""
 
           for tag in "${tags[@]}"; do

--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --features test_kubo
+          args: --features test_kubo,headers
 
   run-test-suite-web-wasm:
     runs-on: ubuntu-latest

--- a/rust/noosphere-sphere/src/content/mod.rs
+++ b/rust/noosphere-sphere/src/content/mod.rs
@@ -5,11 +5,9 @@
 mod decoder;
 mod file;
 mod read;
-mod walker;
 mod write;
 
 pub use decoder::*;
 pub use file::*;
 pub use read::*;
-pub use walker::*;
 pub use write::*;

--- a/rust/noosphere-sphere/src/lib.rs
+++ b/rust/noosphere-sphere/src/lib.rs
@@ -65,6 +65,7 @@ mod content;
 mod context;
 mod cursor;
 mod has;
+mod walker;
 
 pub mod helpers;
 
@@ -80,3 +81,4 @@ pub use has::*;
 pub use metadata::*;
 pub use petname::*;
 pub use sync::*;
+pub use walker::*;

--- a/rust/noosphere/src/ffi/fs.rs
+++ b/rust/noosphere/src/ffi/fs.rs
@@ -14,18 +14,18 @@ use tokio::{
 };
 
 use crate::{
-    ffi::{NsError, NsHeaders, NsNoosphereContext, TryOrInitialize},
+    ffi::{NsError, NsHeaders, NsNoosphere, TryOrInitialize},
     platform::{PlatformKeyMaterial, PlatformStorage},
 };
 
 use noosphere_sphere::{
-    HasMutableSphereContext, HasSphereContext, SphereContentRead, SphereContentWalker,
-    SphereContentWrite, SphereContext, SphereCursor, SphereFile,
+    HasMutableSphereContext, HasSphereContext, SphereContentRead, SphereContentWrite,
+    SphereContext, SphereCursor, SphereFile, SphereWalker,
 };
 
 #[derive_ReprC]
 #[ReprC::opaque]
-pub struct NsSphereFs {
+pub struct NsSphere {
     inner: SphereCursor<
         Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>,
         PlatformKeyMaterial,
@@ -33,7 +33,7 @@ pub struct NsSphereFs {
     >,
 }
 
-impl NsSphereFs {
+impl NsSphere {
     pub fn inner(
         &self,
     ) -> &SphereCursor<
@@ -72,16 +72,16 @@ impl NsSphereFile {
 }
 
 #[ffi_export]
-/// Initialize an instance of a [NsSphereFs] that is a read/write view into
+/// Initialize an instance of a [NsSphere] that is a read/write view into
 /// the contents (as addressed by the slug namespace) of the identitifed sphere
 /// This will fail if it is not possible to initialize a sphere with the given
 /// identity (which implies that no such sphere was ever created or joined on
 /// this device).
 pub fn ns_sphere_fs_open(
-    noosphere: &NsNoosphereContext,
+    noosphere: &NsNoosphere,
     sphere_identity: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
-) -> Option<repr_c::Box<NsSphereFs>> {
+) -> Option<repr_c::Box<NsSphere>> {
     error_out.try_or_initialize(|| {
         let fs = noosphere.async_runtime().block_on(async {
             let sphere_context = noosphere
@@ -91,7 +91,7 @@ pub fn ns_sphere_fs_open(
 
             let cursor = SphereCursor::latest(sphere_context);
 
-            Ok(repr_c::Box::new(NsSphereFs { inner: cursor })) as Result<_, anyhow::Error>
+            Ok(repr_c::Box::new(NsSphere { inner: cursor })) as Result<_, anyhow::Error>
         })?;
 
         Ok(fs)
@@ -99,23 +99,23 @@ pub fn ns_sphere_fs_open(
 }
 
 #[ffi_export]
-/// De-allocate an [NsSphereFs] instance
-pub fn ns_sphere_fs_free(sphere_fs: repr_c::Box<NsSphereFs>) {
-    drop(sphere_fs)
+/// De-allocate an [NsSphere] instance
+pub fn ns_sphere_fs_free(sphere: repr_c::Box<NsSphere>) {
+    drop(sphere)
 }
 
 #[ffi_export]
-/// Read a [NsSphereFile] from a [NsSphereFs] instance by slashlink. Note that
+/// Read a [NsSphereFile] from a [NsSphere] instance by slashlink. Note that
 /// although this function will eventually support slashlinks that include the
 /// pet name of a peer, at this time only slashlinks with slugs referencing the
 /// slug namespace of the local sphere are allowed.
 ///
 /// This function will return a null pointer if the slug does not have a file
 /// associated with it at the revision of the sphere that is referred to by the
-/// [NsSphereFs] being read from.
+/// [NsSphere] being read from.
 pub fn ns_sphere_fs_read(
-    noosphere: &NsNoosphereContext,
-    sphere_fs: &NsSphereFs,
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
     slashlink: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> Option<repr_c::Box<NsSphereFile>> {
@@ -137,7 +137,7 @@ pub fn ns_sphere_fs_read(
                     None => return Err(anyhow!("No slug specified in slashlink!")),
                 };
 
-                let cursor = sphere_fs.inner();
+                let cursor = sphere.inner();
 
                 println!(
                     "Reading sphere {} slug {}...",
@@ -161,7 +161,7 @@ pub fn ns_sphere_fs_read(
 }
 
 #[ffi_export]
-/// Write a byte buffer to a slug in the given [NsSphereFs] instance, assigning
+/// Write a byte buffer to a slug in the given [NsSphere] instance, assigning
 /// its content-type header to the specified value. If additional headers are
 /// specified, they will be appended to the list of headers in the memo that is
 /// created for the content. If some content already exists at the specified
@@ -171,8 +171,8 @@ pub fn ns_sphere_fs_read(
 /// Note that you must invoke [ns_sphere_fs_save] to commit one or more writes
 /// to the sphere.
 pub fn ns_sphere_fs_write(
-    noosphere: &NsNoosphereContext,
-    sphere_fs: &mut NsSphereFs,
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
     slug: char_p::Ref<'_>,
     content_type: char_p::Ref<'_>,
     bytes: c_slice::Ref<'_, u8>,
@@ -182,7 +182,7 @@ pub fn ns_sphere_fs_write(
     error_out.try_or_initialize(|| {
         noosphere.async_runtime().block_on(async {
             let slug = slug.to_str();
-            let cursor = sphere_fs.inner_mut();
+            let cursor = sphere.inner_mut();
 
             println!(
                 "Writing sphere {} slug {}...",
@@ -213,35 +213,35 @@ pub fn ns_sphere_fs_write(
 /// sphere. In order to commit the change, you must save. Note that this call is
 /// a no-op if there is no matching slug linked in the sphere.
 pub fn ns_sphere_fs_remove(
-    noosphere: &NsNoosphereContext,
-    sphere_fs: &mut NsSphereFs,
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
     slug: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) {
     error_out.try_or_initialize(|| {
         noosphere
             .async_runtime()
-            .block_on(async { sphere_fs.inner_mut().remove(slug.to_str()).await })?;
+            .block_on(async { sphere.inner_mut().remove(slug.to_str()).await })?;
         Ok(())
     });
 }
 
 #[ffi_export]
-/// Save any writes performed on the [NsSphereFs] instance. If additional
+/// Save any writes performed on the [NsSphere] instance. If additional
 /// headers are specified, they will be appended to the headers in the memo that
 /// is created to wrap the latest sphere revision.
 ///
 /// This will fail if both no writes have been performed and no additional
 /// headers were specified (in other words: no actual changes were made).
 pub fn ns_sphere_fs_save(
-    noosphere: &NsNoosphereContext,
-    sphere_fs: &mut NsSphereFs,
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
     additional_headers: Option<&NsHeaders>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) {
     error_out.try_or_initialize(|| {
         let cid = noosphere.async_runtime().block_on(
-            sphere_fs
+            sphere
                 .inner_mut()
                 .save(additional_headers.map(|headers| headers.inner().clone())),
         )?;
@@ -255,13 +255,13 @@ pub fn ns_sphere_fs_save(
 #[ffi_export]
 /// Get an array of all of the slugs in a sphere at the current version.
 pub fn ns_sphere_fs_list(
-    noosphere: &NsNoosphereContext,
-    sphere_fs: &NsSphereFs,
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> c_slice::Box<char_p::Box> {
     let possible_output = error_out.try_or_initialize(|| {
         noosphere.async_runtime().block_on(async {
-            let slug_set = SphereContentWalker::from(sphere_fs.inner()).list().await?;
+            let slug_set = SphereWalker::from(sphere.inner()).list_slugs().await?;
             let mut all_slugs: Vec<char_p::Box> = Vec::new();
 
             for slug in slug_set.into_iter() {
@@ -294,8 +294,8 @@ pub fn ns_sphere_fs_list(
 /// Also note that multiple changes to the same slug will be reduced to a
 /// single entry in the array that is returned.
 pub fn ns_sphere_fs_changes(
-    noosphere: &NsNoosphereContext,
-    sphere_fs: &NsSphereFs,
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
     since_cid: Option<char_p::Ref<'_>>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> c_slice::Box<char_p::Box> {
@@ -308,8 +308,8 @@ pub fn ns_sphere_fs_changes(
                 None => None,
             };
 
-            let changed_slug_set = SphereContentWalker::from(sphere_fs.inner())
-                .changes(since.as_ref())
+            let changed_slug_set = SphereWalker::from(sphere.inner())
+                .content_changes(since.as_ref())
                 .await?;
             let mut changed_slugs: Vec<char_p::Box> = Vec::new();
 
@@ -344,7 +344,7 @@ pub fn ns_sphere_file_free(sphere_file: repr_c::Box<NsSphereFile>) {
 /// until this function is invoked, and once the bytes have been read from the
 /// file you must create a new [NsSphereFile] instance to read them again.
 pub fn ns_sphere_file_contents_read(
-    noosphere: &NsNoosphereContext,
+    noosphere: &NsNoosphere,
     sphere_file: &mut NsSphereFile,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> Option<c_slice::Box<u8>> {

--- a/rust/noosphere/src/ffi/key.rs
+++ b/rust/noosphere/src/ffi/key.rs
@@ -1,12 +1,12 @@
 use safer_ffi::prelude::*;
 
-use crate::ffi::{NsError, NsNoosphereContext, TryOrInitialize};
+use crate::ffi::{NsError, NsNoosphere, TryOrInitialize};
 
 #[ffi_export]
 /// Create a key with the given name in the current platform's support key
 /// storage mechanism.
 pub fn ns_key_create(
-    noosphere: &NsNoosphereContext,
+    noosphere: &NsNoosphere,
     name: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) {

--- a/rust/noosphere/src/ffi/noosphere.rs
+++ b/rust/noosphere/src/ffi/noosphere.rs
@@ -13,18 +13,18 @@ use crate::{
 
 #[derive_ReprC]
 #[ReprC::opaque]
-pub struct NsNoosphereContext {
+pub struct NsNoosphere {
     inner: NoosphereContext,
     async_runtime: Arc<TokioRuntime>,
 }
 
-impl NsNoosphereContext {
+impl NsNoosphere {
     pub fn new(
         global_storage_path: &str,
         sphere_storage_path: &str,
         gateway_api: Option<&Url>,
     ) -> Result<Self> {
-        Ok(NsNoosphereContext {
+        Ok(NsNoosphere {
             inner: NoosphereContext::new(NoosphereContextConfiguration {
                 storage: NoosphereStorage::Scoped {
                     path: sphere_storage_path.into(),
@@ -78,14 +78,14 @@ pub fn ns_initialize(
     sphere_storage_path: char_p::Ref<'_>,
     gateway_url: Option<char_p::Ref<'_>>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
-) -> Option<repr_c::Box<NsNoosphereContext>> {
+) -> Option<repr_c::Box<NsNoosphere>> {
     error_out.try_or_initialize(|| {
         let gateway_url = match gateway_url {
             Some(raw_url) => Some(Url::parse(raw_url.to_str()).map_err(|error| anyhow!(error))?),
             None => None,
         };
 
-        Ok(repr_c::Box::new(NsNoosphereContext::new(
+        Ok(repr_c::Box::new(NsNoosphere::new(
             global_storage_path.to_str(),
             sphere_storage_path.to_str(),
             gateway_url.as_ref(),
@@ -96,7 +96,7 @@ pub fn ns_initialize(
 #[ffi_export]
 /// De-allocate a [NoosphereContext]. Note that this will also drop every
 /// [SphereContext] that remains active within the [NoosphereContext].
-pub fn ns_free(noosphere: repr_c::Box<NsNoosphereContext>) {
+pub fn ns_free(noosphere: repr_c::Box<NsNoosphere>) {
     drop(noosphere)
 }
 

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -1,47 +1,206 @@
 #![allow(unused_variables)]
 
-use safer_ffi::prelude::*;
+use std::str::FromStr;
 
-use crate::ffi::NsError;
+use anyhow::anyhow;
+use cid::Cid;
+use noosphere_sphere::{SpherePetnameRead, SpherePetnameWrite, SphereWalker};
+use safer_ffi::{char_p::InvalidNulTerminator, prelude::*};
 
-use super::NsNoosphereContext;
+use crate::ffi::{NsError, TryOrInitialize};
+
+use super::{NsNoosphere, NsSphere};
 
 #[ffi_export]
-/// Get the DID that is assigned to the provided petname; note that the DID is
-/// the ID of the sphere, but in order to read the sphere you must resolve the
-/// DID to a CID, which tells you the version of the sphere to read.
-pub fn ns_sphere_petname_get(
-    noosphere: &NsNoosphereContext,
-    sphere_identity: char_p::Ref<'_>,
+/// Returns true if the given petname has been assigned to a sphere identity. If
+/// it returns false, it implies one of the following: the petname has never
+/// been assigned to any sphere identity, _or_ it was previously assigned to a
+/// sphere identity at least once but has since been unassigned.
+pub fn ns_sphere_petname_is_set(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
     petname: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
-) -> Option<char_p::Box> {
-    todo!();
+) -> safer_ffi::bool {
+    if let Some(result) = error_out.try_or_initialize(|| {
+        noosphere.async_runtime().block_on(async {
+            Ok(match sphere.inner().get_petname(petname.to_str()).await? {
+                Some(_) => true,
+                None => false,
+            })
+        })
+    }) {
+        result
+    } else {
+        false
+    }
 }
 
 #[ffi_export]
-/// Assign a DID to a petname. This will overwrite a petname entry if one already exists
-/// with the given name (and reset the resolved CID, if any).
-pub fn ns_sphere_petname_set(
-    noosphere: &NsNoosphereContext,
-    sphere_identity: char_p::Ref<'_>,
+/// Get the sphere identity - a DID - that the given petname is assigned to in
+/// the sphere. Note that this call will produce an error if the petname has not
+/// been assigned to a sphere identity (or was previously assigned to a sphere
+/// identity but has since been unassigned).
+pub fn ns_sphere_petname_get(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
     petname: char_p::Ref<'_>,
-    did: char_p::Ref<'_>,
+    error_out: Option<Out<'_, repr_c::Box<NsError>>>,
+) -> Option<char_p::Box> {
+    error_out.try_or_initialize(|| {
+        noosphere.async_runtime().block_on(async {
+            sphere
+                .inner()
+                .get_petname(petname.to_str())
+                .await?
+                .ok_or_else(|| anyhow!("No petname '{}' has been set", petname.to_str()))?
+                .to_string()
+                .try_into()
+                .map_err(|error: InvalidNulTerminator<String>| anyhow!(error).into())
+        })
+    })
+}
+
+#[ffi_export]
+/// Assign a petname to a sphere identity (a DID). This will overwrite the
+/// petname so that it is assigned to the new sphere identity if it had been
+/// assigned to a different sphere identity previously.
+///
+/// When a petname is assigned to a new sphere identity, its entry in the
+/// address book will be set to an unresolved state. You may pass null as the
+/// DID to effective unassign the petname from any sphere identity.
+///
+/// Make sure to invoke sync after assigning or unassigning petnames to sphere
+/// identities, so that newly introduced sphere identities can be resolved by
+/// the gateway (if one is configured). Once the gateway's resolutions are
+/// sync'd, the related address book entries will be considered to be in a
+/// resolved state.
+pub fn ns_sphere_petname_set(
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
+    petname: char_p::Ref<'_>,
+    did: Option<char_p::Ref<'_>>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) {
-    todo!();
+    error_out.try_or_initialize(|| {
+        noosphere.async_runtime().block_on(async {
+            sphere
+                .inner_mut()
+                .set_petname(petname.to_str(), did.map(|did| did.to_str().into()))
+                .await?;
+
+            Ok(())
+        })
+    });
 }
 
 #[ffi_export]
-/// Resolve a configured petname to a sphere version (a CID), via the DID that
-/// has been assigned to it. The returned value is a UTF-8, base64-encoded CIDv1
-/// string. If no DID has been assigned to the given petname, no value will be
-/// resolved.
+/// Resolve a configured petname, using the sphere identity that it is assigned
+/// to and determining a link - a CID - that is associated with it. The returned
+/// link is a UTF-8, base64-encoded CIDv1 string that may be used to resolve
+/// data from the IPFS content space. Note that this call will produce an error
+/// if no address has been assigned to the given petname.
 pub fn ns_sphere_petname_resolve(
-    noosphere: &NsNoosphereContext,
-    sphere_identity: char_p::Ref<'_>,
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
     petname: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> Option<char_p::Box> {
-    todo!();
+    error_out.try_or_initialize(|| {
+        noosphere.async_runtime().block_on(async {
+            sphere
+                .inner()
+                .resolve_petname(petname.to_str())
+                .await?
+                .ok_or_else(|| anyhow!("No record resolved for petname '{}'", petname.to_str()))?
+                .to_string()
+                .try_into()
+                .map_err(|error: InvalidNulTerminator<String>| anyhow!(error).into())
+        })
+    })
+}
+
+#[ffi_export]
+/// Get an array of all of the petnames in a sphere at the current version.
+pub fn ns_sphere_petname_list(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
+    error_out: Option<Out<'_, repr_c::Box<NsError>>>,
+) -> c_slice::Box<char_p::Box> {
+    let possible_output = error_out.try_or_initialize(|| {
+        noosphere.async_runtime().block_on(async {
+            let petname_set = SphereWalker::from(sphere.inner()).list_petnames().await?;
+            let mut all_petnames: Vec<char_p::Box> = Vec::new();
+
+            for petname in petname_set.into_iter() {
+                all_petnames.push(
+                    petname
+                        .try_into()
+                        .map_err(|error: InvalidNulTerminator<String>| anyhow!(error))?,
+                );
+            }
+
+            Ok(all_petnames)
+        })
+    });
+
+    match possible_output {
+        Some(slugs) => slugs,
+        None => Vec::new(),
+    }
+    .into_boxed_slice()
+    .into()
+}
+
+#[ffi_export]
+/// Get an array of all of the petnames that changed in a given sphere since a
+/// given revision of that sphere (excluding the given revision). The revision
+/// should be provided as a UTF-8 base64-encoded CIDv1 string. If no revision is
+/// provided, the entire history will be considered (back to and including the
+/// first revision).
+///
+/// Note that a petname change may mean the petname was added, updated or
+/// removed. Also note that multiple changes to the same petname will be reduced
+/// to a single entry in the array that is returned.
+///
+/// A petname will also be considered changed if it goes from an unresolved
+/// state to a resolved state.
+pub fn ns_sphere_petname_changes(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
+    since_cid: Option<char_p::Ref<'_>>,
+    error_out: Option<Out<'_, repr_c::Box<NsError>>>,
+) -> c_slice::Box<char_p::Box> {
+    let possible_output = error_out.try_or_initialize(|| {
+        noosphere.async_runtime().block_on(async {
+            let since = match since_cid {
+                Some(cid_string) => {
+                    Some(Cid::from_str(cid_string.to_str()).map_err(|error| anyhow!(error))?)
+                }
+                None => None,
+            };
+
+            let changed_petname_set = SphereWalker::from(sphere.inner())
+                .petname_changes(since.as_ref())
+                .await?;
+            let mut changed_petnames: Vec<char_p::Box> = Vec::new();
+
+            for petname in changed_petname_set.into_iter() {
+                changed_petnames.push(
+                    petname
+                        .try_into()
+                        .map_err(|error: InvalidNulTerminator<String>| anyhow!(error))?,
+                );
+            }
+
+            Ok(changed_petnames)
+        })
+    });
+
+    match possible_output {
+        Some(petnames) => petnames,
+        None => Vec::new(),
+    }
+    .into_boxed_slice()
+    .into()
 }

--- a/rust/noosphere/src/ffi/sphere.rs
+++ b/rust/noosphere/src/ffi/sphere.rs
@@ -5,7 +5,7 @@ use noosphere_sphere::{HasSphereContext, SphereSync};
 use safer_ffi::char_p::InvalidNulTerminator;
 use safer_ffi::prelude::*;
 
-use crate::ffi::{NsError, NsNoosphereContext, TryOrInitialize};
+use crate::ffi::{NsError, NsNoosphere, TryOrInitialize};
 use crate::sphere::SphereReceipt;
 
 #[derive_ReprC]
@@ -65,7 +65,7 @@ pub fn ns_sphere_receipt_free(sphere_receipt: repr_c::Box<NsSphereReceipt>) {
 /// and a human-readable mnemonic that can be used to rotate the key authorized
 /// to administer the sphere.
 pub fn ns_sphere_create(
-    noosphere: &mut NsNoosphereContext,
+    noosphere: &mut NsNoosphere,
     owner_key_name: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> Option<repr_c::Box<NsSphereReceipt>> {
@@ -84,7 +84,7 @@ pub fn ns_sphere_create(
 /// key and authorization. The authorization should be provided in the form of
 /// a base64-encoded CID v1 string.
 pub fn ns_sphere_join(
-    noosphere: &mut NsNoosphereContext,
+    noosphere: &mut NsNoosphere,
     sphere_identity: char_p::Ref<'_>,
     local_key_name: char_p::Ref<'_>,
     authorization: char_p::Ref<'_>,
@@ -110,7 +110,7 @@ pub fn ns_sphere_join(
 /// in local history. If a version is recorded, it is returned as a
 /// base64-encoded CID v1 string.
 pub fn ns_sphere_version_get(
-    noosphere: &NsNoosphereContext,
+    noosphere: &NsNoosphere,
     sphere_identity: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> Option<char_p::Box> {
@@ -141,7 +141,7 @@ pub fn ns_sphere_version_get(
 /// base64-encoded CID v1 of the latest locally-available sphere revision after
 /// the synchronization process has successfully completed.
 pub fn ns_sphere_sync(
-    noosphere: &mut NsNoosphereContext,
+    noosphere: &mut NsNoosphere,
     sphere_identity: char_p::Ref<'_>,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
 ) -> Option<char_p::Box> {

--- a/rust/noosphere/src/wasm/fs.rs
+++ b/rust/noosphere/src/wasm/fs.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use js_sys::{Array, Function};
 use noosphere_sphere::{
-    HasMutableSphereContext, SphereContentRead, SphereContentWalker, SphereContentWrite,
-    SphereContext, SphereCursor,
+    HasMutableSphereContext, SphereContentRead, SphereContentWrite, SphereContext, SphereCursor,
+    SphereWalker,
 };
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
@@ -114,7 +114,7 @@ impl SphereFs {
     /// after the callback has been invoked once for each entry in the sphere's
     /// namespace.
     pub async fn stream(&self, callback: Function) -> Result<(), String> {
-        let stream = SphereContentWalker::from(self.inner.clone()).into_stream();
+        let stream = SphereWalker::from(self.inner.clone()).into_content_stream();
         let this = JsValue::null();
 
         tokio::pin!(stream);


### PR DESCRIPTION
This is a follow-up to #253 that implements that C FFI surface for petname support. As part of a general transition away from the deprecated `SphereFs` and towards `SphereContext` + traits, this also tweaks the signatures of FFI methods in a (hopefully) non-breaking way to indicate that `SphereFs` is no longer a thing.

Note that this change does not include validation of petname records. A change is already in-progress to implement validation in the gateway.

Fixes #243 