### PR TITLE
feat: Enable support of quorum=0 for DHT during infra bootstrapping phase

### DIFF
--- a/rust/noosphere-ns/src/bin/orb-ns/cli/processor.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/cli/processor.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use noosphere::key::{InsecureKeyStorage, KeyStorage};
 use noosphere_ns::server::HttpClient;
-use noosphere_ns::NameSystemClient;
+use noosphere_ns::DhtClient;
 use serde::Serialize;
 use tracing::*;
 
@@ -125,7 +125,7 @@ pub async fn process_command(
             }
             CLICommand::Records(CLIRecords::Put { record, api_url }) => {
                 let client = HttpClient::new(api_url).await?;
-                client.put_record(record).await?;
+                client.put_record(record, 1).await?;
                 Ok(CommandResponse::empty())
             }
             CLICommand::Peers(CLIPeers::Ls { api_url }) => {

--- a/rust/noosphere-ns/src/bin/orb-ns/runner/runner.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/runner/runner.rs
@@ -1,7 +1,7 @@
 use crate::runner::config::RunnerNodeConfig;
 use anyhow::Result;
 use noosphere_ipfs::{IpfsStore, KuboClient};
-use noosphere_ns::{Multiaddr, NameSystem, NameSystemClient, PeerId};
+use noosphere_ns::{DhtClient, Multiaddr, NameSystem, PeerId};
 use noosphere_storage::{BlockStoreRetry, MemoryStore, UcanStore};
 use serde::Serialize;
 use std::{

--- a/rust/noosphere-ns/src/builder.rs
+++ b/rust/noosphere-ns/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{dht::DhtConfig, name_system::NameSystem, NameSystemClient, NameSystemKeyMaterial};
+use crate::{dht::DhtConfig, name_system::NameSystem, DhtClient, NameSystemKeyMaterial};
 use anyhow::{anyhow, Result};
 use libp2p::{self, Multiaddr};
 use std::net::Ipv4Addr;
@@ -16,7 +16,7 @@ use libp2p::kad::KademliaConfig;
 /// ```
 /// use noosphere_core::authority::generate_ed25519_key;
 /// use noosphere_storage::{SphereDb, MemoryStorage};
-/// use noosphere_ns::{BOOTSTRAP_PEERS, NameSystem, NameSystemClient, NameSystemBuilder};
+/// use noosphere_ns::{BOOTSTRAP_PEERS, NameSystem, DhtClient, NameSystemBuilder};
 /// use ucan_key_support::ed25519::Ed25519KeyMaterial;
 /// use tokio;
 ///

--- a/rust/noosphere-ns/src/dht/rpc.rs
+++ b/rust/noosphere-ns/src/dht/rpc.rs
@@ -7,18 +7,34 @@ use std::{fmt, str};
 
 #[derive(Debug)]
 pub enum DhtRequest {
-    AddPeers { peers: Vec<Multiaddr> },
-    StartListening { address: Multiaddr },
+    AddPeers {
+        peers: Vec<Multiaddr>,
+    },
+    StartListening {
+        address: Multiaddr,
+    },
     StopListening,
     Bootstrap,
     //WaitForPeers(usize),
-    GetAddresses { external: bool },
+    GetAddresses {
+        external: bool,
+    },
     GetPeers,
     GetNetworkInfo,
-    GetRecord { key: Vec<u8> },
-    PutRecord { key: Vec<u8>, value: Vec<u8> },
-    StartProviding { key: Vec<u8> },
-    GetProviders { key: Vec<u8> },
+    GetRecord {
+        key: Vec<u8>,
+    },
+    PutRecord {
+        key: Vec<u8>,
+        value: Vec<u8>,
+        quorum: usize,
+    },
+    StartProviding {
+        key: Vec<u8>,
+    },
+    GetProviders {
+        key: Vec<u8>,
+    },
 }
 
 impl fmt::Display for DhtRequest {
@@ -51,11 +67,12 @@ impl fmt::Display for DhtRequest {
                 "DHTRequest::GetRecord {{ key={:?} }}",
                 str::from_utf8(key)
             ),
-            DhtRequest::PutRecord { key, value } => write!(
+            DhtRequest::PutRecord { key, value, quorum } => write!(
                 fmt,
-                "DHTRequest::PutRecord {{ key={:?}, value={:?} }}",
+                "DHTRequest::PutRecord {{ key={:?}, value={:?}, quorum={:?} }}",
                 str::from_utf8(key),
-                str::from_utf8(value)
+                str::from_utf8(value),
+                quorum,
             ),
             DhtRequest::StartProviding { key } => write!(
                 fmt,

--- a/rust/noosphere-ns/src/helpers.rs
+++ b/rust/noosphere-ns/src/helpers.rs
@@ -1,4 +1,4 @@
-use crate::{DhtConfig, NameSystem, NameSystemClient};
+use crate::{DhtClient, DhtConfig, NameSystem};
 use anyhow::Result;
 use libp2p::Multiaddr;
 use noosphere_core::authority::generate_ed25519_key;

--- a/rust/noosphere-ns/src/lib.rs
+++ b/rust/noosphere-ns/src/lib.rs
@@ -6,11 +6,11 @@ extern crate tracing;
 #[macro_use]
 extern crate lazy_static;
 
-pub mod dht;
-//mod name_resolver;
 mod builder;
-mod client;
+pub mod dht;
+mod dht_client;
 pub mod helpers;
+mod name_resolver;
 mod name_system;
 mod records;
 pub mod utils;
@@ -19,8 +19,9 @@ pub mod utils;
 pub mod server;
 
 pub use builder::NameSystemBuilder;
-pub use client::NameSystemClient;
 pub use dht::{DhtConfig, NetworkInfo, Peer};
+pub use dht_client::DhtClient;
 pub use libp2p::{multiaddr::Multiaddr, PeerId};
+pub use name_resolver::NameResolver;
 pub use name_system::{NameSystem, NameSystemKeyMaterial, BOOTSTRAP_PEERS};
 pub use records::NsRecord;

--- a/rust/noosphere-ns/src/name_resolver.rs
+++ b/rust/noosphere-ns/src/name_resolver.rs
@@ -1,0 +1,62 @@
+use crate::{DhtClient, NsRecord};
+use anyhow::Result;
+use async_trait::async_trait;
+use noosphere_core::data::Did;
+
+#[async_trait]
+pub trait NameResolver: Send + Sync {
+    /// Publishes a record to the name system.
+    async fn publish(&self, record: NsRecord) -> Result<()>;
+    /// Retrieves a record from the name system.
+    async fn resolve(&self, identity: &Did) -> Result<Option<NsRecord>>;
+}
+
+#[async_trait]
+impl<T: DhtClient> NameResolver for T {
+    async fn publish(&self, record: NsRecord) -> Result<()> {
+        self.put_record(record, 0).await
+    }
+
+    async fn resolve(&self, identity: &Did) -> Result<Option<NsRecord>> {
+        self.get_record(identity).await
+    }
+}
+
+/// Helper macro for running agnostic [NameResolver] tests for
+/// multiple implementations: [NameSystem] and [HttpClient].
+#[cfg(test)]
+#[macro_export]
+macro_rules! name_resolver_tests {
+    ($type:ty, $before_each:ident) => {
+        #[tokio::test]
+        async fn name_resolver_simple() -> Result<()> {
+            let resolver = $before_each().await?;
+            $crate::name_resolver::test::test_name_resolver_simple::<$type>(resolver).await
+        }
+    };
+}
+
+#[cfg(test)]
+/// These tests are designed to run on implementations of the
+/// [NameResolver] trait, both `NameSystem` and `server::HttpClient`.
+pub mod test {
+    use super::*;
+    use cid::Cid;
+    use noosphere_core::{authority::generate_ed25519_key, data::Did, tracing::initialize_tracing};
+    use ucan::crypto::KeyMaterial;
+
+    pub async fn test_name_resolver_simple<N: NameResolver>(resolver: N) -> Result<()> {
+        initialize_tracing();
+        let sphere_key = generate_ed25519_key();
+        let sphere_id = Did::from(sphere_key.get_did().await?);
+        let link: Cid = "bafy2bzacec4p5h37mjk2n6qi6zukwyzkruebvwdzqpdxzutu4sgoiuhqwne72"
+            .parse()
+            .unwrap();
+        let record = NsRecord::from_issuer(&sphere_key, &sphere_id, &link, None).await?;
+
+        resolver.publish(record).await?;
+        let resolved = resolver.resolve(&sphere_id).await?.unwrap();
+        assert_eq!(resolved.link().unwrap(), &link);
+        Ok(())
+    }
+}

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -147,10 +147,6 @@ impl NsRecord {
         store: &S,
         opt_did_parser: Option<&mut DidParser>,
     ) -> Result<(), NsRecordError> {
-        if self.is_expired() {
-            return Err(NsRecordError::Expired);
-        }
-
         if self.link.is_none() {
             return Err(NsRecordError::MissingLink);
         }
@@ -194,6 +190,11 @@ impl NsRecord {
         Ok(())
     }
 
+    /// Returns true if the [Ucan] token is past its expiration.
+    pub fn has_publishable_timeframe(&self) -> bool {
+        self.token.is_expired() == false && self.token.is_too_early() == false
+    }
+
     /// The DID key of the sphere that this record maps.
     pub fn identity(&self) -> &str {
         self.token.audience()
@@ -202,11 +203,6 @@ impl NsRecord {
     /// The sphere revision address ([Cid]) that the sphere's identity maps to.
     pub fn link(&self) -> Option<&Cid> {
         self.link.as_ref()
-    }
-
-    /// Returns true if the [Ucan] token is past its expiration.
-    pub fn is_expired(&self) -> bool {
-        self.token.is_expired()
     }
 
     /// Encodes the underlying Ucan token back into a JWT string.

--- a/rust/noosphere-ns/src/server/server.rs
+++ b/rust/noosphere-ns/src/server/server.rs
@@ -1,5 +1,5 @@
 use crate::server::{handlers, routes::Route};
-use crate::{NameSystem, NameSystemClient};
+use crate::{DhtClient, NameSystem};
 use anyhow::Result;
 use axum::routing::{delete, get, post};
 use axum::{Extension, Router, Server};

--- a/rust/noosphere-ns/src/utils.rs
+++ b/rust/noosphere-ns/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::NameSystemClient;
+use crate::DhtClient;
 use anyhow;
 use libp2p::{
     multiaddr::{Multiaddr, Protocol},
@@ -61,7 +61,7 @@ pub fn generate_fact(address: &str) -> serde_json::Value {
 /// A utility for [NameSystemClient] in tests.
 /// Async function returns once there are at least
 /// `requested_peers` peers in the network.
-pub async fn wait_for_peers<T: NameSystemClient>(
+pub async fn wait_for_peers<T: DhtClient>(
     client: &T,
     requested_peers: usize,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION

* Decouple validity vs expiration in NsRecord::validate.
* Fixes #264, using response from name system server.
* Remove "local cache" from NameSystem, as its a bit dated and redundant with libp2p Kademlia storage, where persistence and validity should be handled.
* Rename s/NameSystemClient/DhtClient and separate p2p nature from the name resolver, via NameResolver trait (publish, resolve) for consumer usage (e.g. hiding those quorum rules from gateway).