### PR TITLE
feat: Recursive petname traversal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "rust-analyzer.cargo.target": null,
+  "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
   "lldb.launch.cwd": "${workspaceFolder}",
   "rust-analyzer.procMacro.enable": true,
   "rust-analyzer.procMacro.ignored": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "subtext"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f684e579d8a0d7abafa295b2287d8d68a36e3e23eec985c5231f179a4234f9"
+checksum = "8e6fc6abff2994099c5ba81aea1e65ad9a470a463eb8d4c3796d77d296e621ff"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+subtext = { version = "0.3.3" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "~0.3", features = ["env-filter", "tracing-log"] }
 

--- a/rust/noosphere-core/src/authority/author.rs
+++ b/rust/noosphere-core/src/authority/author.rs
@@ -27,7 +27,7 @@ pub enum Access {
 /// content to a sphere. This construct collects the identity and the
 /// authorization of that entity to make it easier to determine their level of
 /// access to the content of a given sphere.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Author<K>
 where
     K: KeyMaterial + Clone + 'static,

--- a/rust/noosphere-core/src/authority/authorization.rs
+++ b/rust/noosphere-core/src/authority/authorization.rs
@@ -19,7 +19,7 @@ use crate::data::Jwt;
 /// [Authorization] instead.
 /// TODO(ucan-wg/rs-ucan#32): Maybe swap this out is we get a substantially
 /// similar construct to land in rs-ucan
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Authorization {
     /// A fully instantiated UCAN
     Ucan(Ucan),

--- a/rust/noosphere-into/src/into/html/sphere.rs
+++ b/rust/noosphere-into/src/into/html/sphere.rs
@@ -177,7 +177,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_writes_a_file_from_the_sphere_to_the_target_as_html() {
-        let context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(context);
@@ -246,7 +246,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_symlinks_a_file_slug_to_the_latest_file_version() {
-        let context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(context);

--- a/rust/noosphere-ipfs/src/client/gateway.rs
+++ b/rust/noosphere-ipfs/src/client/gateway.rs
@@ -10,7 +10,7 @@ use url::Url;
 /// A high-level HTTP client for accessing IPFS
 /// [HTTP Gateway](https://docs.ipfs.tech/reference/http/gateway/) and normalizing
 /// their expected payloads to Noosphere-friendly formats.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GatewayClient {
     client: Client,
     api_url: Url,

--- a/rust/noosphere-ipfs/src/client/kubo.rs
+++ b/rust/noosphere-ipfs/src/client/kubo.rs
@@ -28,7 +28,7 @@ fn get_codec(cid: &Cid) -> Result<String> {
 /// A high-level HTTP client for accessing IPFS
 /// [Kubo RPC APIs](https://docs.ipfs.tech/reference/kubo/rpc/) and normalizing
 /// their expected payloads to Noosphere-friendly formats
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct KuboClient {
     client: Client<HttpConnector<GaiResolver>>,
     api_url: Url,

--- a/rust/noosphere-ipfs/src/client/mod.rs
+++ b/rust/noosphere-ipfs/src/client/mod.rs
@@ -12,6 +12,7 @@ pub use kubo::KuboClient;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cid::Cid;
+use std::fmt::Debug;
 use tokio::io::AsyncRead;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -30,7 +31,7 @@ impl<S> IpfsClientAsyncReadSendSync for S where S: AsyncRead {}
 /// intended to be general enough to apply to other IPFS implementations.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait IpfsClient: Clone {
+pub trait IpfsClient: Clone + Debug {
     /// Returns true if the block (referenced by [Cid]) is pinned by the IPFS
     /// server
     async fn block_is_pinned(&self, cid: &Cid) -> Result<bool>;

--- a/rust/noosphere-ipfs/src/storage.rs
+++ b/rust/noosphere-ipfs/src/storage.rs
@@ -13,7 +13,7 @@ use noosphere_storage::KeyValueStore;
 /// implementation of [Storage] and an [IpfsClient].
 /// [IpfsStorage] is generic over [BlockStore] and [KeyValueStore]
 /// but will produce a [IpfsStore] wrapped [BlockStore]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IpfsStorage<S, C>
 where
     S: Storage,

--- a/rust/noosphere-sphere/src/cursor.rs
+++ b/rust/noosphere-sphere/src/cursor.rs
@@ -203,7 +203,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_unlink_slugs_from_the_content_space() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -231,7 +231,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_flushes_on_every_save() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let initial_stats = {
@@ -288,7 +288,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_does_not_allow_writes_when_an_author_has_read_only_access() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::Readonly)
+        let sphere_context = simulated_sphere_context(SimulationAccess::Readonly, None)
             .await
             .unwrap();
 
@@ -309,7 +309,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_write_a_file_and_read_it_back() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -344,7 +344,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_overwrite_a_file_with_new_contents_and_preserve_history() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -407,7 +407,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_throws_an_error_when_saving_without_changes() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -421,7 +421,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_throws_an_error_when_saving_with_empty_mutation_and_empty_headers() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);

--- a/rust/noosphere-sphere/src/helpers.rs
+++ b/rust/noosphere-sphere/src/helpers.rs
@@ -27,9 +27,15 @@ pub enum SimulationAccess {
 /// have to the [SphereContext].
 pub async fn simulated_sphere_context(
     profile: SimulationAccess,
+    db: Option<SphereDb<TrackingStorage<MemoryStorage>>>,
 ) -> Result<Arc<Mutex<SphereContext<Ed25519KeyMaterial, TrackingStorage<MemoryStorage>>>>> {
-    let storage_provider = TrackingStorage::wrap(MemoryStorage::default());
-    let mut db = SphereDb::new(&storage_provider).await?;
+    let mut db = match db {
+        Some(db) => db,
+        None => {
+            let storage_provider = TrackingStorage::wrap(MemoryStorage::default());
+            SphereDb::new(&storage_provider).await?
+        }
+    };
 
     let owner_key = generate_ed25519_key();
     let owner_did = owner_key.get_did().await?;

--- a/rust/noosphere-sphere/src/lib.rs
+++ b/rust/noosphere-sphere/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite).await?;
+//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 //!
 //!   sphere_context.write("/foo", "text/plain", "bar".as_ref(), None).await?;
 //!   sphere_context.save(None).await?;
@@ -38,7 +38,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite).await?;
+//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 //!
 //!   sphere_context.set_petname("cdata", Some("did:key:example".into())).await?;
 //!   sphere_context.save(None).await?;

--- a/rust/noosphere-sphere/src/replication.rs
+++ b/rust/noosphere-sphere/src/replication.rs
@@ -213,7 +213,7 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_stream_all_blocks_in_a_sphere_version() {
         initialize_tracing();
-        let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
 
@@ -308,7 +308,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_some_sphere_content() {
         initialize_tracing();
 
-        let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut db = sphere_context
@@ -378,7 +378,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version_as_a_car() {
         initialize_tracing();
 
-        let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
 

--- a/rust/noosphere-sphere/src/walker.rs
+++ b/rust/noosphere-sphere/src/walker.rs
@@ -326,7 +326,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_be_initialized_with_a_context_or_a_cursor() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context.clone());
@@ -367,7 +367,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_list_all_slugs_currently_in_a_sphere() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -411,7 +411,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_stream_the_whole_index() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite)
+        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);

--- a/rust/noosphere-storage/src/db.rs
+++ b/rust/noosphere-storage/src/db.rs
@@ -42,7 +42,7 @@ pub const SPHERE_DB_STORE_NAMES: &[&str] =
 /// orchestrating writes so that as blocks are stored, links are also extracted
 /// and tracked separately, and also hosting metadata information such as sphere
 /// version records and other purely local configuration
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SphereDb<S>
 where
     S: Storage,

--- a/rust/noosphere-storage/src/implementation/memory.rs
+++ b/rust/noosphere-storage/src/implementation/memory.rs
@@ -21,7 +21,7 @@ impl<S: Store> StoreContainsCid for S {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct MemoryStorage {
     stores: Arc<Mutex<HashMap<String, MemoryStore>>>,
 }

--- a/rust/noosphere-storage/src/implementation/native.rs
+++ b/rust/noosphere-storage/src/implementation/native.rs
@@ -12,7 +12,7 @@ pub enum NativeStorageInit {
     Db(Db),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NativeStorage {
     db: Db,
 }

--- a/rust/noosphere-storage/src/implementation/tracking.rs
+++ b/rust/noosphere-storage/src/implementation/tracking.rs
@@ -75,7 +75,7 @@ impl<S: Store> Store for TrackingStore<S> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TrackingStorage<S: Storage> {
     storage: S,
 }

--- a/rust/noosphere-storage/src/implementation/web.rs
+++ b/rust/noosphere-storage/src/implementation/web.rs
@@ -6,7 +6,7 @@ use js_sys::Uint8Array;
 use rexie::{
     KeyRange, ObjectStore, Rexie, RexieBuilder, Store as IdbStore, Transaction, TransactionMode,
 };
-use std::rc::Rc;
+use std::{fmt::Debug, rc::Rc};
 use wasm_bindgen::{JsCast, JsValue};
 
 pub const INDEXEDDB_STORAGE_VERSION: u32 = 1;
@@ -14,6 +14,12 @@ pub const INDEXEDDB_STORAGE_VERSION: u32 = 1;
 #[derive(Clone)]
 pub struct WebStorage {
     db: Rc<Rexie>,
+}
+
+impl Debug for WebStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebStorage").finish()
+    }
 }
 
 impl WebStorage {

--- a/rust/noosphere-storage/src/storage.rs
+++ b/rust/noosphere-storage/src/storage.rs
@@ -2,6 +2,7 @@ use crate::block::BlockStore;
 use crate::key_value::KeyValueStore;
 use anyhow::Result;
 use async_trait::async_trait;
+use std::fmt::Debug;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub trait StorageSendSync: Send + Sync {}
@@ -23,7 +24,7 @@ impl<T> StorageSendSync for T {}
 /// other Noosphere constructs.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait Storage: Clone + StorageSendSync {
+pub trait Storage: Clone + StorageSendSync + Debug {
     type BlockStore: BlockStore;
     type KeyValueStore: KeyValueStore;
 

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = "~0.1"
 async-stream = "~0.3"
 tracing = { workspace = true }
 url = { version = "^2", features = ["serde"] }
-subtext = { version = "0.3.2" }
+subtext = { workspace = true }
 itertools = "0.10.5"
 tokio-stream = "~0.1"
 tokio-util = { version = "~0.7", features = ["io"] }


### PR DESCRIPTION
This change implements recursive petname traversal. Most of the change is a test that was really annoying to write :sweat_smile: 

Fixes #305 