### PR TITLE
Update orb-ns for cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,7 +4079,6 @@ dependencies = [
  "toml",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "ucan",
  "ucan-key-support",
  "url 2.3.1",

--- a/images/orb-ns/start.sh
+++ b/images/orb-ns/start.sh
@@ -26,4 +26,7 @@ if [[ -z "$2" ]]; then
 	exit 1
 fi
 
+echo "RUST_LOG=${RUST_LOG}"
+echo "NOOSPHERE_LOG=${NOOSPHERE_LOG}"
+
 orb-ns run --config $CONFIG_FILE

--- a/images/orb/start.sh
+++ b/images/orb/start.sh
@@ -23,4 +23,7 @@ if ! [ -z "$NS_API" ]; then
 	ARGS="${ARGS} --name-resolver-api ${NS_API}"
 fi
 
+echo "RUST_LOG=${RUST_LOG}"
+echo "NOOSPHERE_LOG=${NOOSPHERE_LOG}"
+
 orb serve $ARGS

--- a/rust/noosphere-cli/tests/peer_to_peer.rs
+++ b/rust/noosphere-cli/tests/peer_to_peer.rs
@@ -86,7 +86,7 @@ async fn start_name_system_server(ipfs_url: &Url) -> Result<(JoinHandle<()>, Url
         tokio::spawn(async move {
             let mut network = NameSystemNetwork::generate(2, store).await.unwrap();
             let node = network.nodes_mut().pop().unwrap();
-            start_name_system_api_server(Arc::new(Mutex::new(node)), listener)
+            start_name_system_api_server(Arc::new(node), listener)
                 .await
                 .unwrap();
         }),

--- a/rust/noosphere-core/src/tracing.rs
+++ b/rust/noosphere-core/src/tracing.rs
@@ -17,6 +17,8 @@ pub static NOOSPHERE_LOG_LEVEL_CRATES: &[&str] = &[
     "noosphere_car",
     "noosphere_api",
     "noosphere_ns",
+    "orb",
+    "orb_ns",
     "tower_http",
 ];
 

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -37,6 +37,8 @@ use ucan::crypto::KeyMaterial;
 use url::Url;
 
 const PERIODIC_PUBLISH_INTERVAL_SECONDS: u64 = 5 * 60;
+/// How many seconds between queueing up an address
+/// to resolve from the name system.
 const PERIODIC_RESOLVER_INTERVAL_SECONDS: u64 = 60;
 
 pub struct NameSystemConfiguration {

--- a/rust/noosphere-ns/Cargo.toml
+++ b/rust/noosphere-ns/Cargo.toml
@@ -51,7 +51,6 @@ toml = { version = "~0.5", optional = true }
 # noosphere_ns::server
 axum = { version = "~0.5", features = ["json", "headers", "macros"], optional = true }
 reqwest = { version = "~0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
-tracing-subscriber = { workspace = true, optional = true }
 tower-http = { version = "~0.3", features = ["trace"], optional = true }
 url = { version = "^2", features = [ "serde" ], optional = true }
 
@@ -65,7 +64,7 @@ tempdir = { version = "~0.3" }
 
 [features]
 default = ["orb-ns", "api-server"]
-api-server = ["axum", "reqwest", "url", "tracing-subscriber", "tower-http"]
+api-server = ["axum", "reqwest", "url", "tower-http"]
 orb-ns = ["clap", "noosphere", "home", "toml", "noosphere-ipfs"]
 
 [[bin]]

--- a/rust/noosphere-ns/src/bin/orb-ns/runner/config.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/runner/config.rs
@@ -187,6 +187,9 @@ listening_address = 10000
 peers = [
     "/ip4/127.0.0.1/tcp/10001"
 ]
+
+[dht_config]
+query_timeout = 55
 "#,
         )
         .await?;
@@ -207,6 +210,14 @@ peers = [
         )
         .await?;
 
+        assert!(
+            config.dht_config.query_timeout == 55,
+            "expected explicit DhtConfig properties to apply"
+        );
+        assert!(
+            config.dht_config.bootstrap_interval == 5 * 60,
+            "expected default DhtConfig properties to apply"
+        );
         assert!(
             keys_equal(&config.key_material, &key_1).await?,
             "expected key material"

--- a/rust/noosphere-ns/src/bin/orb-ns/runner/runner_implementation.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/runner/runner_implementation.rs
@@ -12,7 +12,6 @@ use std::{
     task,
     time::Duration,
 };
-use tokio::sync::Mutex;
 use url::Url;
 
 #[cfg(feature = "api-server")]
@@ -22,7 +21,7 @@ use noosphere_ns::server::ApiServer;
 struct ApiServer;
 #[cfg(not(feature = "api-server"))]
 impl ApiServer {
-    pub fn serve(_ns: Arc<Mutex<NameSystem>>, _listener: TcpListener) -> Self {
+    pub fn serve(_ns: Arc<NameSystem>, _listener: TcpListener) -> Self {
         ApiServer {}
     }
 }
@@ -35,7 +34,7 @@ impl ApiServer {
 pub struct NameSystemRunner {
     #[serde(skip_serializing)]
     #[allow(dead_code)]
-    name_system: Arc<Mutex<NameSystem>>,
+    name_system: Arc<NameSystem>,
     #[serde(skip_serializing)]
     #[allow(dead_code)]
     api_thread: Option<ApiServer>,
@@ -80,7 +79,7 @@ impl NameSystemRunner {
         node.add_peers(config.peers.to_owned()).await?;
         node.bootstrap().await?;
 
-        let wrapped_node = Arc::new(Mutex::new(node));
+        let wrapped_node = Arc::new(node);
 
         let (api_address, api_thread) = if cfg!(feature = "api-server") {
             if let Some(requested_addr) = config.api_address.take() {

--- a/rust/noosphere-ns/src/dht/config.rs
+++ b/rust/noosphere-ns/src/dht/config.rs
@@ -8,40 +8,77 @@ pub struct DhtConfig {
     /// If bootstrap peers are provided, how often,
     /// in seconds, should the bootstrap process execute
     /// to keep routing tables fresh.
+    #[serde(default = "default_bootstrap_interval")]
     pub bootstrap_interval: u64,
     /// How frequently, in seconds, the DHT attempts to
     /// dial peers found in its kbucket. Outside of tests,
     /// should not be lower than 5 seconds.
+    #[serde(default = "default_peer_dialing_interval")]
     pub peer_dialing_interval: u64,
     /// How long, in seconds, published records are replicated to
     /// peers. Should be significantly shorter than `record_ttl`.
     /// See [KademliaConfig::set_publication_interval] and [KademliaConfig::set_provider_publication_interval].
+    #[serde(default = "default_publication_interval")]
     pub publication_interval: u32,
     /// How long, in seconds, until an unsuccessful
     /// DHT query times out.
+    #[serde(default = "default_query_timeout")]
     pub query_timeout: u32,
     /// How long, in seconds, stored records are replicated to
     /// peers. Should be significantly shorter than `publication_interval`.
     /// See [KademliaConfig::set_replication_interval].
     /// Only applies to value records.
+    #[serde(default = "default_replication_interval")]
     pub replication_interval: u32,
     /// How long, in seconds, records remain valid for. Should be significantly
     /// longer than `publication_interval`.
     /// See [KademliaConfig::set_record_ttl] and [KademliaConfig::set_provider_record_ttl].
+    #[serde(default = "default_record_ttl")]
     pub record_ttl: u32,
 }
 
+// We break up defaults into individual functions to support deserializing
+// via serde when `DhtConfig` is used as a nested value. Otherwise,
+// `[dht_config] query_timeout = 60` would require defining all other fields.
+
+fn default_bootstrap_interval() -> u64 {
+    5 * 60 // 5 mins
+}
+
+fn default_peer_dialing_interval() -> u64 {
+    if cfg!(test) {
+        1
+    } else {
+        5
+    }
+}
+
+fn default_publication_interval() -> u32 {
+    60 * 60 * 24 // 1 day
+}
+
+fn default_query_timeout() -> u32 {
+    5 * 60 // 5 mins
+}
+
+fn default_replication_interval() -> u32 {
+    60 * 60 // 1 hour
+}
+
+fn default_record_ttl() -> u32 {
+    60 * 60 * 24 * 3 // 3 days
+}
+
 impl Default for DhtConfig {
-    /// Creates a new [DHTConfig] with defaults applied.
+    /// Creates a new [DhtConfig] with defaults applied.
     fn default() -> Self {
-        let peer_dialing_interval = if cfg!(test) { 1 } else { 5 };
         Self {
-            bootstrap_interval: 5 * 60, // 5 mins
-            peer_dialing_interval,
-            publication_interval: 60 * 60 * 24, // 1 day
-            query_timeout: 5 * 60,              // 5 mins
-            replication_interval: 60 * 60,      // 1 hour
-            record_ttl: 60 * 60 * 24 * 3,       // 3 days
+            bootstrap_interval: default_bootstrap_interval(),
+            peer_dialing_interval: default_peer_dialing_interval(),
+            publication_interval: default_publication_interval(),
+            query_timeout: default_query_timeout(),
+            replication_interval: default_replication_interval(),
+            record_ttl: default_record_ttl(),
         }
     }
 }

--- a/rust/noosphere-ns/src/records.rs
+++ b/rust/noosphere-ns/src/records.rs
@@ -14,7 +14,12 @@ use serde::{
     ser::{self, Serialize, Serializer},
 };
 use serde_json::Value;
-use std::{convert::TryFrom, fmt::Display, str, str::FromStr};
+use std::{
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    str,
+    str::FromStr,
+};
 use ucan::{
     builder::UcanBuilder,
     crypto::KeyMaterial,
@@ -59,7 +64,7 @@ use ucan::{chain::ProofChain, crypto::did::DidParser, Ucan};
 ///   }]
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NsRecord {
     /// The wrapped UCAN token describing this record.
     pub(crate) token: Ucan,
@@ -218,6 +223,18 @@ impl NsRecord {
     /// Encodes the underlying Ucan token back into a JWT string.
     pub fn try_to_string(&self) -> Result<String, anyhow::Error> {
         self.token.encode()
+    }
+}
+
+impl Debug for NsRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let link = self.link.map(|cid| cid.to_string());
+        write!(
+            f,
+            "NsRecord {{ \"sphere\": \"{}\", \"link\": \"{:?}\" }}",
+            self.token.audience(),
+            link
+        )
     }
 }
 

--- a/rust/noosphere-ns/src/server/client.rs
+++ b/rust/noosphere-ns/src/server/client.rs
@@ -175,7 +175,7 @@ mod test {
             .await
             .unwrap();
 
-        let ns = Arc::new(Mutex::new(ns));
+        let ns = Arc::new(ns);
         let server = ApiServer::serve(ns, api_listener);
         let data = DataPlaceholder {
             _server: server,

--- a/rust/noosphere-ns/src/server/implementation.rs
+++ b/rust/noosphere-ns/src/server/implementation.rs
@@ -5,17 +5,13 @@ use axum::routing::{delete, get, post};
 use axum::{Extension, Router, Server};
 use std::net::TcpListener;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tower_http::trace::TraceLayer;
 
 pub async fn start_name_system_api_server(
-    ns: Arc<Mutex<NameSystem>>,
+    ns: Arc<NameSystem>,
     listener: TcpListener,
 ) -> Result<()> {
-    let peer_id = {
-        let resolver = ns.lock().await;
-        resolver.peer_id().to_owned()
-    };
+    let peer_id = ns.peer_id().to_owned();
 
     let app = Router::new()
         .route(
@@ -51,7 +47,7 @@ pub struct ApiServer {
 }
 
 impl ApiServer {
-    pub fn serve(ns: Arc<Mutex<NameSystem>>, listener: TcpListener) -> Self {
+    pub fn serve(ns: Arc<NameSystem>, listener: TcpListener) -> Self {
         let handle = tokio::spawn(async move {
             start_name_system_api_server(ns, listener).await?;
             Ok(())

--- a/rust/noosphere-ns/tests/ns_test.rs
+++ b/rust/noosphere-ns/tests/ns_test.rs
@@ -3,7 +3,9 @@
 
 use anyhow::Result;
 use cid::Cid;
-use noosphere_core::{authority::generate_ed25519_key, data::Did, view::SPHERE_LIFETIME};
+use noosphere_core::{
+    authority::generate_ed25519_key, data::Did, tracing::initialize_tracing, view::SPHERE_LIFETIME,
+};
 use noosphere_ns::{
     helpers::NameSystemNetwork,
     utils::{generate_capability, generate_fact},
@@ -68,6 +70,7 @@ impl PseudoSphere {
 
 #[tokio::test]
 async fn test_name_system_peer_propagation() -> Result<()> {
+    initialize_tracing(None);
     // Create two NameSystems, where `ns_1` is publishing for `sphere_1`
     // and `ns_2` is publishing for `sphere_2`.
     let mut db = SphereDb::new(&MemoryStorage::default()).await?;
@@ -164,8 +167,9 @@ async fn test_name_system_peer_propagation() -> Result<()> {
     Ok(())
 }
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn test_name_system_validation() -> Result<()> {
+    initialize_tracing(None);
     let mut db = SphereDb::new(&MemoryStorage::default()).await?;
     let network = NameSystemNetwork::generate(2, Some(db.clone())).await?;
 


### PR DESCRIPTION
* remove mutex from NameSystem's APIServer
* Add logs for RUST_LOG, NOOSPHERE_LOG in image startup scripts
* add `orb` and `orb_ns` in default tracing

Added here, but not immediate relevant:
* support defining partial DhtConfig values via TOML: ultimately we want to expose these knobs, but turns out libp2p's `query_timeout` is not the overall request timeout that we want currently (as a "request" is comprised of several "queries")
* improve `NsRecord`'s Debug formatting: useful, but really need to fix the debug representation of libp2p's `Record`
* remove `tracing_subscriber` from noosphere_ns, causing wild logging results (unfortunately did not fix tracing weirdness in noosphere_ns)