### PR TITLE
Several updates for noosphere-ipfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,12 +4048,14 @@ dependencies = [
  "noosphere-car",
  "noosphere-core",
  "noosphere-storage",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tracing",
+ "ucan",
  "url 2.3.1",
 ]
 

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -20,6 +20,8 @@ homepage = "https://github.com/subconsciousnetwork/noosphere"
 readme = "README.md"
 
 [features]
+default = ["storage"]
+storage = ["ucan"]
 test_kubo = []
 
 [dependencies]
@@ -38,8 +40,10 @@ tokio = { version = "^1", features = ["io-util"] }
 tracing = "0.1"
 url = { version = "^2", features = [ "serde" ] }
 noosphere-storage = { version = "0.6.0", path = "../noosphere-storage" }
+ucan = { version = "0.1.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+noosphere-car = { version = "0.1.0", path = "../noosphere-car" }
 hyper = { version = "~0.14", features = ["full"] }
 hyper-multipart-rfc7578 = "~0.8"
 ipfs-api-prelude = "~0.5"
@@ -47,7 +51,7 @@ ipfs-api-prelude = "~0.5"
 [dev-dependencies]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-noosphere-car = { version = "0.1.0", path = "../noosphere-car" }
+rand = "~0.8"
 libipld-cbor = "~0.15"
 noosphere-storage = { version = "0.6.0", path = "../noosphere-storage" }
 noosphere-core = { version = "0.8.0", path = "../noosphere-core" }

--- a/rust/noosphere-ipfs/src/lib.rs
+++ b/rust/noosphere-ipfs/src/lib.rs
@@ -1,8 +1,8 @@
-#[macro_use]
-extern crate tracing;
-
 mod client;
+#[cfg(feature = "storage")]
 mod storage;
 
 pub use client::*;
+
+#[cfg(feature = "storage")]
 pub use storage::*;


### PR DESCRIPTION
* IpfsStore::get_block now resolves blocks with the correct output-codec.
* IPFS tests (--features test_kubo) could produce false positives by relying on previously cached values in the IPFS instance. Test data now is randomized.
* Add real test against IPFS for a non-existant block via BlockStoreRetry and IpfsStore