### PR TITLE
feat: validate link records on the gateway

### DIFF
--- a/rust/noosphere-gateway/src/route/push.rs
+++ b/rust/noosphere-gateway/src/route/push.rs
@@ -312,6 +312,7 @@ where
             if let Err(error) = self.name_system_tx.send(NameSystemJob::Publish {
                 context: self.sphere_context.clone(),
                 record: name_record.clone(),
+                temporary_validate_expiry: false,
             }) {
                 warn!("Failed to request name record publish: {}", error);
             }

--- a/rust/noosphere-gateway/src/worker/syndication.rs
+++ b/rust/noosphere-gateway/src/worker/syndication.rs
@@ -77,162 +77,175 @@ where
 
     let kubo_client = Arc::new(KuboClient::new(&ipfs_api)?);
 
-    while let Some(SyndicationJob { revision, context }) = receiver.recv().await {
-        debug!("Attempting to syndicate version DAG {revision} to IPFS");
-        let kubo_identity = match kubo_client.server_identity().await {
-            Ok(id) => id,
-            Err(error) => {
-                warn!(
-                    "Failed to identify an IPFS Kubo node at {}: {}",
-                    ipfs_api, error
-                );
-                continue;
-            }
-        };
-        let checkpoint_key = format!("syndication/kubo/{kubo_identity}");
-
-        debug!("IPFS node identified as {}", kubo_identity);
-
-        // Take a lock on the `SphereContext` and look up the most recent
-        // syndication checkpoint for this Kubo node
-        let (sphere_revision, ancestor_revision, mut syndicated_blocks, db) = {
-            let db = {
-                let context = context.sphere_context().await?;
-                context.db().clone()
-            };
-
-            let counterpart_identity = db.require_key::<_, Did>(COUNTERPART).await?;
-            let sphere = context.to_sphere().await?;
-            let content = sphere.get_content().await?;
-
-            let counterpart_revision = content.require(&counterpart_identity).await?.clone();
-
-            let (last_syndicated_revision, syndicated_blocks) =
-                match context.read(&checkpoint_key).await? {
-                    Some(mut file) => match file.memo.content_type() {
-                        Some(ContentType::Cbor) => {
-                            let mut bytes = Vec::new();
-                            file.contents.read_to_end(&mut bytes).await?;
-                            let SyndicationCheckpoint {
-                                revision,
-                                syndicated_blocks,
-                            } = block_deserialize::<DagCborCodec, _>(&bytes)?;
-                            (Some(revision), syndicated_blocks)
-                        }
-                        _ => (None, BloomFilter::default()),
-                    },
-                    None => (None, BloomFilter::default()),
-                };
-
-            (
-                counterpart_revision,
-                last_syndicated_revision,
-                syndicated_blocks,
-                db,
-            )
-        };
-
-        let timeline = Timeline::new(&db)
-            .slice(&sphere_revision, ancestor_revision.as_ref())
-            .to_chronological()
-            .await?;
-
-        // For all CIDs since the last historical checkpoint, syndicate a CAR
-        // of blocks that are unique to that revision to the backing IPFS
-        // implementation
-        for (cid, _) in timeline {
-            // TODO(#175): At each increment, if there are sub-graphs of a
-            // sphere that should *not* be syndicated (e.g., other spheres
-            // referenced by this sphere that are probably syndicated
-            // elsewhere), we should add them to the bloom filter at this spot.
-
-            let stream = db.query_links(&cid, {
-                let filter = Arc::new(syndicated_blocks.clone());
-                let kubo_client = kubo_client.clone();
-
-                move |cid| {
-                    let filter = filter.clone();
-                    let kubo_client = kubo_client.clone();
-                    let cid = *cid;
-
-                    async move {
-                        // The Bloom filter probabilistically tells us if we
-                        // have syndicated a block; it is probabilistic because
-                        // `contains` may give us false positives. But, all
-                        // negatives are guaranteed to not have been added. So,
-                        // we can rely on it as a short cut to find unsyndicated
-                        // blocks, and for positives we can verify the pin
-                        // status with the IPFS node.
-                        if !filter.contains(&cid.to_bytes()) {
-                            return Ok(true);
-                        }
-
-                        // This will probably end up being rather noisy for the
-                        // IPFS node, but hopefully checking for a pin is not
-                        // overly costly. We may have to come up with a
-                        // different strategy if this turns out to be too noisy.
-                        Ok(!kubo_client.block_is_pinned(&cid).await?)
-                    }
-                }
-            });
-
-            // TODO(#2): It would be cool to make reading from storage and
-            // writing to an HTTP request body concurrent / streamed; this way
-            // we could send over CARs of arbitrary size (within the limits of
-            // whatever the IPFS receiving implementation can support).
-            let mut car = Vec::new();
-            let car_header = CarHeader::new_v1(vec![cid]);
-            let mut car_writer = CarWriter::new(car_header, &mut car);
-
-            tokio::pin!(stream);
-
-            loop {
-                match stream.try_next().await {
-                    Ok(Some(cid)) => {
-                        trace!("Syndication will include block {}", cid);
-                        // TODO(#176): We need to build-up a list of blocks that aren't
-                        // able to be loaded so that we can be resilient to incomplete
-                        // data when syndicating to IPFS
-                        syndicated_blocks.add(&cid.to_bytes());
-
-                        let block = db.require_block(&cid).await?;
-
-                        car_writer.write(cid, block).await?;
-                    }
-                    Err(error) => {
-                        warn!("Encountered error while streaming links: {:?}", error);
-                    }
-                    _ => break,
-                }
-            }
-
-            match kubo_client.syndicate_blocks(Cursor::new(car)).await {
-                Ok(_) => debug!("Syndicated sphere revision {} to IPFS", cid),
-                Err(error) => warn!("Failed to syndicate revision {} to IPFS: {:?}", cid, error),
-            };
-        }
-
-        // At the end, take another lock on the `SphereContext` in order to
-        // update the syndication checkpoint for this particular IPFS server
-        {
-            let mut cursor = SphereCursor::latest(context.clone());
-            let (_, bytes) = block_serialize::<DagCborCodec, _>(&SyndicationCheckpoint {
-                revision,
-                syndicated_blocks,
-            })?;
-
-            cursor
-                .write(
-                    &checkpoint_key,
-                    &ContentType::Cbor.to_string(),
-                    Cursor::new(bytes),
-                    None,
-                )
-                .await?;
-
-            cursor.save(None).await?;
+    while let Some(job) = receiver.recv().await {
+        if let Err(error) = process_job(job, kubo_client.clone(), &ipfs_api).await {
+            warn!("Error processing IPFS job: {}", error);
         }
     }
+    Ok(())
+}
 
+async fn process_job<C, K, S>(
+    job: SyndicationJob<C>,
+    kubo_client: Arc<KuboClient>,
+    ipfs_api: &Url,
+) -> Result<()>
+where
+    C: HasMutableSphereContext<K, S>,
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    let SyndicationJob { revision, context } = job;
+    debug!("Attempting to syndicate version DAG {revision} to IPFS");
+    let kubo_identity = kubo_client.server_identity().await.map_err(|error| {
+        anyhow::anyhow!(
+            "Failed to identify an IPFS Kubo node at {}: {}",
+            ipfs_api,
+            error
+        )
+    })?;
+    let checkpoint_key = format!("syndication/kubo/{kubo_identity}");
+
+    debug!("IPFS node identified as {}", kubo_identity);
+
+    // Take a lock on the `SphereContext` and look up the most recent
+    // syndication checkpoint for this Kubo node
+    let (sphere_revision, ancestor_revision, mut syndicated_blocks, db) = {
+        let db = {
+            let context = context.sphere_context().await?;
+            context.db().clone()
+        };
+
+        let counterpart_identity = db.require_key::<_, Did>(COUNTERPART).await?;
+        let sphere = context.to_sphere().await?;
+        let content = sphere.get_content().await?;
+
+        let counterpart_revision = content.require(&counterpart_identity).await?.clone();
+
+        let (last_syndicated_revision, syndicated_blocks) =
+            match context.read(&checkpoint_key).await? {
+                Some(mut file) => match file.memo.content_type() {
+                    Some(ContentType::Cbor) => {
+                        let mut bytes = Vec::new();
+                        file.contents.read_to_end(&mut bytes).await?;
+                        let SyndicationCheckpoint {
+                            revision,
+                            syndicated_blocks,
+                        } = block_deserialize::<DagCborCodec, _>(&bytes)?;
+                        (Some(revision), syndicated_blocks)
+                    }
+                    _ => (None, BloomFilter::default()),
+                },
+                None => (None, BloomFilter::default()),
+            };
+
+        (
+            counterpart_revision,
+            last_syndicated_revision,
+            syndicated_blocks,
+            db,
+        )
+    };
+
+    let timeline = Timeline::new(&db)
+        .slice(&sphere_revision, ancestor_revision.as_ref())
+        .to_chronological()
+        .await?;
+
+    // For all CIDs since the last historical checkpoint, syndicate a CAR
+    // of blocks that are unique to that revision to the backing IPFS
+    // implementation
+    for (cid, _) in timeline {
+        // TODO(#175): At each increment, if there are sub-graphs of a
+        // sphere that should *not* be syndicated (e.g., other spheres
+        // referenced by this sphere that are probably syndicated
+        // elsewhere), we should add them to the bloom filter at this spot.
+
+        let stream = db.query_links(&cid, {
+            let filter = Arc::new(syndicated_blocks.clone());
+            let kubo_client = kubo_client.clone();
+
+            move |cid| {
+                let filter = filter.clone();
+                let kubo_client = kubo_client.clone();
+                let cid = *cid;
+
+                async move {
+                    // The Bloom filter probabilistically tells us if we
+                    // have syndicated a block; it is probabilistic because
+                    // `contains` may give us false positives. But, all
+                    // negatives are guaranteed to not have been added. So,
+                    // we can rely on it as a short cut to find unsyndicated
+                    // blocks, and for positives we can verify the pin
+                    // status with the IPFS node.
+                    if !filter.contains(&cid.to_bytes()) {
+                        return Ok(true);
+                    }
+
+                    // This will probably end up being rather noisy for the
+                    // IPFS node, but hopefully checking for a pin is not
+                    // overly costly. We may have to come up with a
+                    // different strategy if this turns out to be too noisy.
+                    Ok(!kubo_client.block_is_pinned(&cid).await?)
+                }
+            }
+        });
+
+        // TODO(#2): It would be cool to make reading from storage and
+        // writing to an HTTP request body concurrent / streamed; this way
+        // we could send over CARs of arbitrary size (within the limits of
+        // whatever the IPFS receiving implementation can support).
+        let mut car = Vec::new();
+        let car_header = CarHeader::new_v1(vec![cid]);
+        let mut car_writer = CarWriter::new(car_header, &mut car);
+
+        tokio::pin!(stream);
+
+        loop {
+            match stream.try_next().await {
+                Ok(Some(cid)) => {
+                    trace!("Syndication will include block {}", cid);
+                    // TODO(#176): We need to build-up a list of blocks that aren't
+                    // able to be loaded so that we can be resilient to incomplete
+                    // data when syndicating to IPFS
+                    syndicated_blocks.add(&cid.to_bytes());
+
+                    let block = db.require_block(&cid).await?;
+
+                    car_writer.write(cid, block).await?;
+                }
+                Err(error) => {
+                    warn!("Encountered error while streaming links: {:?}", error);
+                }
+                _ => break,
+            }
+        }
+
+        match kubo_client.syndicate_blocks(Cursor::new(car)).await {
+            Ok(_) => debug!("Syndicated sphere revision {} to IPFS", cid),
+            Err(error) => warn!("Failed to syndicate revision {} to IPFS: {:?}", cid, error),
+        };
+    }
+
+    // At the end, take another lock on the `SphereContext` in order to
+    // update the syndication checkpoint for this particular IPFS server
+    {
+        let mut cursor = SphereCursor::latest(context.clone());
+        let (_, bytes) = block_serialize::<DagCborCodec, _>(&SyndicationCheckpoint {
+            revision,
+            syndicated_blocks,
+        })?;
+
+        cursor
+            .write(
+                &checkpoint_key,
+                &ContentType::Cbor.to_string(),
+                Cursor::new(bytes),
+                None,
+            )
+            .await?;
+
+        cursor.save(None).await?;
+    }
     Ok(())
 }


### PR DESCRIPTION
Enables gateways to validate a records' proof chain before adoption over IPFS, and verify expiry before publishing. Fixes #257. Changes in `syndication.rs` are exclusively from moving the logic inside a function to catch errors without taking down the processor (only logic change is early aborting if IPFS node isn't found).