### PR TITLE
fix: Unreachable petname sequence is not an error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+  "rust-analyzer.cargo.target": null,
   "lldb.launch.cwd": "${workspaceFolder}",
   "rust-analyzer.procMacro.enable": true,
   "rust-analyzer.procMacro.ignored": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5904,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "subtext"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fc6abff2994099c5ba81aea1e65ad9a470a463eb8d4c3796d77d296e621ff"
+checksum = "fd41fd9fc6998faab4b179e626264e294226ecf922322f4a823bb9f774f78fa7"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-subtext = { version = "0.3.3" }
+subtext = { version = "0.3.4" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "~0.3", features = ["env-filter", "tracing-log"] }
 thiserror = { version = "^1.0.38" }

--- a/rust/noosphere-cli/tests/peer_to_peer.rs
+++ b/rust/noosphere-cli/tests/peer_to_peer.rs
@@ -389,6 +389,7 @@ async fn traverse_spheres_and_read_content_via_noosphere_gateway_via_ipfs() {
                 .unwrap()
                 .traverse_by_petname("thirdparty")
                 .await
+                .unwrap()
                 .unwrap(),
         ));
 

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -603,4 +603,56 @@ final class NoosphereTests: XCTestCase {
         ns_sphere_free(sphere)
         ns_free(noosphere)
     }
+
+    // TODO(#315): Re-enable this test at some point
+    /*
+    func testDoesNotPanicWhenReadingProblematicSlashlinks() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil, nil)
+
+        ns_key_create(noosphere, "bob", nil)
+
+        let sphere_receipt = ns_sphere_create(noosphere, "bob", nil)
+
+        let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt, nil)
+
+        let sphere = ns_sphere_open(noosphere, sphere_identity_ptr, nil)
+
+        var maybe_error = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+
+        // Invalid slashlink
+        var result = ns_sphere_content_read(noosphere, sphere, "cdata.dev/does-not-exist", maybe_error)
+        
+        assert(result == nil)
+        assert(maybe_error.pointee != nil)
+
+        let error_message_ptr = ns_error_string(maybe_error.pointee)
+        let error_message = String.init(cString: error_message_ptr!)
+        print(error_message)
+
+        maybe_error.deallocate()
+        maybe_error = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+
+        // Valid slashlink, unresolvable peer
+        result = ns_sphere_content_read(noosphere, sphere, "@ben/does-not-exist", maybe_error)
+
+        if maybe_error.pointee != nil {
+            let error_message_ptr = ns_error_string(maybe_error.pointee)
+            let error_message = String.init(cString: error_message_ptr!)
+            print(error_message)
+        }
+
+        assert(result == nil)
+        // NOTE: This assertion always fails on Github (and only on Github)
+        assert(maybe_error.pointee == nil)
+
+        maybe_error.deallocate()
+        maybe_error = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+
+        // Valid slashlink, unresolvable slug
+        result = ns_sphere_content_read(noosphere, sphere, "/does-not-exist", maybe_error)
+
+        assert(result == nil)
+        assert(maybe_error.pointee == nil)
+    }
+    */
 }


### PR DESCRIPTION
This change makes double-darn sure that we aren't panicking unexpectedly when dealing with slashlinks in the FFI. It also changes some of the error semantics of traversal. Previously, trying to traverse to a petname that isn't assigned to a DID would result in an error. Now, it results in a `None` (similar to how reading a slug that isn't assigned results in `None`).