### PR TITLE
feat: Revise links and gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,6 +3915,7 @@ dependencies = [
  "cid 0.9.0",
  "futures",
  "horrorshow",
+ "libipld-cbor 0.15.0",
  "noosphere-core",
  "noosphere-sphere",
  "noosphere-storage",

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -1,10 +1,9 @@
 use anyhow::{anyhow, Result};
 use cid::Cid;
 use globset::{Glob, GlobSet, GlobSetBuilder};
-use libipld_cbor::DagCborCodec;
 use noosphere_core::{
     authority::Authorization,
-    data::{BodyChunkIpld, ContentType, Did, Header, MemoIpld},
+    data::{BodyChunkIpld, ContentType, Did, Header},
     view::Sphere,
 };
 use noosphere_storage::{BlockStore, KeyValueStore, NativeStorage, SphereDb, Store};
@@ -192,7 +191,7 @@ impl Workspace {
 
         let mut changes = ContentChanges::default();
 
-        while let Some(Ok((slug, cid))) = stream.next().await {
+        while let Some(Ok((slug, memo))) = stream.next().await {
             if content.ignored.contains(slug) {
                 continue;
             }
@@ -220,8 +219,6 @@ impl Workspace {
                         .insert(slug.clone(), Some(content_type.clone()));
                 }
                 None => {
-                    let memo = db.load::<DagCborCodec, MemoIpld>(cid).await?;
-
                     changes.removed.insert(slug.clone(), memo.content_type());
                 }
             }

--- a/rust/noosphere-cli/tests/gateway.rs
+++ b/rust/noosphere-cli/tests/gateway.rs
@@ -24,7 +24,6 @@ use noosphere_core::{
     view::{Sphere, SphereMutation},
 };
 
-use libipld_cbor::DagCborCodec;
 use ucan::crypto::KeyMaterial;
 
 use noosphere_cli::native::{
@@ -415,15 +414,10 @@ async fn gateway_updates_an_existing_sphere_with_changes_from_the_client() {
             let memo = MemoIpld::for_body(client_sphere_context.db_mut(), vec![value])
                 .await
                 .unwrap();
-            let memo_cid = client_sphere_context
-                .db_mut()
-                .save::<DagCborCodec, _>(&memo)
-                .await
-                .unwrap();
 
             let mut mutation =
                 SphereMutation::new(&client_sphere_context.author().identity().await.unwrap());
-            mutation.links_mut().set(&value.into(), &memo_cid);
+            mutation.links_mut().set(&value.into(), &memo);
 
             let mut revision = sphere.apply_mutation(&mutation).await.unwrap();
             final_cid = revision
@@ -566,15 +560,9 @@ async fn gateway_serves_sphere_revisions_to_a_client() {
             let memo = MemoIpld::for_body(client_sphere_context.db_mut(), vec![value])
                 .await
                 .unwrap();
-            let memo_cid = client_sphere_context
-                .db_mut()
-                .save::<DagCborCodec, _>(&memo)
-                .await
-                .unwrap();
-
             let mut mutation =
                 SphereMutation::new(&client_sphere_context.author().identity().await.unwrap());
-            mutation.links_mut().set(&value.into(), &memo_cid);
+            mutation.links_mut().set(&value.into(), &memo);
 
             let mut revision = sphere.apply_mutation(&mutation).await.unwrap();
 

--- a/rust/noosphere-core/src/data/address.rs
+++ b/rust/noosphere-core/src/data/address.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use cid::Cid;
 use serde::{Deserialize, Serialize};
-use ucan::Ucan;
+use ucan::{store::UcanJwtStore, Ucan};
 
 use super::{Did, Jwt};
 
@@ -14,17 +14,37 @@ use super::{Did, Jwt};
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Hash)]
 pub struct AddressIpld {
     pub identity: Did,
-    pub last_known_record: Option<Jwt>,
+    pub last_known_record: Option<Cid>,
 }
 
 impl AddressIpld {
+    /// If there is a last known record, attempt to retrieve it from storage as
+    /// a [Jwt] proof token
+    pub async fn get_proof<S: UcanJwtStore>(&self, store: &S) -> Option<Jwt> {
+        match &self.last_known_record {
+            Some(cid) => store
+                .read_token(cid)
+                .await
+                .unwrap_or(None)
+                .map(|jwt| jwt.into()),
+            _ => None,
+        }
+    }
+
     /// If a last known record is available, parses it as a [Ucan] and
     /// looks for the referenced pointer to some data in IPFS (via a [Cid]
     /// in the `fct` field).
-    pub async fn dereference(&self) -> Option<Cid> {
+    pub async fn dereference<S: UcanJwtStore>(&self, store: &S) -> Option<Cid> {
         match &self.last_known_record {
-            Some(token) => {
-                let ucan = match Ucan::try_from(token.to_string()) {
+            Some(cid) => {
+                let token = match store.require_token(cid).await {
+                    Ok(jwt) => jwt,
+                    Err(error) => {
+                        error!("Failed to look up token for {}: {}", cid, error);
+                        return None;
+                    }
+                };
+                let ucan = match Ucan::try_from(token) {
                     Ok(ucan) => ucan,
                     _ => return None,
                 };

--- a/rust/noosphere-core/src/data/links.rs
+++ b/rust/noosphere-core/src/data/links.rs
@@ -1,5 +1,3 @@
-use cid::Cid;
+use crate::data::{MemoIpld, VersionedMapIpld};
 
-use crate::data::VersionedMapIpld;
-
-pub type LinksIpld = VersionedMapIpld<String, Cid>;
+pub type LinksIpld = VersionedMapIpld<String, MemoIpld>;

--- a/rust/noosphere-core/src/data/memo.rs
+++ b/rust/noosphere-core/src/data/memo.rs
@@ -17,7 +17,7 @@ use super::ContentType;
 
 /// A basic Memo. A Memo is a history-retaining structure that pairs
 /// inline headers with a body CID.
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, Hash)]
 pub struct MemoIpld {
     /// An optional pointer to the previous version of the DAG
     pub parent: Option<Cid>,

--- a/rust/noosphere-core/src/tracing.rs
+++ b/rust/noosphere-core/src/tracing.rs
@@ -23,8 +23,9 @@ pub fn initialize_tracing() {
                     .unwrap_or_else(|_| "noosphere_cli,orb,tower_http=debug".into()),
             ))
             .with(
-                tracing_subscriber::fmt::layer(), // .with_file(true)
-                                                  // .with_line_number(true),
+                tracing_subscriber::fmt::layer()
+                    .with_file(true)
+                    .with_line_number(true),
             )
             .init();
     });

--- a/rust/noosphere-core/src/tracing.rs
+++ b/rust/noosphere-core/src/tracing.rs
@@ -23,9 +23,8 @@ pub fn initialize_tracing() {
                     .unwrap_or_else(|_| "noosphere_cli,orb,tower_http=debug".into()),
             ))
             .with(
-                tracing_subscriber::fmt::layer()
-                    .with_file(true)
-                    .with_line_number(true),
+                tracing_subscriber::fmt::layer(), // .with_file(true)
+                                                  // .with_line_number(true),
             )
             .init();
     });

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -119,7 +119,7 @@ impl<'a> SphereMutation {
     }
 }
 
-pub type LinksMutation = VersionedMapMutation<String, Cid>;
+pub type LinksMutation = VersionedMapMutation<String, MemoIpld>;
 pub type NamesMutation = VersionedMapMutation<String, AddressIpld>;
 pub type AllowedUcansMutation = VersionedMapMutation<CidKey, DelegationIpld>;
 pub type RevokedUcansMutation = VersionedMapMutation<CidKey, RevocationIpld>;

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -71,7 +71,7 @@ impl<S: BlockStore> Sphere<S> {
     /// Produce a bundle that contains the sparse set of blocks needed
     /// to produce this revision to the sphere
     pub async fn to_bundle(&self) -> Result<Bundle> {
-        MemoIpld::try_bundle_with_cid(self.cid(), &self.store).await
+        MemoIpld::bundle_with_cid(self.cid(), &self.store).await
     }
 
     /// Produce a bundle that contains the sparse set of blocks needed to

--- a/rust/noosphere-core/src/view/timeline.rs
+++ b/rust/noosphere-core/src/view/timeline.rs
@@ -94,15 +94,14 @@ impl<'a, S: BlockStore> Display for Timeslice<'a, S> {
 #[cfg(test)]
 mod tests {
     use cid::Cid;
-    use libipld_core::raw::RawCodec;
-    use noosphere_storage::{BlockStore, MemoryStore};
-    use serde_bytes::Bytes;
+    use noosphere_storage::MemoryStore;
     use ucan::crypto::KeyMaterial;
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use crate::{
         authority::generate_ed25519_key,
+        data::MemoIpld,
         view::{Sphere, SphereMutation},
     };
 
@@ -125,7 +124,7 @@ mod tests {
             let mut mutation = SphereMutation::new(&owner_did);
             mutation.links_mut().set(
                 &format!("foo/{i}"),
-                &store.save::<RawCodec, _>(Bytes::new(&[i])).await.unwrap(),
+                &MemoIpld::for_body(&mut store, &[i]).await.unwrap(),
             );
             let mut revision = sphere.apply_mutation(&mutation).await.unwrap();
             let next_cid = revision.try_sign(&owner_key, Some(&ucan)).await.unwrap();

--- a/rust/noosphere-core/src/view/versioned_map.rs
+++ b/rust/noosphere-core/src/view/versioned_map.rs
@@ -5,18 +5,22 @@ use async_once_cell::OnceCell;
 use cid::Cid;
 use futures::Stream;
 use libipld_cbor::DagCborCodec;
+use libipld_core::{
+    codec::{Codec, Encode},
+    ipld::Ipld,
+};
 
 use crate::data::{
-    AddressIpld, ChangelogIpld, CidKey, DelegationIpld, LinksIpld, MapOperation, RevocationIpld,
-    VersionedMapIpld, VersionedMapKey, VersionedMapValue,
+    AddressIpld, ChangelogIpld, CidKey, DelegationIpld, LinksIpld, MapOperation, MemoIpld,
+    RevocationIpld, VersionedMapIpld, VersionedMapKey, VersionedMapValue,
 };
 
 use noosphere_collections::hamt::Hamt;
-use noosphere_storage::BlockStore;
+use noosphere_storage::{block_serialize, BlockStore};
 
 use super::VersionedMapMutation;
 
-pub type Links<S> = VersionedMap<String, Cid, S>;
+pub type Links<S> = VersionedMap<String, MemoIpld, S>;
 pub type Names<S> = VersionedMap<String, AddressIpld, S>;
 pub type AllowedUcans<S> = VersionedMap<CidKey, DelegationIpld, S>;
 pub type RevokedUcans<S> = VersionedMap<CidKey, RevocationIpld, S>;
@@ -132,10 +136,44 @@ where
         hamt.get(key).await
     }
 
+    /// Get a [Cid] for a given [Codec] that refers to the value stored at the
+    /// given key, if any.
+    pub async fn get_as_cid<C>(&self, key: &K) -> Result<Option<Cid>>
+    where
+        C: Codec + Default,
+        Ipld: Encode<C>,
+        u64: From<C>,
+    {
+        // TODO: We should explore refering to values internally via links, so
+        // that we can avoid this re-serialization just to derive a CID. This may
+        // be incompatible with other IPLD HAMT implementations, but may be a
+        // worthy optimization none-the-less.
+        let hamt = self.get_hamt().await?;
+        let value = hamt.get(key).await?;
+
+        Ok(match value {
+            Some(value) => Some(block_serialize::<C, _>(value)?.0),
+            None => None,
+        })
+    }
+
     /// Same as `get`, but gives an error result if the key is not present in
     /// the underlying HAMT.
     pub async fn require(&self, key: &K) -> Result<&V> {
         self.get(key)
+            .await?
+            .ok_or_else(|| anyhow!("Key {} not found!", key))
+    }
+
+    /// Same as `get_as_cid`, but gives an error result if the key is not present in
+    /// the underlying HAMT.
+    pub async fn require_as_cid<C>(&self, key: &K) -> Result<Cid>
+    where
+        C: Codec + Default,
+        Ipld: Encode<C>,
+        u64: From<C>,
+    {
+        self.get_as_cid(key)
             .await?
             .ok_or_else(|| anyhow!("Key {} not found!", key))
     }

--- a/rust/noosphere-gateway/src/gateway.rs
+++ b/rust/noosphere-gateway/src/gateway.rs
@@ -3,17 +3,15 @@ use axum::http::{HeaderValue, Method};
 use axum::routing::{get, put};
 use axum::{Extension, Router, Server};
 use noosphere_core::data::Did;
-use noosphere_sphere::SphereContext;
+use noosphere_sphere::HasMutableSphereContext;
+use noosphere_storage::Storage;
 use std::net::TcpListener;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use ucan::crypto::KeyMaterial;
 use url::Url;
 
 use noosphere_api::route::Route as GatewayRoute;
-use noosphere_storage::NativeStorage;
 
 use crate::nns::{start_name_system, NameSystemConfiguration};
 use crate::{
@@ -29,24 +27,25 @@ pub struct GatewayScope {
     pub counterpart: Did,
 }
 
-pub async fn start_gateway<K>(
+pub async fn start_gateway<H, K, S>(
     listener: TcpListener,
     gateway_scope: GatewayScope,
-    sphere_context: Arc<Mutex<SphereContext<K, NativeStorage>>>,
+    sphere_context: H,
     ipfs_api: Url,
     name_resolver_api: Url,
     cors_origin: Option<Url>,
 ) -> Result<()>
 where
+    H: HasMutableSphereContext<K, S> + 'static,
     K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
 {
     initialize_tracing();
 
     let gateway_key_did = {
-        let sphere_context = sphere_context.lock().await;
+        let sphere_context = sphere_context.sphere_context().await?;
         sphere_context.author().identity().await?
     };
-
     let mut cors = CorsLayer::new();
 
     if let Some(cors_origin) = cors_origin {
@@ -68,8 +67,8 @@ where
             ]);
     }
 
-    let (syndication_tx, syndication_task) = start_ipfs_syndication::<K, NativeStorage>(ipfs_api);
-    let (name_system_tx, name_system_task) = start_name_system::<K, NativeStorage>(
+    let (syndication_tx, syndication_task) = start_ipfs_syndication::<H, K, S>(ipfs_api);
+    let (name_system_tx, name_system_task) = start_name_system::<H, K, S>(
         NameSystemConfiguration::Remote(name_resolver_api),
         vec![sphere_context.clone()],
     );
@@ -78,10 +77,13 @@ where
         .route(&GatewayRoute::Did.to_string(), get(did_route::<K>))
         .route(
             &GatewayRoute::Identify.to_string(),
-            get(identify_route::<K>),
+            get(identify_route::<H, K, S>),
         )
-        .route(&GatewayRoute::Push.to_string(), put(push_route::<K>))
-        .route(&GatewayRoute::Fetch.to_string(), get(fetch_route::<K>))
+        .route(&GatewayRoute::Push.to_string(), put(push_route::<H, K, S>))
+        .route(
+            &GatewayRoute::Fetch.to_string(),
+            get(fetch_route::<H, K, S>),
+        )
         .layer(Extension(sphere_context.clone()))
         .layer(Extension(gateway_scope.clone()))
         .layer(Extension(gateway_key_did))

--- a/rust/noosphere-gateway/src/gateway.rs
+++ b/rust/noosphere-gateway/src/gateway.rs
@@ -27,16 +27,16 @@ pub struct GatewayScope {
     pub counterpart: Did,
 }
 
-pub async fn start_gateway<H, K, S>(
+pub async fn start_gateway<C, K, S>(
     listener: TcpListener,
     gateway_scope: GatewayScope,
-    sphere_context: H,
+    sphere_context: C,
     ipfs_api: Url,
     name_resolver_api: Url,
     cors_origin: Option<Url>,
 ) -> Result<()>
 where
-    H: HasMutableSphereContext<K, S> + 'static,
+    C: HasMutableSphereContext<K, S> + 'static,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -67,8 +67,8 @@ where
             ]);
     }
 
-    let (syndication_tx, syndication_task) = start_ipfs_syndication::<H, K, S>(ipfs_api);
-    let (name_system_tx, name_system_task) = start_name_system::<H, K, S>(
+    let (syndication_tx, syndication_task) = start_ipfs_syndication::<C, K, S>(ipfs_api);
+    let (name_system_tx, name_system_task) = start_name_system::<C, K, S>(
         NameSystemConfiguration::Remote(name_resolver_api),
         vec![sphere_context.clone()],
     );
@@ -77,12 +77,12 @@ where
         .route(&GatewayRoute::Did.to_string(), get(did_route::<K>))
         .route(
             &GatewayRoute::Identify.to_string(),
-            get(identify_route::<H, K, S>),
+            get(identify_route::<C, K, S>),
         )
-        .route(&GatewayRoute::Push.to_string(), put(push_route::<H, K, S>))
+        .route(&GatewayRoute::Push.to_string(), put(push_route::<C, K, S>))
         .route(
             &GatewayRoute::Fetch.to_string(),
-            get(fetch_route::<H, K, S>),
+            get(fetch_route::<C, K, S>),
         )
         .layer(Extension(sphere_context.clone()))
         .layer(Extension(gateway_scope.clone()))

--- a/rust/noosphere-gateway/src/ipfs.rs
+++ b/rust/noosphere-gateway/src/ipfs.rs
@@ -50,11 +50,11 @@ pub struct SyndicationCheckpoint {
 /// Start a Tokio task that waits for [SyndicationJob] messages and then
 /// attempts to syndicate to the configured IPFS RPC. Currently only Kubo IPFS
 /// backends are supported.
-pub fn start_ipfs_syndication<H, K, S>(
+pub fn start_ipfs_syndication<C, K, S>(
     ipfs_api: Url,
-) -> (UnboundedSender<SyndicationJob<H>>, JoinHandle<Result<()>>)
+) -> (UnboundedSender<SyndicationJob<C>>, JoinHandle<Result<()>>)
 where
-    H: HasMutableSphereContext<K, S> + 'static,
+    C: HasMutableSphereContext<K, S> + 'static,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -63,12 +63,12 @@ where
     (tx, tokio::task::spawn(ipfs_syndication_task(ipfs_api, rx)))
 }
 
-async fn ipfs_syndication_task<H, K, S>(
+async fn ipfs_syndication_task<C, K, S>(
     ipfs_api: Url,
-    mut receiver: UnboundedReceiver<SyndicationJob<H>>,
+    mut receiver: UnboundedReceiver<SyndicationJob<C>>,
 ) -> Result<()>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-gateway/src/ipfs.rs
+++ b/rust/noosphere-gateway/src/ipfs.rs
@@ -101,7 +101,9 @@ where
             let sphere = context.to_sphere().await?;
             let links = sphere.get_links().await?;
 
-            let counterpart_revision = *links.require(&counterpart_identity).await?;
+            let counterpart_revision = links
+                .require_as_cid::<DagCborCodec>(&counterpart_identity)
+                .await?;
 
             let (last_syndicated_revision, syndicated_blocks) =
                 match context.read(&checkpoint_key).await? {

--- a/rust/noosphere-gateway/src/ipfs.rs
+++ b/rust/noosphere-gateway/src/ipfs.rs
@@ -9,17 +9,14 @@ use noosphere_core::{
 };
 use noosphere_ipfs::{IpfsClient, KuboClient};
 use noosphere_sphere::{
-    metadata::COUNTERPART, HasMutableSphereContext, HasSphereContext, SphereContentRead,
-    SphereContentWrite, SphereContext, SphereCursor,
+    metadata::COUNTERPART, HasMutableSphereContext, SphereContentRead, SphereContentWrite,
+    SphereCursor,
 };
 use noosphere_storage::{block_deserialize, block_serialize, BlockStore, KeyValueStore, Storage};
 use serde::{Deserialize, Serialize};
 use tokio::{
     io::AsyncReadExt,
-    sync::{
-        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-        Mutex,
-    },
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     task::JoinHandle,
 };
 use tokio_stream::StreamExt;
@@ -31,17 +28,13 @@ use wnfs::private::BloomFilter;
 
 /// A [SyndicationJob] is a request to syndicate the blocks of a _counterpart_
 /// sphere to the broader IPFS network.
-pub struct SyndicationJob<K, S>
-where
-    K: KeyMaterial + Clone + 'static,
-    S: Storage,
-{
+pub struct SyndicationJob<C> {
     /// The revision of the _local_ sphere to discover the _counterpart_ sphere
     /// from; the counterpart sphere's revision will need to be derived using
     /// this checkpoint in local sphere history.
     pub revision: Cid,
     /// The [SphereContext] that corresponds to the _local_ sphere.
-    pub context: Arc<Mutex<SphereContext<K, S>>>,
+    pub context: C,
 }
 
 /// A [SyndicationCheckpoint] represents the last spot in the history of a
@@ -57,13 +50,11 @@ pub struct SyndicationCheckpoint {
 /// Start a Tokio task that waits for [SyndicationJob] messages and then
 /// attempts to syndicate to the configured IPFS RPC. Currently only Kubo IPFS
 /// backends are supported.
-pub fn start_ipfs_syndication<K, S>(
+pub fn start_ipfs_syndication<H, K, S>(
     ipfs_api: Url,
-) -> (
-    UnboundedSender<SyndicationJob<K, S>>,
-    JoinHandle<Result<()>>,
-)
+) -> (UnboundedSender<SyndicationJob<H>>, JoinHandle<Result<()>>)
 where
+    H: HasMutableSphereContext<K, S> + 'static,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -72,11 +63,12 @@ where
     (tx, tokio::task::spawn(ipfs_syndication_task(ipfs_api, rx)))
 }
 
-async fn ipfs_syndication_task<K, S>(
+async fn ipfs_syndication_task<H, K, S>(
     ipfs_api: Url,
-    mut receiver: UnboundedReceiver<SyndicationJob<K, S>>,
+    mut receiver: UnboundedReceiver<SyndicationJob<H>>,
 ) -> Result<()>
 where
+    H: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -101,7 +93,7 @@ where
         // syndication checkpoint for this Kubo node
         let (sphere_revision, ancestor_revision, mut syndicated_blocks, db) = {
             let db = {
-                let context = context.lock().await;
+                let context = context.sphere_context().await?;
                 context.db().clone()
             };
 

--- a/rust/noosphere-gateway/src/nns.rs
+++ b/rust/noosphere-gateway/src/nns.rs
@@ -56,12 +56,12 @@ pub enum NameSystemJob<C> {
     },
 }
 
-pub fn start_name_system<H, K, S>(
+pub fn start_name_system<C, K, S>(
     configuration: NameSystemConfiguration,
-    local_spheres: Vec<H>,
-) -> (UnboundedSender<NameSystemJob<H>>, JoinHandle<Result<()>>)
+    local_spheres: Vec<C>,
+) -> (UnboundedSender<NameSystemJob<C>>, JoinHandle<Result<()>>)
 where
-    H: HasMutableSphereContext<K, S> + 'static,
+    C: HasMutableSphereContext<K, S> + 'static,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -81,11 +81,11 @@ where
     (tx, task)
 }
 
-async fn periodic_resolver_task<H, K, S>(
-    tx: UnboundedSender<NameSystemJob<H>>,
-    local_spheres: Vec<H>,
+async fn periodic_resolver_task<C, K, S>(
+    tx: UnboundedSender<NameSystemJob<C>>,
+    local_spheres: Vec<C>,
 ) where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -103,12 +103,12 @@ async fn periodic_resolver_task<H, K, S>(
     }
 }
 
-pub async fn name_system_task<H, K, S>(
+pub async fn name_system_task<C, K, S>(
     configuration: NameSystemConfiguration,
-    mut receiver: UnboundedReceiver<NameSystemJob<H>>,
+    mut receiver: UnboundedReceiver<NameSystemJob<C>>,
 ) -> Result<()>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -227,13 +227,13 @@ where
 
 /// Consumes a stream of name / address tuples, resolving them one at a time
 /// and updating the provided [SphereContext] with the latest resolved values
-async fn resolve_all<H, K, S, N>(
+async fn resolve_all<C, K, S, N>(
     client: Arc<dyn NameSystemClient>,
-    mut context: H,
+    mut context: C,
     stream: N,
 ) -> Result<()>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
     N: Stream<Item = Result<(String, AddressIpld)>>,

--- a/rust/noosphere-gateway/src/nns.rs
+++ b/rust/noosphere-gateway/src/nns.rs
@@ -240,8 +240,10 @@ where
 {
     tokio::pin!(stream);
 
+    let db = context.sphere_context().await?.db().clone();
+
     while let Some((name, address)) = stream.try_next().await? {
-        let last_known_record = address.last_known_record.clone();
+        let last_known_record = address.get_proof(&db).await;
 
         let next_record =
             match resolve_record(client.clone(), name.clone(), address.identity.clone()).await? {
@@ -264,9 +266,7 @@ where
                     "Gateway adopting petname record for '{}' ({}): {}",
                     name, address.identity, record
                 );
-                context
-                    .adopt_petname(&name, &address.identity, record)
-                    .await?;
+                context.adopt_petname(&name, record).await?;
             }
             _ => continue,
         }

--- a/rust/noosphere-gateway/src/route/fetch.rs
+++ b/rust/noosphere-gateway/src/route/fetch.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 use axum::{extract::Query, http::StatusCode, response::IntoResponse, Extension};
 use cid::Cid;
+use libipld_cbor::DagCborCodec;
 use noosphere_api::data::{FetchParameters, FetchResponse};
 use noosphere_core::{
     authority::{SphereAction, SphereReference},
@@ -96,9 +97,8 @@ where
     match latest_local_sphere
         .get_links()
         .await?
-        .get(&scope.counterpart)
+        .get_as_cid::<DagCborCodec>(&scope.counterpart)
         .await?
-        .cloned()
     {
         Some(latest_counterpart_sphere_cid) => {
             debug!("Resolving oldest counterpart sphere version...");
@@ -107,7 +107,7 @@ where
                 Some(since_local_sphere_cid) => {
                     let since_local_sphere = Sphere::at(since_local_sphere_cid, db);
                     let links = since_local_sphere.get_links().await?;
-                    links.get(&scope.counterpart).await?.cloned()
+                    links.get_as_cid::<DagCborCodec>(&scope.counterpart).await?
                 }
                 None => None,
             };

--- a/rust/noosphere-gateway/src/route/fetch.rs
+++ b/rust/noosphere-gateway/src/route/fetch.rs
@@ -18,14 +18,14 @@ use ucan::{
 
 use crate::{authority::GatewayAuthority, extractor::Cbor, GatewayScope};
 
-pub async fn fetch_route<H, K, S>(
+pub async fn fetch_route<C, K, S>(
     authority: GatewayAuthority<K>,
     Query(FetchParameters { since }): Query<FetchParameters>,
     Extension(scope): Extension<GatewayScope>,
-    Extension(sphere_context): Extension<H>,
+    Extension(sphere_context): Extension<C>,
 ) -> Result<impl IntoResponse, StatusCode>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone,
     S: Storage,
 {

--- a/rust/noosphere-gateway/src/route/identify.rs
+++ b/rust/noosphere-gateway/src/route/identify.rs
@@ -10,13 +10,13 @@ use ucan::{
 
 use crate::{authority::GatewayAuthority, GatewayScope};
 
-pub async fn identify_route<H, K, S>(
+pub async fn identify_route<C, K, S>(
     authority: GatewayAuthority<K>,
     Extension(scope): Extension<GatewayScope>,
-    Extension(sphere_context): Extension<H>,
+    Extension(sphere_context): Extension<C>,
 ) -> Result<impl IntoResponse, StatusCode>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone,
     S: Storage,
 {

--- a/rust/noosphere-gateway/src/route/identify.rs
+++ b/rust/noosphere-gateway/src/route/identify.rs
@@ -1,11 +1,8 @@
-use std::sync::Arc;
-
 use axum::{http::StatusCode, response::IntoResponse, Extension, Json};
 use noosphere_api::data::IdentifyResponse;
 use noosphere_core::authority::{SphereAction, SphereReference};
-use noosphere_sphere::SphereContext;
-use noosphere_storage::NativeStorage;
-use tokio::sync::Mutex;
+use noosphere_sphere::HasSphereContext;
+use noosphere_storage::Storage;
 use ucan::{
     capability::{Capability, Resource, With},
     crypto::KeyMaterial,
@@ -13,11 +10,16 @@ use ucan::{
 
 use crate::{authority::GatewayAuthority, GatewayScope};
 
-pub async fn identify_route<K: KeyMaterial + Clone>(
+pub async fn identify_route<H, K, S>(
     authority: GatewayAuthority<K>,
     Extension(scope): Extension<GatewayScope>,
-    Extension(sphere_context): Extension<Arc<Mutex<SphereContext<K, NativeStorage>>>>,
-) -> Result<impl IntoResponse, StatusCode> {
+    Extension(sphere_context): Extension<H>,
+) -> Result<impl IntoResponse, StatusCode>
+where
+    H: HasSphereContext<K, S>,
+    K: KeyMaterial + Clone,
+    S: Storage,
+{
     debug!("Invoking identify route...");
 
     authority.try_authorize(&Capability {
@@ -29,7 +31,10 @@ pub async fn identify_route<K: KeyMaterial + Clone>(
         can: SphereAction::Fetch,
     })?;
 
-    let sphere_context = sphere_context.lock().await;
+    let sphere_context = sphere_context
+        .sphere_context()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let db = sphere_context.db();
     let gateway_key = &sphere_context.author().key;
     let gateway_authorization =

--- a/rust/noosphere-gateway/src/route/push.rs
+++ b/rust/noosphere-gateway/src/route/push.rs
@@ -24,16 +24,16 @@ use crate::{
 };
 
 // #[debug_handler]
-pub async fn push_route<H, K, S>(
+pub async fn push_route<C, K, S>(
     authority: GatewayAuthority<K>,
     ContentLengthLimit(Cbor(request_body)): ContentLengthLimit<Cbor<PushBody>, { 1024 * 5000 }>,
-    Extension(sphere_context): Extension<H>,
+    Extension(sphere_context): Extension<C>,
     Extension(gateway_scope): Extension<GatewayScope>,
-    Extension(syndication_tx): Extension<UnboundedSender<SyndicationJob<H>>>,
-    Extension(name_system_tx): Extension<UnboundedSender<NameSystemJob<H>>>,
+    Extension(syndication_tx): Extension<UnboundedSender<SyndicationJob<C>>>,
+    Extension(name_system_tx): Extension<UnboundedSender<NameSystemJob<C>>>,
 ) -> Result<Cbor<PushResponse>, StatusCode>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -67,24 +67,24 @@ where
     Ok(Cbor(gateway_push_routine.invoke().await?))
 }
 
-pub struct GatewayPushRoutine<H, K, S>
+pub struct GatewayPushRoutine<C, K, S>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    sphere_context: H,
+    sphere_context: C,
     gateway_scope: GatewayScope,
-    syndication_tx: UnboundedSender<SyndicationJob<H>>,
-    name_system_tx: UnboundedSender<NameSystemJob<H>>,
+    syndication_tx: UnboundedSender<SyndicationJob<C>>,
+    name_system_tx: UnboundedSender<NameSystemJob<C>>,
     request_body: PushBody,
     key_type: PhantomData<K>,
     storage_type: PhantomData<S>,
 }
 
-impl<H, K, S> GatewayPushRoutine<H, K, S>
+impl<C, K, S> GatewayPushRoutine<C, K, S>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-into/Cargo.toml
+++ b/rust/noosphere-into/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = "^1"
 
 horrorshow = "~0.8"
 cid = "~0.9"
+libipld-cbor = "~0.15"
 
 bytes = "^1"
 tokio-stream = "~0.1"

--- a/rust/noosphere-into/src/into/html/sphere.rs
+++ b/rust/noosphere-into/src/into/html/sphere.rs
@@ -19,9 +19,9 @@ static DEFAULT_STYLES: &[u8] = include_bytes!("./static/styles.css");
 /// Given a sphere [Did], [SphereDb] and a [WriteTarget], produce rendered HTML
 /// output up to and including the complete historical revisions of the
 /// slug-named content of the sphere.
-pub async fn sphere_into_html<H, K, S, W>(sphere_context: H, write_target: &W) -> Result<()>
+pub async fn sphere_into_html<C, K, S, W>(sphere_context: C, write_target: &W) -> Result<()>
 where
-    H: HasSphereContext<K, S> + 'static,
+    C: HasSphereContext<K, S> + 'static,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
     W: WriteTarget + 'static,

--- a/rust/noosphere-into/src/transform/sphere/html.rs
+++ b/rust/noosphere-into/src/transform/sphere/html.rs
@@ -9,12 +9,12 @@ use ucan::crypto::KeyMaterial;
 
 /// Given a [Transform] and a [Sphere], produce a stream that yields the file
 /// content as an HTML document
-pub fn sphere_to_html_document_stream<H, K, S, T>(
-    context: H,
+pub fn sphere_to_html_document_stream<C, K, S, T>(
+    context: C,
     transform: T,
 ) -> impl Stream<Item = String>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
     T: Transform,

--- a/rust/noosphere-sphere/src/content/read.rs
+++ b/rust/noosphere-sphere/src/content/read.rs
@@ -46,7 +46,7 @@ where
         let hamt = links.get_hamt().await?;
 
         Ok(match hamt.get(&slug.to_string()).await? {
-            Some(content_cid) => Some(self.get_file(&revision, content_cid).await?),
+            Some(memo) => Some(self.get_file(&revision, memo.clone()).await?),
             None => None,
         })
     }

--- a/rust/noosphere-sphere/src/content/read.rs
+++ b/rust/noosphere-sphere/src/content/read.rs
@@ -32,9 +32,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> SphereContentRead<K, S> for H
+impl<C, K, S> SphereContentRead<K, S> for C
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-sphere/src/content/write.rs
+++ b/rust/noosphere-sphere/src/content/write.rs
@@ -74,11 +74,18 @@ where
     async fn link_raw(&mut self, slug: &str, cid: &Cid) -> Result<()> {
         self.assert_write_access().await?;
 
+        let memo = self
+            .sphere_context()
+            .await?
+            .db()
+            .load::<DagCborCodec, _>(cid)
+            .await?;
+
         self.sphere_context_mut()
             .await?
             .mutation_mut()
             .links_mut()
-            .set(&slug.into(), cid);
+            .set(&slug.into(), &memo);
 
         Ok(())
     }

--- a/rust/noosphere-sphere/src/content/write.rs
+++ b/rust/noosphere-sphere/src/content/write.rs
@@ -65,9 +65,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> SphereContentWrite<K, S> for H
+impl<C, K, S> SphereContentWrite<K, S> for C
 where
-    H: HasSphereContext<K, S> + HasMutableSphereContext<K, S>,
+    C: HasSphereContext<K, S> + HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-sphere/src/cursor.rs
+++ b/rust/noosphere-sphere/src/cursor.rs
@@ -19,27 +19,27 @@ use crate::SphereContext;
 /// implementor of [HasSphereContext] and mount it to a specific version of the
 /// sphere.
 #[derive(Clone)]
-pub struct SphereCursor<H, K, S>
+pub struct SphereCursor<C, K, S>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    has_sphere_context: H,
+    has_sphere_context: C,
     key: PhantomData<K>,
     storage: PhantomData<S>,
     sphere_version: Option<Cid>,
 }
 
-impl<H, K, S> SphereCursor<H, K, S>
+impl<C, K, S> SphereCursor<C, K, S>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Same as [SphereCursor::mount], but mounts the [SphereCursor] to a known
     /// version of the history of the sphere.
-    pub fn mounted_at(has_sphere_context: H, sphere_version: &Cid) -> Self {
+    pub fn mounted_at(has_sphere_context: C, sphere_version: &Cid) -> Self {
         SphereCursor {
             has_sphere_context,
             key: PhantomData,
@@ -77,7 +77,7 @@ where
     /// sphere, mounted to that version. If the latest version changes due to
     /// effects in the distance, the cursor will still point to the same version
     /// it referred to when it was created.
-    pub async fn mounted(has_sphere_context: H) -> Result<Self> {
+    pub async fn mounted(has_sphere_context: C) -> Result<Self> {
         // let sphere_version = has_sphere_context.sphere_context().await?.head().await?;
         let mut cursor = Self::latest(has_sphere_context);
         cursor.mount().await?;
@@ -87,7 +87,7 @@ where
     /// Create this [SphereCursor] at the latest local version of the associated
     /// sphere. The [SphereCursor] will always point to the latest local
     /// version, unless subsequently mounted.
-    pub fn latest(has_sphere_context: H) -> Self {
+    pub fn latest(has_sphere_context: C) -> Self {
         SphereCursor {
             has_sphere_context,
             key: PhantomData,
@@ -116,13 +116,13 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> HasMutableSphereContext<K, S> for SphereCursor<H, K, S>
+impl<C, K, S> HasMutableSphereContext<K, S> for SphereCursor<C, K, S>
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage,
 {
-    type MutableSphereContext = H::MutableSphereContext;
+    type MutableSphereContext = C::MutableSphereContext;
 
     async fn sphere_context_mut(&mut self) -> Result<Self::MutableSphereContext> {
         self.has_sphere_context.sphere_context_mut().await
@@ -141,13 +141,13 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> HasSphereContext<K, S> for SphereCursor<H, K, S>
+impl<C, K, S> HasSphereContext<K, S> for SphereCursor<C, K, S>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    type SphereContext = H::SphereContext;
+    type SphereContext = C::SphereContext;
 
     async fn sphere_context(&self) -> Result<Self::SphereContext> {
         self.has_sphere_context.sphere_context().await
@@ -163,13 +163,13 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<'a, H, K, S> HasSphereContext<K, S> for &'a SphereCursor<H, K, S>
+impl<'a, C, K, S> HasSphereContext<K, S> for &'a SphereCursor<C, K, S>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    type SphereContext = H::SphereContext;
+    type SphereContext = C::SphereContext;
 
     async fn sphere_context(&self) -> Result<Self::SphereContext> {
         self.has_sphere_context.sphere_context().await

--- a/rust/noosphere-sphere/src/internal.rs
+++ b/rust/noosphere-sphere/src/internal.rs
@@ -37,9 +37,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> SphereContextInternal<K, S> for H
+impl<C, K, S> SphereContextInternal<K, S> for C
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-sphere/src/internal.rs
+++ b/rust/noosphere-sphere/src/internal.rs
@@ -3,7 +3,7 @@ use crate::{AsyncFileBody, HasSphereContext};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use libipld_cbor::DagCborCodec;
-use noosphere_storage::{BlockStore, Storage};
+use noosphere_storage::{block_serialize, Storage};
 use std::str::FromStr;
 use tokio_util::io::StreamReader;
 use ucan::crypto::KeyMaterial;
@@ -31,7 +31,7 @@ where
     async fn get_file(
         &self,
         sphere_revision: &Cid,
-        memo_revision: &Cid,
+        memo: MemoIpld,
     ) -> Result<SphereFile<Box<dyn AsyncFileBody>>>;
 }
 
@@ -56,14 +56,10 @@ where
     async fn get_file(
         &self,
         sphere_revision: &Cid,
-        memo_revision: &Cid,
+        memo: MemoIpld,
     ) -> Result<SphereFile<Box<dyn AsyncFileBody>>> {
         let sphere_context = self.sphere_context().await?;
-
-        let memo = sphere_context
-            .db()
-            .load::<DagCborCodec, MemoIpld>(memo_revision)
-            .await?;
+        let (memo_version, _) = block_serialize::<DagCborCodec, _>(&memo)?;
         let content_type = match memo.get_first_header(&Header::ContentType.to_string()) {
             Some(content_type) => Some(ContentType::from_str(content_type.as_str())?),
             None => None,
@@ -78,7 +74,7 @@ where
         Ok(SphereFile {
             sphere_identity: sphere_context.identity().clone(),
             sphere_version: *sphere_revision,
-            memo_version: *memo_revision,
+            memo_version,
             memo,
             // NOTE: we have to box here because traits don't support `impl` types in return values
             contents: Box::new(StreamReader::new(stream)),

--- a/rust/noosphere-sphere/src/petname/read.rs
+++ b/rust/noosphere-sphere/src/petname/read.rs
@@ -49,7 +49,7 @@ where
         trace!("Recorded address for {name}: {:?}", address_ipld);
 
         Ok(match address_ipld {
-            Some(address) => address.dereference().await,
+            Some(address) => address.dereference(self.sphere_context().await?.db()).await,
             None => None,
         })
     }

--- a/rust/noosphere-sphere/src/petname/read.rs
+++ b/rust/noosphere-sphere/src/petname/read.rs
@@ -27,9 +27,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> SpherePetnameRead<K, S> for H
+impl<C, K, S> SpherePetnameRead<K, S> for C
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-sphere/src/petname/write.rs
+++ b/rust/noosphere-sphere/src/petname/write.rs
@@ -32,9 +32,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> SpherePetnameWrite<K, S> for H
+impl<C, K, S> SpherePetnameWrite<K, S> for C
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-sphere/src/petname/write.rs
+++ b/rust/noosphere-sphere/src/petname/write.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use noosphere_core::data::{AddressIpld, Did, Jwt};
 use noosphere_storage::Storage;
-use ucan::crypto::KeyMaterial;
+use ucan::{crypto::KeyMaterial, store::UcanJwtStore, Ucan};
 
 use crate::{internal::SphereContextInternal, HasMutableSphereContext, SpherePetnameRead};
 
@@ -27,12 +27,7 @@ where
     /// associated [Jwt] to a known value. The [Jwt] must be a valid UCAN that
     /// publishes a name record and grants sufficient authority from the
     /// configured [Did] to the publisher.
-    async fn adopt_petname(
-        &mut self,
-        name: &str,
-        identity: &Did,
-        record: &Jwt,
-    ) -> Result<Option<Did>>;
+    async fn adopt_petname(&mut self, name: &str, record: &Jwt) -> Result<Option<Did>>;
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -69,16 +64,22 @@ where
         Ok(())
     }
 
-    async fn adopt_petname(
-        &mut self,
-        name: &str,
-        identity: &Did,
-        record: &Jwt,
-    ) -> Result<Option<Did>> {
+    async fn adopt_petname(&mut self, name: &str, record: &Jwt) -> Result<Option<Did>> {
         self.assert_write_access().await?;
+
+        let ucan = Ucan::try_from(record.as_str())?;
+        let identity = Did::from(ucan.audience());
+
+        let cid = self
+            .sphere_context_mut()
+            .await?
+            .db_mut()
+            .write_token(record)
+            .await?;
 
         // TODO: Verify that a record for an existing address is actually newer than the old one
         // TODO: Validate the record as a UCAN
+
         debug!(
             "Adopting '{}' ({}), resolving to {}...",
             name, identity, record
@@ -86,7 +87,7 @@ where
 
         let new_address = AddressIpld {
             identity: identity.clone(),
-            last_known_record: Some(record.clone()),
+            last_known_record: Some(cid),
         };
 
         let names = self
@@ -106,7 +107,7 @@ where
 
         match previous_address {
             Some(previous_address) => {
-                if identity != &previous_address.identity {
+                if identity != previous_address.identity {
                     return Ok(Some(previous_address.identity.to_owned()));
                 }
             }

--- a/rust/noosphere-sphere/src/sync/mod.rs
+++ b/rust/noosphere-sphere/src/sync/mod.rs
@@ -26,9 +26,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<H, K, S> SphereSync<K, S> for H
+impl<C, K, S> SphereSync<K, S> for C
 where
-    H: HasMutableSphereContext<K, S>,
+    C: HasMutableSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {

--- a/rust/noosphere-sphere/src/walker.rs
+++ b/rust/noosphere-sphere/src/walker.rs
@@ -180,11 +180,11 @@ where
         try_stream! {
             let sphere = self.has_sphere_context.to_sphere().await?;
             let links = sphere.get_links().await?;
-            let stream = links.stream().await?;
+            let stream = links.into_stream().await?;
 
             for await entry in stream {
-                let (key, memo_revision) = entry?;
-                let file = self.has_sphere_context.get_file(sphere.cid(), memo_revision).await?;
+                let (key, memo) = entry?;
+                let file = self.has_sphere_context.get_file(sphere.cid(), memo).await?;
 
                 yield (key.clone(), file);
             }
@@ -201,11 +201,11 @@ where
         try_stream! {
             let sphere = self.has_sphere_context.to_sphere().await?;
             let links = sphere.get_links().await?;
-            let stream = links.stream().await?;
+            let stream = links.into_stream().await?;
 
             for await entry in stream {
-                let (key, memo_revision) = entry?;
-                let file = self.has_sphere_context.get_file(sphere.cid(), memo_revision).await?;
+                let (key, memo) = entry?;
+                let file = self.has_sphere_context.get_file(sphere.cid(), memo).await?;
 
                 yield (key.clone(), file);
             }

--- a/rust/noosphere-sphere/src/walker.rs
+++ b/rust/noosphere-sphere/src/walker.rs
@@ -19,24 +19,24 @@ use crate::{
 /// [HasSphereContext] into an async [Stream] over sphere content, allowing
 /// incremental iteration over both the breadth of content at any version, or
 /// the depth of changes over a range of history.
-pub struct SphereWalker<H, K, S>
+pub struct SphereWalker<C, K, S>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    has_sphere_context: H,
+    has_sphere_context: C,
     key: PhantomData<K>,
     storage: PhantomData<S>,
 }
 
-impl<H, K, S> From<H> for SphereWalker<H, K, S>
+impl<C, K, S> From<C> for SphereWalker<C, K, S>
 where
-    H: HasSphereContext<K, S>,
+    C: HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    fn from(has_sphere_context: H) -> Self {
+    fn from(has_sphere_context: C) -> Self {
         SphereWalker {
             has_sphere_context,
             key: Default::default(),
@@ -45,9 +45,9 @@ where
     }
 }
 
-impl<H, K, S> SphereWalker<H, K, S>
+impl<C, K, S> SphereWalker<C, K, S>
 where
-    H: SpherePetnameRead<K, S> + HasSphereContext<K, S>,
+    C: SpherePetnameRead<K, S> + HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
@@ -165,9 +165,9 @@ where
     }
 }
 
-impl<H, K, S> SphereWalker<H, K, S>
+impl<C, K, S> SphereWalker<C, K, S>
 where
-    H: SphereContentRead<K, S> + HasSphereContext<K, S>,
+    C: SphereContentRead<K, S> + HasSphereContext<K, S>,
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {


### PR DESCRIPTION
This change is a precursor to #269 . It represents two important revisions that clean things up to prepare for sphere traversal.

 1. The gateway is now generic to the storage type and sphere context provider it supports
 2. Sphere link values are now `MemoIpld` instead of `Cid`

(1) enables us to pass in an `IpfsStorage`-wrapped storage to the gateway without changing the underlying implementation to be aware of it.

(2) aligns links with the way we store other constructs (like petnames and authorizations), and enables us to clean up a gross corner of how we determine what must be bundled for a given sphere revision to be transferred over the network.