### PR TITLE
fix: Introduce `TryOrReset` to help worker threads

### DIFF
--- a/rust/noosphere-gateway/src/again.rs
+++ b/rust/noosphere-gateway/src/again.rs
@@ -1,0 +1,147 @@
+use anyhow::Result;
+use std::future::Future;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+/// Wraps an "initialization" step, expressed as a closure, and allows
+/// a user to invoke closures with the result of that initialization step
+/// as a context argument. The result of invocation is always returned, but
+/// a failure result causes the initialized context to be reset is that it
+/// is re-initialized upon the next invocation attempt.
+pub struct Again<I, O, F>
+where
+    F: Future<Output = Result<O, anyhow::Error>>,
+    I: Fn() -> F,
+{
+    init: I,
+    initialized: OnceCell<Arc<O>>,
+}
+
+impl<I, O, F> Again<I, O, F>
+where
+    F: Future<Output = Result<O, anyhow::Error>>,
+    I: Fn() -> F,
+{
+    pub fn new(init: I) -> Self {
+        Again {
+            init,
+            initialized: OnceCell::new(),
+        }
+    }
+
+    /// Invoke a closure with the initialized context. The result will be
+    /// returned as normal, but an error result will cause the initialized
+    /// context to be reset so that the next time an invocation is attempted,
+    /// context initialization will be retried.
+    pub async fn invoke_or_reset<Ii, Oo, Ff>(&mut self, invoke: Ii) -> Result<Oo>
+    where
+        Ii: FnOnce(Arc<O>) -> Ff,
+        Ff: Future<Output = Result<Oo, anyhow::Error>>,
+    {
+        match self
+            .initialized
+            .get_or_try_init(|| async { Ok(Arc::new((self.init)().await?)) })
+            .await
+        {
+            Ok(initialized) => match invoke(initialized.clone()).await {
+                Ok(output) => Ok(output),
+                Err(error) => {
+                    self.initialized.take();
+                    Err(error)
+                }
+            },
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{anyhow, Result};
+    use std::{ops::AddAssign, sync::Arc};
+
+    use tokio::sync::Mutex;
+
+    use super::Again;
+
+    #[tokio::test]
+    async fn it_initializes_context_before_invocation_and_recovers_from_failure() {
+        let count = Arc::new(Mutex::new(0u32));
+
+        let mut again = Again::new(|| async {
+            let mut count = count.lock().await;
+            count.add_assign(1);
+            Ok(format!("Hello {}", count))
+        });
+
+        again
+            .invoke_or_reset(|context| async move {
+                assert_eq!("Hello 1", context.as_str());
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        let _: Result<()> = again
+            .invoke_or_reset(|_| async move { Err(anyhow!("Arbitrary error")) })
+            .await;
+
+        again
+            .invoke_or_reset(|context| async move {
+                assert_eq!("Hello 2", context.as_str());
+                Ok(())
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn it_only_initializes_context_once_as_long_as_results_are_ok() {
+        let count = Arc::new(Mutex::new(0u32));
+
+        let mut again = Again::new(|| async {
+            let mut count = count.lock().await;
+            count.add_assign(1);
+            Ok(format!("Hello {}", count))
+        });
+
+        for _ in 0..10 {
+            again
+                .invoke_or_reset(|context| async move {
+                    assert_eq!("Hello 1", context.as_str());
+                    Ok(())
+                })
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn it_will_try_again_next_time_if_initialization_fails() {
+        let count = Arc::new(Mutex::new(0u32));
+        let mut again = Again::new(|| async {
+            let mut count = count.lock().await;
+            count.add_assign(1);
+            if count.to_owned() == 1 {
+                Err(anyhow!("Arbitrary failure"))
+            } else {
+                Ok(format!("Hello {}", count))
+            }
+        });
+
+        let _ = again
+            .invoke_or_reset(|_| async move {
+                assert!(false, "First initialization should not have succeeded");
+                Ok(())
+            })
+            .await;
+
+        again
+            .invoke_or_reset(|context| async move {
+                assert_eq!("Hello 2", context.as_str());
+                Ok(())
+            })
+            .await
+            .unwrap()
+    }
+}

--- a/rust/noosphere-gateway/src/lib.rs
+++ b/rust/noosphere-gateway/src/lib.rs
@@ -6,7 +6,7 @@ extern crate tracing;
 mod authority;
 
 #[cfg(not(target_arch = "wasm32"))]
-mod again;
+mod try_or_reset;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod extractor;

--- a/rust/noosphere-gateway/src/lib.rs
+++ b/rust/noosphere-gateway/src/lib.rs
@@ -6,6 +6,9 @@ extern crate tracing;
 mod authority;
 
 #[cfg(not(target_arch = "wasm32"))]
+mod again;
+
+#[cfg(not(target_arch = "wasm32"))]
 mod extractor;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -1,4 +1,4 @@
-use crate::again::Again;
+use crate::try_or_reset::TryOrReset;
 use anyhow::anyhow;
 use anyhow::Result;
 use cid::Cid;
@@ -109,14 +109,14 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    let mut with_client = Again::new(|| async {
+    let mut with_client = TryOrReset::new(|| async {
         match &configuration {
             NameSystemConfiguration::Remote(url) => NameSystemHttpClient::new(url.clone()).await,
         }
     });
 
     while let Some(job) = receiver.recv().await {
-        let run_job = with_client.invoke_or_reset(|client| async move {
+        let run_job = with_client.invoke(|client| async move {
             debug!("Running {}", job);
             match job {
                 NameSystemJob::Publish { record, .. } => {

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -1,3 +1,4 @@
+use crate::again::Again;
 use anyhow::anyhow;
 use anyhow::Result;
 use cid::Cid;
@@ -9,10 +10,12 @@ use noosphere_sphere::{
     HasMutableSphereContext, SphereCursor, SpherePetnameRead, SpherePetnameWrite,
 };
 use noosphere_storage::Storage;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 use strum_macros::Display;
 use tokio::{
     sync::{
@@ -35,9 +38,7 @@ pub enum NameSystemConfiguration {
 #[derive(Display)]
 pub enum NameSystemJob<C> {
     /// Resolve all names in the sphere at the latest version
-    ResolveAll {
-        context: C,
-    },
+    ResolveAll { context: C },
     /// Resolve a single name from a given sphere at the latest version
     #[allow(dead_code)]
     ResolveImmediately {
@@ -47,14 +48,9 @@ pub enum NameSystemJob<C> {
     },
     /// Resolve all added names of a given sphere since the given sphere
     /// revision
-    ResolveSince {
-        context: C,
-        since: Option<Cid>,
-    },
-    Publish {
-        context: C,
-        record: Jwt,
-    },
+    ResolveSince { context: C, since: Option<Cid> },
+    /// Publish a link record (given as a [Jwt]) to the name system
+    Publish { context: C, record: Jwt },
 }
 
 pub fn start_name_system<C, K, S>(
@@ -113,12 +109,14 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    let client: Arc<dyn NameSystemClient> = Arc::new(match configuration {
-        NameSystemConfiguration::Remote(url) => NameSystemHttpClient::new(url).await?,
+    let mut with_client = Again::new(|| async {
+        match &configuration {
+            NameSystemConfiguration::Remote(url) => NameSystemHttpClient::new(url.clone()).await,
+        }
     });
 
     while let Some(job) = receiver.recv().await {
-        let run_job = || async {
+        let run_job = with_client.invoke_or_reset(|client| async move {
             debug!("Running {}", job);
             match job {
                 NameSystemJob::Publish { record, .. } => {
@@ -215,9 +213,9 @@ where
                 }
             };
             Ok(())
-        };
+        });
 
-        match run_job().await {
+        match run_job.await {
             Err(error) => error!("NNS job failed: {}", error),
             _ => debug!("NNS job completed successfully"),
         }
@@ -265,7 +263,7 @@ where
             Some(record) if last_known_record != next_record => {
                 debug!(
                     "Gateway adopting petname record for '{}' ({}): {}",
-                    name, identity.did, &record
+                    name, identity.did, record
                 );
                 context.adopt_petname(&name, record).await?;
             }

--- a/rust/noosphere-ipfs/src/client/kubo.rs
+++ b/rust/noosphere-ipfs/src/client/kubo.rs
@@ -22,6 +22,7 @@ pub struct KuboClient {
 }
 
 impl KuboClient {
+    // TODO: This probably doesn't need to return a result
     pub fn new(api_url: &Url) -> Result<Self> {
         let client = hyper::Client::builder().build_http();
         Ok(KuboClient {


### PR DESCRIPTION
This introduces an `TryOrReset` construct that makes initialization of HTTP clients more resilient. In the case of both the name system and gateway APIs, client initialization is predicated on verifying the identity of the node we are talking to. `TryOrReset` enables us to express usage of a client that is resilient to failures related to identifying nodes, while mostly retaining the efficiency of the current pattern where client initialization only has to happen once.