### PR TITLE
fix: increase timeout in DHT network tests to satisfy CI, fixes #311

### DIFF
--- a/rust/noosphere-ns/src/dht/node.rs
+++ b/rust/noosphere-ns/src/dht/node.rs
@@ -293,7 +293,7 @@ mod test {
 
         // Wait for the peers to establish connections.
         await_or_timeout(
-            2000,
+            5000,
             swarm_command(nodes, |c| c.wait_for_peers(expected_peers)),
             format!("waiting for {} peers", expected_peers),
         )


### PR DESCRIPTION
This increases the timeout for the 4 networked DhtNode tests, mostly due to the minimum internal timeouts of libp2p's dht are 1 second (meaning, if a "window" is missed, a whole other second is needed to begin the next step in the bootstrapping process); even locally this fails if less than `2000`.