### PR TITLE
chore: Fix deprecation notices from libp2p 0.51.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,7 +2874,6 @@ dependencies = [
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
- "libp2p-mplex",
  "libp2p-noise",
  "libp2p-quic",
  "libp2p-swarm",
@@ -3085,24 +3084,6 @@ dependencies = [
  "libp2p-kad",
  "libp2p-swarm",
  "prometheus-client",
-]
-
-[[package]]
-name = "libp2p-mplex"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d34780b514b159e6f3fd70ba3e72664ec89da28dca2d1e7856ee55e2c7031ba"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "futures",
- "libp2p-core",
- "log 0.4.17",
- "nohash-hasher",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "smallvec",
- "unsigned-varint 0.7.1",
 ]
 
 [[package]]

--- a/rust/noosphere-ns/Cargo.toml
+++ b/rust/noosphere-ns/Cargo.toml
@@ -38,7 +38,7 @@ ucan-key-support = { workspace = true }
 tokio = { version = "1.15", features = ["io-util", "io-std", "sync", "macros", "rt", "rt-multi-thread"] }
 noosphere-storage = { version = "0.6.2", path = "../noosphere-storage" }
 noosphere-core = { version = "0.9.3", path = "../noosphere-core" }
-libp2p = { version = "0.51.3", default-features = false, features = [ "identify", "dns", "kad", "macros", "mplex", "noise", "serde", "tcp", "tokio", "yamux" ] }
+libp2p = { version = "0.51.3", default-features = false, features = [ "ed25519", "identify", "dns", "kad", "macros", "noise", "serde", "tcp", "tokio", "yamux" ] }
 
 # noosphere_ns::bin
 noosphere = { version = "0.9.1", path = "../noosphere", optional = true }

--- a/rust/noosphere-ns/src/dht/node.rs
+++ b/rust/noosphere-ns/src/dht/node.rs
@@ -33,7 +33,7 @@ macro_rules! ensure_response {
 /// #[tokio::main]
 /// async fn main() {
 ///     let node = DhtNode::new(
-///         Keypair::Ed25519(ed25519::Keypair::generate()),
+///         Keypair::generate_ed25519(),
 ///         Default::default(),
 ///         Some(AllowAllValidator{}),
 ///     ).unwrap();
@@ -267,7 +267,7 @@ mod test {
         let mut nodes = vec![];
         for _ in 0..node_count {
             let node = DhtNode::new(
-                Keypair::Ed25519(libp2p::core::identity::ed25519::Keypair::generate()),
+                Keypair::generate_ed25519(),
                 Default::default(),
                 validator.clone(),
             )?;
@@ -309,7 +309,7 @@ mod test {
 
     fn create_unfiltered_dht_node() -> Result<DhtNode, DhtError> {
         DhtNode::new::<AllowAllValidator>(
-            Keypair::Ed25519(libp2p::core::identity::ed25519::Keypair::generate()),
+            Keypair::generate_ed25519(),
             Default::default(),
             Some(AllowAllValidator {}),
         )


### PR DESCRIPTION
* Consistently use `libp2p::identity::Keypair` rather than `libp2p::core::identity::Keypair` and use the `libp2p-identity` crate recently introduced. Rework some of the decoding methods.
  * New keys use secret key only for de/encoding -- the `ed25519_to_bytes` helper could be configured to use this, or removed completely if inlined into the `NameSystemKeyMaterial` trait.
* Remove deprecated/unused mplex module
* Replace `Swarm::with_tokio_executor`
* New `libp2p_allow_block_list` module requires more configuring with our mixed `DhtBehavior` (implementing for both kad/identify underlying behaviors), so `SwarmEvent::BannedPeer` event remains deprecated