### PR TITLE
feat: Add additional tracing instrumentation to noosphere-ns and noosphere-ipfs

### DIFF
--- a/rust/noosphere-ipfs/src/client/kubo.rs
+++ b/rust/noosphere-ipfs/src/client/kubo.rs
@@ -47,6 +47,7 @@ impl KuboClient {
 
 #[async_trait]
 impl IpfsClient for KuboClient {
+    #[instrument(skip(self), level = "trace")]
     async fn block_is_pinned(&self, cid: &Cid) -> Result<bool> {
         let mut api_url = self.api_url.clone();
         let cid_base64 = cid.to_string();
@@ -67,6 +68,7 @@ impl IpfsClient for KuboClient {
         }
     }
 
+    #[instrument(skip(self), level = "trace")]
     async fn server_identity(&self) -> Result<String> {
         let mut api_url = self.api_url.clone();
 
@@ -85,6 +87,7 @@ impl IpfsClient for KuboClient {
         }
     }
 
+    #[instrument(skip(self, car), level = "trace")]
     async fn syndicate_blocks<R>(&self, car: R) -> Result<()>
     where
         R: IpfsClientAsyncReadSendSync,
@@ -117,6 +120,7 @@ impl IpfsClient for KuboClient {
         */
     }
 
+    #[instrument(skip(self), level = "trace")]
     async fn get_block(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
         let output_codec = get_codec(cid)?;
         let mut api_url = self.api_url.clone();

--- a/rust/noosphere-ipfs/src/lib.rs
+++ b/rust/noosphere-ipfs/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate tracing;
+
 mod client;
 #[cfg(feature = "storage")]
 mod storage;

--- a/rust/noosphere-ns/src/name_system.rs
+++ b/rust/noosphere-ns/src/name_system.rs
@@ -111,24 +111,11 @@ impl NameSystem {
                     // Validation/correctness and filtering through
                     // the most recent values can be performed here
                     let record = NsRecord::try_from(value)?;
-                    info!(
-                        "NameSystem: GetRecord: {} {}",
-                        identity,
-                        record
-                            .link()
-                            .map_or_else(|| String::from("None"), |cid| cid.to_string())
-                    );
                     Ok((identity.to_owned(), Some(record)))
                 }
-                None => {
-                    warn!("NameSystem: GetRecord: No record found for {}.", identity);
-                    Ok((identity.to_owned(), None))
-                }
+                None => Ok((identity.to_owned(), None)),
             },
-            Err(e) => {
-                warn!("NameSystem: GetRecord: Failure for {} {:?}.", identity, e);
-                Err(anyhow!(e.to_string()))
-            }
+            Err(e) => Err(anyhow!(e.to_string())),
         }
     }
 
@@ -139,14 +126,8 @@ impl NameSystem {
     async fn dht_put_record(&self, identity: &Did, record: &NsRecord) -> Result<()> {
         let record: Vec<u8> = record.try_into()?;
         match self.dht.put_record(identity.as_bytes(), &record).await {
-            Ok(_) => {
-                info!("NameSystem: PutRecord: {}", identity);
-                Ok(())
-            }
-            Err(e) => {
-                warn!("NameSystem: PutRecord: Failure for {} {:?}.", identity, e);
-                Err(anyhow!(e.to_string()))
-            }
+            Ok(_) => Ok(()),
+            Err(e) => Err(anyhow!(e.to_string())),
         }
     }
 }

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -130,6 +130,7 @@ impl NsRecord {
     /// Validates the underlying [Ucan] token, ensuring that
     /// the sphere's owner authorized the publishing of a new
     /// content address. Returns an `Err` if validation fails.
+    #[instrument(skip(store, did_parser), level = "trace")]
     pub async fn validate<S: Storage>(
         &self,
         store: &SphereDb<S>,


### PR DESCRIPTION
* Adds tracing to relevant DHT commands, IPFS lookups, and record validations. Future improvements could include spans that follow DHT operations logically (responses from the DHT are polled and reconciled with one or many top-level requests), and better formatting of Cids/Records.
* Remove some redundant, ill-formatted tracing