### PR TITLE
feat!: Sphere traversal C FFI

### DIFF
--- a/c/example/main.c
+++ b/c/example/main.c
@@ -33,7 +33,7 @@ void test_noosphere()
   setbuf(stdout, NULL);
   const char *hello_message = "Hello, Subconscious";
 
-  ns_noosphere_context_t *noosphere =
+  ns_noosphere_t *noosphere =
       ns_initialize("/tmp/foo", "/tmp/bar", NULL, NULL);
 
   ns_key_create(noosphere, "bob", NULL);
@@ -44,15 +44,15 @@ void test_noosphere()
   // printf("Sphere identity: %s\n", sphere_identity);
   // printf("Recovery code: %s\n", sphere_mnemonic);
 
-  ns_sphere_fs_t *sphere_fs = ns_sphere_fs_open(noosphere, sphere_identity, NULL);
+  ns_sphere_t *sphere = ns_sphere_open(noosphere, sphere_identity, NULL);
   slice_ref_uint8_t data = str_to_buffer(hello_message);
 
-  ns_sphere_fs_write(noosphere, sphere_fs, "hello", "text/subtext", data, NULL,
+  ns_sphere_content_write(noosphere, sphere, "hello", "text/subtext", data, NULL,
                      NULL);
-  ns_sphere_fs_save(noosphere, sphere_fs, NULL, NULL);
+  ns_sphere_save(noosphere, sphere, NULL, NULL);
 
   ns_sphere_file_t *file =
-      ns_sphere_fs_read(noosphere, sphere_fs, "/hello", NULL);
+      ns_sphere_content_read(noosphere, sphere, "/hello", NULL);
 
   slice_boxed_char_ptr_t headers =
       ns_sphere_file_header_values_read(file, "Content-Type");
@@ -73,7 +73,7 @@ void test_noosphere()
   ns_string_array_free(headers);
   ns_bytes_free(contents);
   ns_sphere_file_free(file);
-  ns_sphere_fs_free(sphere_fs);
+  ns_sphere_free(sphere);
   ns_string_free(sphere_identity);
   ns_string_free(sphere_mnemonic);
   ns_sphere_receipt_free(sphere_receipt);

--- a/rust/noosphere-gateway/src/worker/syndication.rs
+++ b/rust/noosphere-gateway/src/worker/syndication.rs
@@ -24,7 +24,7 @@ use ucan::crypto::KeyMaterial;
 use url::Url;
 
 use noosphere_car::{CarHeader, CarWriter};
-use wnfs::private::BloomFilter;
+use wnfs::private::namefilter::BloomFilter;
 
 /// A [SyndicationJob] is a request to syndicate the blocks of a _counterpart_
 /// sphere to the broader IPFS network.

--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -78,7 +78,7 @@ impl NsSphereFile {
 }
 
 #[ffi_export]
-/// Initialize an instance of a [NsSphere] that is a read/write view into
+/// Initialize an instance of a `ns_sphere_t` that is a read/write view into
 /// the contents (as addressed by the slug namespace) of the identitifed sphere
 /// This will fail if it is not possible to initialize a sphere with the given
 /// identity (which implies that no such sphere was ever created or joined on
@@ -105,18 +105,20 @@ pub fn ns_sphere_open(
 }
 
 #[ffi_export]
-/// Access another sphere by a petname. The petname should be one that has been
-/// assigned to the sphere's identity using `ns_sphere_petname_set`. If any of
-/// the data required to access the target sphere is not available locally, it
-/// will be replicated from the network through a the configured Noosphere
-/// Gateway. If no such gateway is configured and the data is not available
-/// locally, this call will fail. The returned `NsSphere` pointer can be used to
-/// access the content, petnames, revision history and other features of the
-/// target sphere with the same APIs used to access the local user's sphere,
-/// except that any operations that attempt to modify the sphere will be
-/// rejected. Note that since this function has a reasonable likelihood to call
-/// out to the network, it is possible that it may block for a significant
-/// amount of time when network conditions are poor.
+/// Access another sphere by a petname.
+///
+/// The petname should be one that has been assigned to the sphere's identity
+/// using `ns_sphere_petname_set()`. If any of the data required to access the
+/// target sphere is not available locally, it will be replicated from the
+/// network through a the configured Noosphere Gateway. If no such gateway is
+/// configured and the data is not available locally, this call will fail. The
+/// returned `NsSphere` pointer can be used to access the content, petnames,
+/// revision history and other features of the target sphere with the same APIs
+/// used to access the local user's sphere, except that any operations that
+/// attempt to modify the sphere will be rejected. Note that since this function
+/// has a reasonable likelihood to call out to the network, it is possible that
+/// it may block for a significant amount of time when network conditions are
+/// poor.
 pub fn ns_sphere_traverse_by_petname(
     noosphere: &NsNoosphere,
     sphere: &mut NsSphere,
@@ -143,20 +145,20 @@ pub fn ns_sphere_traverse_by_petname(
 }
 
 #[ffi_export]
-/// De-allocate an [NsSphere] instance
+/// De-allocate an `ns_sphere_t`
 pub fn ns_sphere_free(sphere: repr_c::Box<NsSphere>) {
     drop(sphere)
 }
 
 #[ffi_export]
-/// Read a [NsSphereFile] from a [NsSphere] instance by slashlink. Note that
-/// although this function will eventually support slashlinks that include the
-/// pet name of a peer, at this time only slashlinks with slugs referencing the
-/// slug namespace of the local sphere are allowed.
+/// Read a `ns_sphere_file_t` from a `ns_sphere_t` instance by slashlink. Note
+/// that although this function will eventually support slashlinks that include
+/// the pet name of a peer, at this time only slashlinks with slugs referencing
+/// the slug namespace of the local sphere are allowed.
 ///
 /// This function will return a null pointer if the slug does not have a file
 /// associated with it at the revision of the sphere that is referred to by the
-/// [NsSphere] being read from.
+/// `ns_sphere_t` being read from.
 pub fn ns_sphere_content_read(
     noosphere: &NsNoosphere,
     sphere: &NsSphere,
@@ -206,14 +208,14 @@ pub fn ns_sphere_content_read(
 }
 
 #[ffi_export]
-/// Write a byte buffer to a slug in the given [NsSphere] instance, assigning
+/// Write a byte buffer to a slug in the given `ns_sphere_t` instance, assigning
 /// its content-type header to the specified value. If additional headers are
 /// specified, they will be appended to the list of headers in the memo that is
 /// created for the content. If some content already exists at the specified
 /// slug, it will be assigned to be the previous historical revision of the new
 /// content.
 ///
-/// Note that you must invoke [ns_sphere_save] to commit one or more writes to
+/// Note that you must invoke `ns_sphere_save()` to commit one or more writes to
 /// the sphere.
 pub fn ns_sphere_content_write(
     noosphere: &NsNoosphere,
@@ -272,7 +274,7 @@ pub fn ns_sphere_content_remove(
 }
 
 #[ffi_export]
-/// Save any writes performed on the [NsSphere] instance. If additional
+/// Save any writes performed on the `ns_sphere_t` instance. If additional
 /// headers are specified, they will be appended to the headers in the memo that
 /// is created to wrap the latest sphere revision.
 ///
@@ -378,16 +380,16 @@ pub fn ns_sphere_content_changes(
 }
 
 #[ffi_export]
-/// De-allocate an [NsSphereFile] instance
+/// De-allocate an `ns_sphere_file_t`
 pub fn ns_sphere_file_free(sphere_file: repr_c::Box<NsSphereFile>) {
     drop(sphere_file)
 }
 
 #[ffi_export]
-/// Read the contents of an [NsSphereFile] as a byte array. Note that the
-/// [NsSphereFile] is lazy and stateful: it doesn't read any bytes from disk
+/// Read the contents of an `ns_sphere_file_t` as a byte array. Note that the
+/// `ns_sphere_file_t` is lazy and stateful: it doesn't read any bytes from disk
 /// until this function is invoked, and once the bytes have been read from the
-/// file you must create a new [NsSphereFile] instance to read them again.
+/// file you must create a new `ns_sphere_file_t` instance to read them again.
 pub fn ns_sphere_file_contents_read(
     noosphere: &NsNoosphere,
     sphere_file: &mut NsSphereFile,
@@ -462,7 +464,7 @@ pub fn ns_sphere_file_header_names_read(sphere_file: &NsSphereFile) -> c_slice::
 
 #[ffi_export]
 /// Get the base64-encoded CID v1 string for the memo that refers to the content
-/// of this [SphereFile].
+/// of this `ns_sphere_file_t`.
 pub fn ns_sphere_file_version_get(
     sphere_file: &NsSphereFile,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,5 +1,5 @@
+mod context;
 mod error;
-mod fs;
 mod headers;
 mod key;
 mod noosphere;
@@ -7,8 +7,8 @@ mod petname;
 mod sphere;
 
 pub use crate::ffi::noosphere::*;
+pub use context::*;
 pub use error::*;
-pub use fs::*;
 pub use headers::*;
 pub use key::*;
 pub use petname::*;


### PR DESCRIPTION
This change introduces a C FFI for sphere traversal.

This change also breaks a bunch of existing FFI by renaming functions to better align with the `SphereContext` refactor we did in #253. Only the names of functions have been changed. The semantics remain the same.

Additionally, the change fixes the C example, which has actually been broken for a little while.

I really wanted to include an integration test for this one, but it's actually a lot harder to do than it seems. We need to spin up two gateways and a name system node as separate processes in order to perform the test. This means that we would have to build both `orb` and `orb-ns` for the MacOS target before running the Swift tests and then write some helper code to spin them up during a test. In the end, we already cover the majority of the testable behavior in the equivalent Rust integration test. So, I've filed #291 for us to do the work down the road.

