### PR TITLE
feat: Sphere writes do not block immutable reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "cid 0.9.0",
+ "gloo-timers",
+ "instant",
  "itertools",
  "js-sys",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ resolver = "2"
 [workspace.dependencies]
 subtext = { version = "0.3.4" }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "~0.3", features = ["env-filter", "tracing-log"] }
-thiserror = { version = "^1.0.38" }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
+thiserror = { version = "1" }
+instant = { version = "0.1" }
+gloo-timers = { version = "0.2", features = ["futures"] }
 
 [profile.release]
 opt-level = 'z'

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -6,7 +6,7 @@ use ucan::crypto::KeyMaterial;
 use crate::{
     authority::Authorization,
     data::{
-        ChangelogIpld, DelegationIpld, IdentityIpld, Jwt, Link, MapOperation, MemoIpld,
+        ChangelogIpld, DelegationIpld, Did, IdentityIpld, Jwt, Link, MapOperation, MemoIpld,
         RevocationIpld, VersionedMapKey, VersionedMapValue,
     },
 };
@@ -49,7 +49,7 @@ impl<S: BlockStore> SphereRevision<S> {
 /// [SphereRevision], which may then be signed.
 #[derive(Debug)]
 pub struct SphereMutation {
-    did: String,
+    did: Did,
     content: ContentMutation,
     identities: IdentitiesMutation,
     delegations: DelegationsMutation,
@@ -65,6 +65,11 @@ impl<'a> SphereMutation {
             delegations: DelegationsMutation::new(did),
             revocations: RevocationsMutation::new(did),
         }
+    }
+
+    /// Get the identity of the author of this mutation
+    pub fn author(&self) -> &Did {
+        &self.did
     }
 
     /// Reset the state of the [SphereMutation], so that it may be re-used

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -74,3 +74,7 @@ tempfile = "^3"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "~0.3"
 witty-phrase-generator = "~0.2"
+instant = { workspace = true, features = ["wasm-bindgen", "stdweb"] }
+gloo-timers = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies.js-sys]

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -144,7 +144,9 @@ pub fn ns_sphere_petname_list(
 ) -> c_slice::Box<char_p::Box> {
     let possible_output = error_out.try_or_initialize(|| {
         noosphere.async_runtime().block_on(async {
-            let petname_set = SphereWalker::from(sphere.inner()).list_petnames().await?;
+            let petname_set = SphereWalker::from(sphere.inner().clone())
+                .list_petnames()
+                .await?;
             let mut all_petnames: Vec<char_p::Box> = Vec::new();
 
             for petname in petname_set.into_iter() {
@@ -197,7 +199,7 @@ pub fn ns_sphere_petname_changes(
                 None => None,
             };
 
-            let changed_petname_set = SphereWalker::from(sphere.inner())
+            let changed_petname_set = SphereWalker::from(sphere.inner().clone())
                 .petname_changes(since.as_ref())
                 .await?;
             let mut changed_petnames: Vec<char_p::Box> = Vec::new();

--- a/rust/noosphere/src/noosphere.rs
+++ b/rust/noosphere/src/noosphere.rs
@@ -199,11 +199,11 @@ impl NoosphereContext {
         Ok(())
     }
 
-    /// Access a [SphereContext] associated with the given sphere DID identity.
-    /// The sphere must already have been initialized locally (either by
+    /// Access a [SphereChannel] associated with the given sphere DID identity.
+    /// The related sphere must already have been initialized locally (either by
     /// creating it or joining one that was created elsewhere). The act of
-    /// creating or joining will initialize a [SphereContext], but if such a
-    /// context has not already been initialized, accessing it with this method
+    /// creating or joining will initialize a [SphereChannel], but if such a
+    /// channel has not already been initialized, accessing it with this method
     /// will cause it to be initialized and a reference kept by this
     /// [NoosphereContext].
     pub async fn get_sphere_channel(&self, sphere_identity: &Did) -> Result<PlatformSphereChannel> {

--- a/rust/noosphere/src/noosphere.rs
+++ b/rust/noosphere/src/noosphere.rs
@@ -8,8 +8,8 @@ use url::Url;
 
 use crate::{
     key::KeyStorage,
-    platform::{PlatformKeyMaterial, PlatformKeyStorage, PlatformStorage},
-    sphere::{SphereContextBuilder, SphereReceipt},
+    platform::{PlatformKeyStorage, PlatformSphereChannel},
+    sphere::{SphereChannel, SphereContextBuilder, SphereReceipt},
 };
 
 /// An enum describing different storage stragies that may be interesting
@@ -71,8 +71,7 @@ pub struct NoosphereContextConfiguration {
 /// a handle to backing storage for spheres that are being accessed regularly.
 pub struct NoosphereContext {
     configuration: NoosphereContextConfiguration,
-    sphere_contexts:
-        Arc<Mutex<BTreeMap<Did, Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>>>>,
+    sphere_channels: Arc<Mutex<BTreeMap<Did, PlatformSphereChannel>>>,
 }
 
 impl NoosphereContext {
@@ -80,7 +79,7 @@ impl NoosphereContext {
     pub fn new(configuration: NoosphereContextConfiguration) -> Result<Self> {
         Ok(NoosphereContext {
             configuration,
-            sphere_contexts: Default::default(),
+            sphere_channels: Default::default(),
         })
     }
 
@@ -153,8 +152,11 @@ impl NoosphereContext {
         let context = SphereContext::from(artifacts);
 
         let sphere_identity = context.identity().to_owned();
-        let mut sphere_contexts = self.sphere_contexts.lock().await;
-        sphere_contexts.insert(sphere_identity.clone(), Arc::new(Mutex::new(context)));
+        let mut sphere_contexts = self.sphere_channels.lock().await;
+        sphere_contexts.insert(
+            sphere_identity.clone(),
+            SphereChannel::new(Arc::new(context.clone()), Arc::new(Mutex::new(context))),
+        );
 
         Ok(SphereReceipt {
             identity: sphere_identity,
@@ -188,8 +190,11 @@ impl NoosphereContext {
         let context = SphereContext::from(artifacts);
 
         let sphere_identity = context.identity().to_owned();
-        let mut sphere_contexts = self.sphere_contexts.lock().await;
-        sphere_contexts.insert(sphere_identity, Arc::new(Mutex::new(context)));
+        let mut sphere_contexts = self.sphere_channels.lock().await;
+        sphere_contexts.insert(
+            sphere_identity,
+            SphereChannel::new(Arc::new(context.clone()), Arc::new(Mutex::new(context))),
+        );
 
         Ok(())
     }
@@ -201,11 +206,8 @@ impl NoosphereContext {
     /// context has not already been initialized, accessing it with this method
     /// will cause it to be initialized and a reference kept by this
     /// [NoosphereContext].
-    pub async fn get_sphere_context(
-        &self,
-        sphere_identity: &Did,
-    ) -> Result<Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>> {
-        let mut contexts = self.sphere_contexts.lock().await;
+    pub async fn get_sphere_channel(&self, sphere_identity: &Did) -> Result<PlatformSphereChannel> {
+        let mut contexts = self.sphere_channels.lock().await;
 
         if !contexts.contains_key(sphere_identity) {
             let artifacts = SphereContextBuilder::default()
@@ -219,8 +221,10 @@ impl NoosphereContext {
                 .await?;
 
             let context = SphereContext::from(artifacts);
-
-            contexts.insert(sphere_identity.to_owned(), Arc::new(Mutex::new(context)));
+            contexts.insert(
+                sphere_identity.to_owned(),
+                SphereChannel::new(Arc::new(context.clone()), Arc::new(Mutex::new(context))),
+            );
         }
 
         Ok(contexts

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -143,4 +143,20 @@ mod inner {
     }
 }
 
+use std::sync::Arc;
+
 pub use inner::*;
+use noosphere_sphere::SphereContext;
+use tokio::sync::Mutex;
+
+use crate::sphere::SphereChannel;
+
+// NOTE: We may someday define the 3rd and 4th terms of this type differently on
+// web, where `Arc` and `Mutex` are currently overkill for our needs and may be
+// substituted for `Rc` and `RwLock`, respectively.
+pub type PlatformSphereChannel = SphereChannel<
+    PlatformKeyMaterial,
+    PlatformStorage,
+    Arc<SphereContext<PlatformKeyMaterial, PlatformStorage>>,
+    Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>,
+>;

--- a/rust/noosphere/src/sphere/channel.rs
+++ b/rust/noosphere/src/sphere/channel.rs
@@ -1,0 +1,67 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use noosphere_sphere::{HasMutableSphereContext, HasSphereContext, SphereContext};
+use noosphere_storage::Storage;
+use tokio::sync::Mutex;
+use ucan::crypto::KeyMaterial;
+
+/// A [SphereChannel] provides duplex access to a given sphere, where one side
+/// is read-only/immutable, and the other side is read-write/mutable. This
+/// supports immutable sphere reads to happen in parallel with long-running
+/// mutable operations on the sphere. Note that it is up to the user of a
+/// [SphereChannel] to be mindful of potential race conditions. For example, if
+/// you read from the immutable side while concurrently writing to the mutable
+/// side, the result of your read will subject to the race outcome.
+#[derive(Clone)]
+pub struct SphereChannel<K, S, Ci, Cm>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Storage,
+    Ci: HasSphereContext<K, S>,
+    Cm: HasMutableSphereContext<K, S>,
+{
+    immutable: Ci,
+    mutable: Cm,
+    key_marker: PhantomData<K>,
+    storage_marker: PhantomData<S>,
+}
+
+impl<K, S, Ci, Cm> SphereChannel<K, S, Ci, Cm>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Storage,
+    Ci: HasSphereContext<K, S>,
+    Cm: HasMutableSphereContext<K, S>,
+{
+    pub fn new(immutable: Ci, mutable: Cm) -> Self {
+        Self {
+            immutable,
+            mutable,
+            key_marker: PhantomData,
+            storage_marker: PhantomData,
+        }
+    }
+
+    /// The immutable / read-only side of the channel
+    pub fn immutable(&self) -> &Ci {
+        &self.immutable
+    }
+
+    /// The mutable / read-write side of the channel
+    pub fn mutable(&mut self) -> &mut Cm {
+        &mut self.mutable
+    }
+}
+
+impl<K, S> Into<SphereChannel<K, S, Arc<SphereContext<K, S>>, Arc<Mutex<SphereContext<K, S>>>>>
+    for SphereContext<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    fn into(
+        self,
+    ) -> SphereChannel<K, S, Arc<SphereContext<K, S>>, Arc<Mutex<SphereContext<K, S>>>> {
+        SphereChannel::new(Arc::new(self.clone()), Arc::new(Mutex::new(self)))
+    }
+}

--- a/rust/noosphere/src/sphere/mod.rs
+++ b/rust/noosphere/src/sphere/mod.rs
@@ -1,5 +1,7 @@
 mod builder;
+mod channel;
 mod receipt;
 
 pub use builder::*;
+pub use channel::*;
 pub use receipt::*;

--- a/rust/noosphere/src/wasm/noosphere.rs
+++ b/rust/noosphere/src/wasm/noosphere.rs
@@ -163,7 +163,7 @@ impl NoosphereContext {
         Ok(SphereContext {
             inner: self
                 .inner
-                .get_sphere_context(&identity.into())
+                .get_sphere_channel(&identity.into())
                 .await
                 .map_err(|error| format!("{:?}", error))?,
         })

--- a/rust/noosphere/tests/integration.rs
+++ b/rust/noosphere/tests/integration.rs
@@ -223,7 +223,7 @@ async fn writes_do_not_block_reads() {
 
     assert!(pending_file.is_none());
 
-    write_task.await.unwrap();
+    write_task.await.unwrap().unwrap();
 
     let pending_file = sphere_channel.immutable().read("foo").await.unwrap();
 

--- a/rust/noosphere/tests/integration.rs
+++ b/rust/noosphere/tests/integration.rs
@@ -1,9 +1,21 @@
 #![cfg(test)]
 
+use std::pin::Pin;
+
+#[cfg(target_arch = "wasm32")]
+use instant::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Duration;
+
+use anyhow::Result;
+use async_stream::try_stream;
+use bytes::Bytes;
 use noosphere_core::{data::ContentType, tracing::initialize_tracing};
 use noosphere_sphere::{HasMutableSphereContext, SphereContentRead, SphereContentWrite};
 
 use tokio::io::AsyncReadExt;
+use tokio_stream::Stream;
+use tokio_util::io::StreamReader;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -57,13 +69,42 @@ fn platform_configuration() -> (
     (configuration, (global_storage, sphere_storage))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::time::sleep;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::task::spawn;
+
+#[cfg(target_arch = "wasm32")]
+async fn spawn<F, O>(future: F) -> O
+where
+    F: std::future::Future<Output = O> + 'static,
+{
+    future.await
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn sleep(duration: Duration) {
+    gloo_timers::future::sleep(duration).await
+}
+
+fn slow_content() -> Pin<Box<StreamReader<impl Stream<Item = Result<Bytes, std::io::Error>>, Bytes>>>
+{
+    Box::pin(StreamReader::new(try_stream! {
+        for _ in 0..3 {
+            sleep(Duration::from_millis(100)).await;
+            yield Bytes::from(vec![0])
+        }
+    }))
+}
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn single_player_single_device_end_to_end_workflow() {
     initialize_tracing();
 
     let (configuration, _temporary_directories) = platform_configuration();
-    let key_name = "foobar";
+    let key_name = "foobarbaz";
 
     // Create the sphere and write a file to it
     let sphere_identity = {
@@ -76,17 +117,18 @@ async fn single_player_single_device_end_to_end_workflow() {
             ..
         } = noosphere.create_sphere(key_name).await.unwrap();
 
-        let mut sphere_context = noosphere
-            .get_sphere_context(&sphere_identity)
+        let mut sphere_channel = noosphere
+            .get_sphere_channel(&sphere_identity)
             .await
             .unwrap();
 
-        sphere_context
+        sphere_channel
+            .mutable()
             .write("foo", "text/plain", b"bar".as_ref(), None)
             .await
             .unwrap();
 
-        sphere_context.save(None).await.unwrap();
+        sphere_channel.mutable().save(None).await.unwrap();
 
         sphere_identity
     };
@@ -95,12 +137,17 @@ async fn single_player_single_device_end_to_end_workflow() {
     {
         let noosphere = NoosphereContext::new(configuration.clone()).unwrap();
 
-        let mut sphere_context = noosphere
-            .get_sphere_context(&sphere_identity)
+        let mut sphere_channel = noosphere
+            .get_sphere_channel(&sphere_identity)
             .await
             .unwrap();
 
-        let mut file = sphere_context.read("foo").await.unwrap().unwrap();
+        let mut file = sphere_channel
+            .immutable()
+            .read("foo")
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             file.memo.content_type(),
@@ -112,11 +159,73 @@ async fn single_player_single_device_end_to_end_workflow() {
 
         assert_eq!(contents, "bar");
 
-        sphere_context
+        sphere_channel
+            .mutable()
             .write("cats", "text/subtext", b"are great".as_ref(), None)
             .await
             .unwrap();
 
-        sphere_context.save(None).await.unwrap();
+        sphere_channel.mutable().save(None).await.unwrap();
     };
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn writes_do_not_block_reads() {
+    let (configuration, _temporary_directories) = platform_configuration();
+    let key_name = "foobar";
+
+    let noosphere = NoosphereContext::new(configuration.clone()).unwrap();
+
+    noosphere.create_key(key_name).await.unwrap();
+
+    let SphereReceipt {
+        identity: sphere_identity,
+        ..
+    } = noosphere.create_sphere(key_name).await.unwrap();
+
+    let mut sphere_channel = noosphere
+        .get_sphere_channel(&sphere_identity)
+        .await
+        .unwrap();
+
+    sphere_channel
+        .mutable()
+        .write("cats", "text/subtext", b"are great".as_ref(), None)
+        .await
+        .unwrap();
+    sphere_channel.mutable().save(None).await.unwrap();
+
+    let write_task = spawn({
+        let mut sphere_channel = sphere_channel.clone();
+        async move {
+            sphere_channel
+                .mutable()
+                .write("foo", "application/octet-stream", slow_content(), None)
+                .await?;
+
+            sphere_channel.mutable().save(None).await
+        }
+    });
+
+    let mut file = sphere_channel
+        .immutable()
+        .read("cats")
+        .await
+        .unwrap()
+        .unwrap();
+    let mut content = String::new();
+    file.contents.read_to_string(&mut content).await.unwrap();
+
+    assert_eq!(content.as_str(), "are great");
+
+    let pending_file = sphere_channel.immutable().read("foo").await.unwrap();
+
+    assert!(pending_file.is_none());
+
+    write_task.await.unwrap();
+
+    let pending_file = sphere_channel.immutable().read("foo").await.unwrap();
+
+    assert!(pending_file.is_some());
 }

--- a/rust/noosphere/tests/integration.rs
+++ b/rust/noosphere/tests/integration.rs
@@ -76,11 +76,11 @@ use tokio::time::sleep;
 use tokio::task::spawn;
 
 #[cfg(target_arch = "wasm32")]
-async fn spawn<F, O>(future: F) -> O
+async fn spawn<F, O>(future: F) -> Result<O>
 where
     F: std::future::Future<Output = O> + 'static,
 {
-    future.await
+    Ok(future.await)
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
This change introduces a `SphereChannel`, which enables us to execute read-only and read-write streams of work on spheres concurrently or in parallel. Standard race condition considerations apply: if you intersperse reads and parallel writes, the values that are read will be subject to race results (for example).

Although the mutable and immutable sides of the channel do not block each other, it's still possible for immutable reads to reach out to the network (which means any given immutable read may take a beat to finish, subject to network conditions).