### PR TITLE
fix: Remove vestigial `tracing-core` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,7 +3932,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-core",
  "tracing-subscriber",
  "tracing-wasm",
  "ucan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ resolver = "2"
 [workspace.dependencies]
 subtext = { version = "0.3.4" }
 tracing = { version = "0.1" }
-tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
 thiserror = { version = "1" }
 instant = { version = "0.1" }

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -60,7 +60,6 @@ serde_bytes = "~0.11"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "^1", features = ["full"] }
 tracing-subscriber = { workspace = true }
-tracing-core = { worksapce = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: This is needed so that rand can be included in WASM builds


### PR DESCRIPTION
The typo in the dependency was preventing us from publishing to crates.io.

And, the dependency is not used (which is why we didn't see any errors in CI). So, we remove it.