### PR TITLE
Introduce `ns_sphere_identity` FFI call

### DIFF
--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -530,7 +530,7 @@ pub fn ns_sphere_file_version_get(
 }
 
 #[ffi_export]
-/// @memberof ns_sphere_file_t
+/// @memberof ns_sphere_t
 /// Get the identity (a DID encoded as a UTF-8 string)
 /// for this ns_sphere_t.
 pub fn ns_sphere_identity(

--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -528,3 +528,21 @@ pub fn ns_sphere_file_version_get(
             .map_err(|error: InvalidNulTerminator<String>| anyhow!(error).into())
     })
 }
+
+#[ffi_export]
+/// @memberof ns_sphere_file_t
+/// Get the identity (a DID encoded as a UTF-8 string)
+/// for this ns_sphere_file_t.
+pub fn ns_sphere_file_identity_get(
+    sphere_file: &NsSphereFile,
+    error_out: Option<Out<'_, repr_c::Box<NsError>>>,
+) -> Option<char_p::Box> {
+    error_out.try_or_initialize(|| {
+        sphere_file
+            .inner
+            .sphere_identity
+            .to_string()
+            .try_into()
+            .map_err(|error: InvalidNulTerminator<String>| anyhow!(error).into())
+    })
+}

--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -533,7 +533,7 @@ pub fn ns_sphere_file_version_get(
 /// @memberof ns_sphere_file_t
 /// Get the identity (a DID encoded as a UTF-8 string)
 /// for this ns_sphere_t.
-pub fn ns_sphere_identity_get(
+pub fn ns_sphere_identity(
     noosphere: &NsNoosphere,
     sphere: &NsSphere,
     error_out: Option<Out<'_, repr_c::Box<NsError>>>,

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -418,7 +418,7 @@ final class NoosphereTests: XCTestCase {
         let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt, nil)
         let sphere = ns_sphere_open(noosphere, sphere_identity_ptr, nil)
 
-        let reported_identity_str = ns_sphere_identity_get(noosphere, sphere, nil)
+        let reported_identity_str = ns_sphere_identity(noosphere, sphere, nil)
 
         assert(String.init(cString: reported_identity_str!) == String.init(cString: sphere_identity_ptr!))
         

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -407,6 +407,28 @@ final class NoosphereTests: XCTestCase {
         ns_sphere_free(sphere)
         ns_free(noosphere)
     }
+
+    func testGettingIdentityFromSphere() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil, nil)
+
+        ns_key_create(noosphere, "bob", nil)
+
+        let sphere_receipt = ns_sphere_create(noosphere, "bob", nil)
+
+        let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt, nil)
+        let sphere = ns_sphere_open(noosphere, sphere_identity_ptr, nil)
+
+        let reported_identity_str = ns_sphere_identity_get(noosphere, sphere, nil)
+
+        assert(String.init(cString: reported_identity_str!) == String.init(cString: sphere_identity_ptr!))
+        
+        ns_string_free(sphere_identity_ptr)
+        ns_sphere_receipt_free(sphere_receipt)
+        ns_string_free(reported_identity_str)
+        
+        ns_sphere_free(sphere)
+        ns_free(noosphere)
+    }
     
     func testSettingAndGettingAPetname() throws {
         let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil, nil)


### PR DESCRIPTION
Context:

>  Right now when I call `ns_sphere_traverse_by_petname` I get back a pointer to a `ns_sphere_t` which we wrap in our own `Sphere` Swift type. That is all good except that `Sphere` needs to know the DID of the `ns_sphere_t` it holds, but (afaict?) there is no easy way for me to get it reliably when traversing to a fully qualified petname (e.g. `@ben.chris.jordan`).

> I find myself wishing for either:
> 1. `ns_sphere_identity_get` so I can read the DID out of the sphere post-traversal
> 2. `ns_resolve_did` which can translate from a fully qualified petname to a DID (resolve is overloaded as a term)

> Leaning towards (1). I can work around this by traversing one hop at a time in a loop and retrieving each DID along the way using `ns_sphere_petname_get` but it seems a shame when traversing can handle dotted petnames.

# Changes

- Introduce `ns_sphere_identity` FFI export