### PR TITLE
chore: additional work on FFI documentation.

### DIFF
--- a/docs/api/build_c.sh
+++ b/docs/api/build_c.sh
@@ -7,5 +7,5 @@ cargo run --features=headers --example generate_header
 cp noosphere.h "$SCRIPT_DIR/noosphere.h"
 cd "$SCRIPT_DIR"
 
-doxygen noosphere.doxygen
+doxygen ./doxyfile
 rm "$SCRIPT_DIR/noosphere.h"

--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -517,7 +517,7 @@ EXTRACT_STATIC         = NO
 # for Java sources.
 # The default value is: YES.
 
-EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_CLASSES  = NO 
 
 # This flag is only useful for Objective-C code. If set to YES, local methods,
 # which are defined in the implementation section but not in the interface are
@@ -648,7 +648,7 @@ SORT_MEMBER_DOCS       = YES
 # this will also influence the order of the classes in the class list.
 # The default value is: NO.
 
-SORT_BRIEF_DOCS        = NO
+SORT_BRIEF_DOCS        = YES
 
 # If the SORT_MEMBERS_CTORS_1ST tag is set to YES then doxygen will sort the
 # (brief and detailed) documentation of class members so that constructors and
@@ -667,7 +667,7 @@ SORT_MEMBERS_CTORS_1ST = NO
 # appear in their defined order.
 # The default value is: NO.
 
-SORT_GROUP_NAMES       = NO
+SORT_GROUP_NAMES       = YES
 
 # If the SORT_BY_SCOPE_NAME tag is set to YES, the class list will be sorted by
 # fully-qualified names, including namespaces. If set to NO, the class list will

--- a/docs/api/doxygen_index.md
+++ b/docs/api/doxygen_index.md
@@ -1,7 +1,15 @@
 # Noosphere
 
-Documentation for [Noosphere]'s C API.
+Documentation for [Noosphere]'s C API and FFI layer.
 
-* [noosphere.h](noosphere_8h.html)
+See an [example case](https://github.com/subconsciousnetwork/noosphere/blob/main/c/example/main.c) in the repository.
+
+## Overview
+
+All functions in noosphere.h return owned data, unless otherwise specified.
+That means you _must_ manually release all data returned by these functions,
+using the corresponding "free" function, e.g. `ns_string_free()` to release
+a `char *` returned from a Noosphere function.
 
 [Noosphere]: https://github.com/subconsciousnetwork/noosphere
+

--- a/rust/noosphere-core/src/data/strings.rs
+++ b/rust/noosphere-core/src/data/strings.rs
@@ -101,8 +101,8 @@ macro_rules! string_coherent {
 /// resolved into a so-called DID Document, usually in order to obtain PKI
 /// details related to a particular user or process.
 ///
-/// See: https://en.wikipedia.org/wiki/Decentralized_identifier
-/// See: https://www.w3.org/TR/did-core/
+/// See: <https://en.wikipedia.org/wiki/Decentralized_identifier>
+/// See: <https://www.w3.org/TR/did-core/>
 #[repr(transparent)]
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Did(pub String);
@@ -113,8 +113,8 @@ string_coherent!(Did);
 /// particular format of JSON and an associated signature, commonly used for
 /// authorization flows on the web, but notably also used by the UCAN spec.
 ///
-/// See: https://jwt.io/
-/// See: https://ucan.xyz/
+/// See: <https://jwt.io/>
+/// See: <https://ucan.xyz/>
 #[repr(transparent)]
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Jwt(pub String);
@@ -124,7 +124,7 @@ string_coherent!(Jwt);
 /// A BIP39-compatible mnemonic phrase that represents the data needed to
 /// recover the private half of a cryptographic key pair.
 ///
-/// See: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+/// See: <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki>
 #[repr(transparent)]
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Mnemonic(pub String);

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -15,6 +15,8 @@ use noosphere_storage::BlockStore;
 
 #[cfg(doc)]
 use crate::view::Sphere;
+#[cfg(doc)]
+use crate::data::Did;
 
 /// A [SphereRevision] represents a new, unsigned version of a [Sphere]. A
 /// [SphereRevision] must be signed as a final step before the [Cid] of a new

--- a/rust/noosphere-into/src/transcluder/content.rs
+++ b/rust/noosphere-into/src/transcluder/content.rs
@@ -10,7 +10,7 @@ use subtext::{block::Block, primitive::Entity, Peer};
 use tokio_stream::StreamExt;
 use ucan::crypto::KeyMaterial;
 
-/// A [Transcluder] implementation that uses [SphereFs] to resolve the content
+/// A [Transcluder] implementation that uses [HasSphereContext] to resolve the content
 /// being transcluded.
 #[derive(Clone)]
 pub struct SphereContentTranscluder<R, K, S>

--- a/rust/noosphere-sphere/src/context.rs
+++ b/rust/noosphere-sphere/src/context.rs
@@ -18,6 +18,9 @@ use url::Url;
 
 use crate::metadata::GATEWAY_URL;
 
+#[cfg(doc)]
+use crate::has::HasSphereContext;
+
 /// A [SphereContext] is an accessor construct over locally replicated sphere
 /// data. It embodies both the storage layer that contains the sphere's data
 /// as the information needed to verify a user's intended level of access to
@@ -255,7 +258,7 @@ where
     }
 
     /// Get a [Sphere] view over the current sphere's latest revision. This view
-    /// offers lower-level access than [SphereFs], but includes affordances to
+    /// offers lower-level access than [HasSphereContext], but includes affordances to
     /// help tranversing and manipulating IPLD structures that are more
     /// convenient than working directly with raw data.
     pub async fn sphere(&self) -> Result<Sphere<SphereDb<S>>> {

--- a/rust/noosphere-storage/src/block.rs
+++ b/rust/noosphere-storage/src/block.rs
@@ -16,6 +16,9 @@ use libipld_core::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 
+#[cfg(doc)]
+use serde::Deserialize;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub trait BlockStoreSendSync: Send + Sync {}
 

--- a/rust/noosphere/src/ffi/error.rs
+++ b/rust/noosphere/src/ffi/error.rs
@@ -48,20 +48,23 @@ impl TryOrInitialize<repr_c::Box<NsError>> for Option<Out<'_, repr_c::Box<NsErro
 #[derive_ReprC(rename = "ns_error")]
 #[repr(opaque)]
 /// @class ns_error_t
-///
-/// An error class.
+/// An opaque struct representing an error.
 pub struct NsError {
     inner: NoosphereError,
 }
 
 #[ffi_export]
-/// De-allocate an [NsError]
+/// @memberof ns_error_t
+/// Deallocate an ns_error_t.
 pub fn ns_error_free(error: repr_c::Box<NsError>) {
     drop(error)
 }
 
 #[ffi_export]
-/// Returns a string message that describes the error in greater detail.
+/// @memberof ns_error_t
+/// Returns an owned string describing the error in greater detail.
+///
+/// Caller is responsible for deallocating returned string via ns_string_free.
 pub fn ns_error_string(error: &NsError) -> char_p::Box {
     error
         .inner

--- a/rust/noosphere/src/ffi/headers.rs
+++ b/rust/noosphere/src/ffi/headers.rs
@@ -3,8 +3,9 @@ use safer_ffi::prelude::*;
 #[derive_ReprC(rename = "ns_headers")]
 #[repr(opaque)]
 /// @class ns_headers_t
+/// An opaque struct representing name/value headers.
 ///
-/// TBD
+/// Headers are used in ns_sphere_file_t to assign metadata, like content type.
 pub struct NsHeaders {
     inner: Vec<(String, String)>,
 }
@@ -20,20 +21,25 @@ impl NsHeaders {
 }
 
 #[ffi_export]
-/// Create a [NsHeaders] buffer for the purpose of building up a set of headers
+/// @memberof ns_headers_t
+/// Allocate and initialize a ns_headers_t instance with no values.
+///
+/// Used for the purpose of building up a set of headers
 /// intended to be added to a memo before it is written to a sphere
 pub fn ns_headers_create() -> repr_c::Box<NsHeaders> {
     Box::new(NsHeaders { inner: Vec::new() }).into()
 }
 
 #[ffi_export]
-/// Add a name/value pair to an [NsHeaders] buffer
+/// @memberof ns_headers_t
+/// Add a name/value pair to a ns_headers_t instance.
 pub fn ns_headers_add(headers: &mut NsHeaders, name: char_p::Ref<'_>, value: char_p::Ref<'_>) {
     headers.inner.push((name.to_string(), value.to_string()))
 }
 
 #[ffi_export]
-/// De-allocate an [NsHeaders] buffer
+/// @memberof ns_headers_t
+/// Deallocate a ns_headers_t instance.
 pub fn ns_headers_free(headers: repr_c::Box<NsHeaders>) {
     drop(headers)
 }

--- a/rust/noosphere/src/ffi/noosphere.rs
+++ b/rust/noosphere/src/ffi/noosphere.rs
@@ -14,8 +14,7 @@ use crate::{
 #[derive_ReprC(rename = "ns_noosphere")]
 #[repr(opaque)]
 /// @class ns_noosphere_t
-///
-/// Core noosphere class.
+/// Root noosphere context, entrypoint of the Noosphere API.
 pub struct NsNoosphere {
     inner: NoosphereContext,
     async_runtime: Arc<TokioRuntime>,
@@ -58,24 +57,18 @@ impl NsNoosphere {
 }
 
 #[ffi_export]
-/// Initialize a [NoosphereContext] and return a boxed pointer to it. This is
-/// the entrypoint to the Noosphere API, and the returned pointer is used to
-/// invoke almost all other API functions.
+/// @memberof ns_noosphere_t
+/// Initialize a ns_noosphere_t instance.
 ///
-/// In order to initialize the [NoosphereContext], you must provide two
+/// In order to initialize the ns_noosphere_t, you must provide two
 /// namespace strings: one for "global" Noosphere configuration, and another for
 /// sphere storage. Note that at this time "global" configuration is only used
 /// for insecure, on-disk key storage and we will probably deprecate such
 /// configuration at a future date.
 ///
-/// You can also initialize the [NoosphereContext] with an optional third
+/// You can also initialize the ns_noosphere_t with an optional third
 /// argument: a URL string that refers to a Noosphere Gateway API somewhere on
 /// the network that one or more local spheres may have access to.
-///
-/// For this and all other ns_* functions that return a pointer, the pointer
-/// should be considered to refer to owned data unless specified otherwise in
-/// documentation. This means that you _must_ manually free all data given to
-/// you by the FFI (using the appropriate ns-prefixed "free" function).
 pub fn ns_initialize(
     global_storage_path: char_p::Ref<'_>,
     sphere_storage_path: char_p::Ref<'_>,
@@ -98,26 +91,29 @@ pub fn ns_initialize(
 }
 
 #[ffi_export]
-/// De-allocate a [NoosphereContext]. Note that this will also drop every
-/// [SphereContext] that remains active within the [NoosphereContext].
+/// @memberof ns_noosphere_t
+/// Deallocate a ns_noosphere_t instance.
+///
+/// Note that this will also deallocate every ns_sphere_t that remains
+/// active within the ns_noosphere_t.
 pub fn ns_free(noosphere: repr_c::Box<NsNoosphere>) {
     drop(noosphere)
 }
 
 #[ffi_export]
-/// De-allocate a Noosphere-allocated byte array
+/// Deallocate a Noosphere-allocated byte array.
 pub fn ns_bytes_free(bytes: c_slice::Box<u8>) {
     drop(bytes)
 }
 
 #[ffi_export]
-/// De-allocate a Noosphere-allocated string
+/// Deallocate a Noosphere-allocated string.
 pub fn ns_string_free(string: char_p::Box) {
     drop(string)
 }
 
 #[ffi_export]
-/// De-allocate a Noosphere-allocated array of strings
+/// Deallocate a Noosphere-allocated array of strings.
 pub fn ns_string_array_free(string_array: c_slice::Box<char_p::Box>) {
     drop(string_array)
 }

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -12,8 +12,10 @@ use crate::ffi::{NsError, TryOrInitialize};
 use super::{NsNoosphere, NsSphere};
 
 #[ffi_export]
-/// Returns true if the given petname has been assigned to a sphere identity. If
-/// it returns false, it implies one of the following: the petname has never
+/// @memberof ns_sphere_t
+/// Whether the given petname has been assigned to a sphere identity.
+///
+/// If return value is `0`, it implies one of the following: the petname has never
 /// been assigned to any sphere identity, _or_ it was previously assigned to a
 /// sphere identity at least once but has since been unassigned.
 pub fn ns_sphere_petname_is_set(
@@ -41,8 +43,11 @@ pub fn ns_sphere_petname_is_set(
 }
 
 #[ffi_export]
-/// Get the sphere identity - a DID - that the given petname is assigned to in
-/// the sphere. Note that this call will produce an error if the petname has not
+/// @memberof ns_sphere_t
+/// Get the sphere identity as a DID that the given petname is assigned to in
+/// the sphere.
+///
+/// This call will produce an error if the petname has not
 /// been assigned to a sphere identity (or was previously assigned to a sphere
 /// identity but has since been unassigned).
 pub fn ns_sphere_petname_get(
@@ -66,9 +71,11 @@ pub fn ns_sphere_petname_get(
 }
 
 #[ffi_export]
-/// Assign a petname to a sphere identity (a DID). This will overwrite the
-/// petname so that it is assigned to the new sphere identity if it had been
-/// assigned to a different sphere identity previously.
+/// @memberof ns_sphere_t
+/// Assign a petname to a sphere identity (a DID).
+///
+/// This will overwrite the petname so that it is assigned to the new sphere
+/// identity if it had been assigned to a different sphere identity previously.
 ///
 /// When a petname is assigned to a new sphere identity, its entry in the
 /// address book will be set to an unresolved state. You may pass null as the
@@ -99,8 +106,11 @@ pub fn ns_sphere_petname_set(
 }
 
 #[ffi_export]
-/// Resolve a configured petname, using the sphere identity that it is assigned
-/// to and determining a link - a CID - that is associated with it. The returned
+/// @memberof ns_sphere_t
+/// Resolve a configured petname.
+///
+/// Uses the sphere identity that the petname is assigned to and determining
+/// a link - a CID - that is associated with it. The returned
 /// link is a UTF-8, base64-encoded CIDv1 string that may be used to resolve
 /// data from the IPFS content space. Note that this call will produce an error
 /// if no address has been assigned to the given petname.
@@ -125,6 +135,7 @@ pub fn ns_sphere_petname_resolve(
 }
 
 #[ffi_export]
+/// @memberof ns_sphere_t
 /// Get an array of all of the petnames in a sphere at the current version.
 pub fn ns_sphere_petname_list(
     noosphere: &NsNoosphere,
@@ -157,8 +168,10 @@ pub fn ns_sphere_petname_list(
 }
 
 #[ffi_export]
-/// Get an array of all of the petnames that changed in a given sphere since a
-/// given revision of that sphere (excluding the given revision). The revision
+/// @memberof ns_sphere_t
+/// Get an array of all of the petnames that changed in a given sphere.
+///
+/// Includes changes since, and excluding, the given revision. The revision
 /// should be provided as a UTF-8 base64-encoded CIDv1 string. If no revision is
 /// provided, the entire history will be considered (back to and including the
 /// first revision).

--- a/rust/noosphere/src/ffi/sphere.rs
+++ b/rust/noosphere/src/ffi/sphere.rs
@@ -11,8 +11,11 @@ use crate::sphere::SphereReceipt;
 #[derive_ReprC(rename = "ns_sphere_receipt")]
 #[repr(opaque)]
 /// @class ns_sphere_receipt_t
+/// An opaque struct representing initialization information of a sphere.
 ///
-/// TBD.
+/// Contains the identity of a sphere (DID) and a human-readable
+/// mnemonic that can be used to rotate the key authorized
+/// to administer the sphere.
 pub struct NsSphereReceipt {
     inner: SphereReceipt,
 }
@@ -24,8 +27,9 @@ impl From<SphereReceipt> for NsSphereReceipt {
 }
 
 #[ffi_export]
+/// @memberof ns_sphere_receipt_t
 /// Read the sphere identity (a DID encoded as a UTF-8 string) from a
-/// [SphereReceipt]
+/// ns_sphere_receipt_t
 pub fn ns_sphere_receipt_identity<'a>(
     sphere_receipt: &'a NsSphereReceipt,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
@@ -41,7 +45,8 @@ pub fn ns_sphere_receipt_identity<'a>(
 }
 
 #[ffi_export]
-/// Read the mnemonic from a [SphereReceipt]
+/// @memberof ns_sphere_receipt_t
+/// Read the mnemonic from a ns_sphere_receipt_t.
 pub fn ns_sphere_receipt_mnemonic<'a>(
     sphere_receipt: &'a NsSphereReceipt,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,
@@ -57,14 +62,17 @@ pub fn ns_sphere_receipt_mnemonic<'a>(
 }
 
 #[ffi_export]
-/// De-allocate a [SphereReceipt]
+/// @memberof ns_sphere_receipt_t
+/// Deallocate a ns_sphere_receipt_t
 pub fn ns_sphere_receipt_free(sphere_receipt: repr_c::Box<NsSphereReceipt>) {
     drop(sphere_receipt)
 }
 
 #[ffi_export]
+/// @memberof ns_sphere_t
 /// Initialize a brand new sphere, authorizing the given key to administer it.
-/// The returned value is a [SphereReceipt], containing the DID of the sphere
+///
+/// The returned value is a ns_sphere_receipt_t, containing the DID of the sphere
 /// and a human-readable mnemonic that can be used to rotate the key authorized
 /// to administer the sphere.
 pub fn ns_sphere_create(
@@ -84,8 +92,11 @@ pub fn ns_sphere_create(
 }
 
 #[ffi_export]
+/// @memberof ns_sphere_t
 /// Join a sphere by initializing it and configuring it to use the specified
-/// key and authorization. The authorization should be provided in the form of
+/// key and authorization.
+///
+/// The authorization should be provided in the form of
 /// a base64-encoded CID v1 string.
 pub fn ns_sphere_join(
     noosphere: &mut NsNoosphere,
@@ -110,9 +121,11 @@ pub fn ns_sphere_join(
 }
 
 #[ffi_export]
+/// @memberof ns_sphere_t
 /// Get the version of a given sphere that is considered the most recent version
-/// in local history. If a version is recorded, it is returned as a
-/// base64-encoded CID v1 string.
+/// in local history.
+///
+/// If a version is recorded, it is returned as a base64-encoded CID v1 string.
 pub fn ns_sphere_version_get(
     noosphere: &NsNoosphere,
     sphere_identity: char_p::Ref<'_>,
@@ -138,8 +151,11 @@ pub fn ns_sphere_version_get(
 }
 
 #[ffi_export]
-/// Sync a sphere with a gateway. A gateway URL must have been configured when
-/// the [NoosphereContext] was initialized. And, the sphere must have already
+/// @memberof ns_sphere_t
+/// Sync a sphere with a gateway.
+///
+/// A gateway URL must have been configured when
+/// the ns_noosphere_t was initialized. And, the sphere must have already
 /// been created or joined by the caller so that it is locally initialized (it's
 /// okay if this was done in an earlier session). The returned string is the
 /// base64-encoded CID v1 of the latest locally-available sphere revision after

--- a/rust/noosphere/src/key/insecure.rs
+++ b/rust/noosphere/src/key/insecure.rs
@@ -56,7 +56,7 @@ impl InsecureKeyStorage {
     /// but for now we aren't certain if we can depend on the ability to
     /// enumerate keys in general WebAuthn cases.
     ///
-    /// See: https://www.w3.org/TR/webauthn-3/#client-side-discoverable-credential
+    /// See: <https://www.w3.org/TR/webauthn-3/#client-side-discoverable-credential>
     pub async fn get_discoverable_keys(&self) -> Result<BTreeMap<String, Did>> {
         let mut discoverable_keys = BTreeMap::<String, Did>::new();
         let mut directory = fs::read_dir(&self.storage_path).await?;


### PR DESCRIPTION
* Expand @\class and @\memberof Doxygen relationships amongst FFI functions.
* Refine some FFI docs for consistent language and adapted to Doxygen's "summary" and "detailed" views (via newlines).
* Fix up rustdoc lints.