### PR TITLE
feat: Improve "orb" error messaging when sphere directory is expected and does not exist

### DIFF
--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -24,7 +24,7 @@ noosphere-ns = { version = "0.5.0", path = "../noosphere-ns" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tempfile = "^3"
-clap = { version = "^4", features = ["derive", "cargo"] }
+clap = { version = "^4.1", features = ["derive", "cargo"] }
 anyhow = "^1"
 
 tokio = { version = "^1", features = ["full"] }

--- a/rust/noosphere-cli/src/native/commands/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/auth.rs
@@ -21,6 +21,7 @@ use tokio_stream::StreamExt;
 use crate::native::workspace::Workspace;
 
 pub async fn auth_add(did: &str, name: Option<String>, workspace: &Workspace) -> Result<Cid> {
+    workspace.ensure_sphere_initialized()?;
     let sphere_did = workspace.sphere_identity().await?;
     let mut db = workspace.db().await?;
 
@@ -192,6 +193,7 @@ pub async fn auth_list(as_json: bool, workspace: &Workspace) -> Result<()> {
 }
 
 pub async fn auth_revoke(name: &str, workspace: &Workspace) -> Result<()> {
+    workspace.ensure_sphere_initialized()?;
     let sphere_did = workspace.sphere_identity().await?;
     let mut db = workspace.db().await?;
 

--- a/rust/noosphere-cli/src/native/commands/config.rs
+++ b/rust/noosphere-cli/src/native/commands/config.rs
@@ -57,6 +57,7 @@ impl<'a> Config<'a> {
 }
 
 pub async fn config_set(command: ConfigSetCommand, workspace: &Workspace) -> Result<()> {
+    workspace.ensure_sphere_initialized()?;
     let context = workspace.sphere_context().await?;
     let context = context.lock().await;
 
@@ -72,6 +73,7 @@ pub async fn config_set(command: ConfigSetCommand, workspace: &Workspace) -> Res
 }
 
 pub async fn config_get(command: ConfigGetCommand, workspace: &Workspace) -> Result<()> {
+    workspace.ensure_sphere_initialized()?;
     let context = workspace.sphere_context().await?;
     let context = context.lock().await;
 

--- a/rust/noosphere-cli/src/native/commands/save.rs
+++ b/rust/noosphere-cli/src/native/commands/save.rs
@@ -10,6 +10,8 @@ use crate::native::workspace::{FileReference, Workspace};
 /// TODO(#105): We may want to change this to take an optional list of paths to
 /// consider, and allow the user to rely on their shell for glob filtering
 pub async fn save(workspace: &Workspace) -> Result<()> {
+    workspace.ensure_sphere_initialized()?;
+
     let mut memory_store = MemoryStore::default();
     let mut db = workspace.db().await?;
 

--- a/rust/noosphere-cli/src/native/commands/serve.rs
+++ b/rust/noosphere-cli/src/native/commands/serve.rs
@@ -16,6 +16,8 @@ pub async fn serve(
     cors_origin: Option<Url>,
     workspace: &Workspace,
 ) -> Result<()> {
+    workspace.ensure_sphere_initialized()?;
+
     let listener = TcpListener::bind((interface, port))?;
 
     let counterpart = workspace.counterpart_identity().await?;

--- a/rust/noosphere-cli/src/native/commands/sphere.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere.rs
@@ -10,12 +10,7 @@ use noosphere_sphere::SphereContext;
 use ucan::crypto::KeyMaterial;
 
 pub async fn sphere_create(owner_key: &str, workspace: &Workspace) -> Result<()> {
-    if workspace.sphere_directory().exists() {
-        return Err(anyhow!(
-            "A sphere is already initialized in {:?}",
-            workspace.root_directory()
-        ));
-    }
+    workspace.ensure_sphere_uninitialized()?;
 
     let sphere_context_artifacts = SphereContextBuilder::default()
         .create_sphere()
@@ -56,12 +51,7 @@ pub async fn sphere_join(
     sphere_identity: &Did,
     workspace: &Workspace,
 ) -> Result<()> {
-    if workspace.sphere_directory().exists() {
-        return Err(anyhow!(
-            "A sphere is already initialized in {:?}",
-            workspace.root_directory()
-        ));
-    }
+    workspace.ensure_sphere_uninitialized()?;
     println!("Joining sphere {}...", sphere_identity);
 
     let did = {

--- a/rust/noosphere-cli/src/native/commands/status.rs
+++ b/rust/noosphere-cli/src/native/commands/status.rs
@@ -26,6 +26,8 @@ pub fn status_section(
 }
 
 pub async fn status(workspace: &Workspace) -> Result<()> {
+    workspace.ensure_sphere_initialized()?;
+
     let identity = workspace.sphere_identity().await?;
 
     println!("This sphere's identity is {identity}");

--- a/rust/noosphere-cli/src/native/commands/sync.rs
+++ b/rust/noosphere-cli/src/native/commands/sync.rs
@@ -1,11 +1,10 @@
 use crate::native::workspace::Workspace;
 use anyhow::{anyhow, Result};
-use noosphere_core::tracing::initialize_tracing;
 use noosphere_sphere::SphereSync;
 use noosphere_storage::MemoryStore;
 
 pub async fn sync(workspace: &Workspace) -> Result<()> {
-    initialize_tracing();
+    workspace.ensure_sphere_initialized()?;
 
     let mut memory_store = MemoryStore::default();
 

--- a/rust/noosphere-cli/src/native/mod.rs
+++ b/rust/noosphere-cli/src/native/mod.rs
@@ -3,7 +3,7 @@ pub mod workspace;
 
 use anyhow::Result;
 
-use noosphere_core::data::Did;
+use noosphere_core::{data::Did, tracing::initialize_tracing};
 use std::ffi::OsString;
 
 use std::net::IpAddr;
@@ -192,6 +192,7 @@ pub enum KeyCommand {
     },
 
     /// Print the pet name and DID for all available keys
+    #[clap(alias = "ls")]
     List {
         /// Output the list of available keys as formatted JSON
         #[clap(short = 'j', long)]
@@ -268,6 +269,7 @@ pub enum AuthCommand {
 }
 
 pub async fn main() -> Result<()> {
+    initialize_tracing();
     let args = Cli::parse();
 
     let current_working_directory = std::env::current_dir()?;

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -150,6 +150,26 @@ impl Workspace {
         Ok(context.identity().clone())
     }
 
+    pub fn ensure_sphere_initialized(&self) -> Result<()> {
+        match self.sphere_directory().exists() {
+            false => Err(anyhow!(
+                "No sphere initialized in {:?}",
+                self.root_directory()
+            )),
+            true => Ok(()),
+        }
+    }
+
+    pub fn ensure_sphere_uninitialized(&self) -> Result<()> {
+        match self.sphere_directory().exists() {
+            true => Err(anyhow!(
+                "A sphere is already initialized in {:?}",
+                self.root_directory()
+            )),
+            false => Ok(()),
+        }
+    }
+
     /// Returns true if the given path has a .sphere folder in it
     fn has_sphere_directory(path: &Path) -> bool {
         path.is_absolute() && path.join(SPHERE_DIRECTORY).is_dir()


### PR DESCRIPTION
 ...and other orb papercuts.
* Prevents ambitious creation of an uninitialized ".sphere" dir that lacks a "user_key_name", fixing #232. (thus causing many phantom `.sphere` dirs)
* Updates and constrains "clap" to match "noosphere-ns".
* Adds a hidden alias of "ls" to "list" in "orb" e.g. "orb key ls".
* Hoists tracing utility to native::main