### PR TITLE
feat: Enable expired yet valid records in the name system. Update to ucan 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6529,9 +6529,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucan"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45b08aa0818ab9be5d922d3931ea893a6c2e84d1a3bd6433ff2ca3e04a23425"
+checksum = "b0237a17cf06465fce3ab4126c91d0745123b0d21a2ef5adbd3da47d10309455"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6557,9 +6557,9 @@ dependencies = [
 
 [[package]]
 name = "ucan-key-support"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bac0239e6369aa844b2b153cd3cf0cbbc13fa6ff5ccc277408c36c44568e8e3"
+checksum = "f99720d7a9d4b5a7cf3f2a9d17c951bbaa6331f00c07aa8845e80e9fb4c8faf1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"]
 thiserror = { version = "1" }
 instant = { version = "0.1" }
 gloo-timers = { version = "0.2", features = ["futures"] }
-ucan = { version = "0.1.2" }
-ucan-key-support = { version = "0.1.2" }
+ucan = { version = "0.2.0" }
+ucan-key-support = { version = "0.1.3" }
 libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }

--- a/rust/noosphere-api/src/data.rs
+++ b/rust/noosphere-api/src/data.rs
@@ -208,7 +208,7 @@ impl IdentifyResponse {
         // Verify that the signature is valid
         gateway_key.verify(&payload_bytes, &signature_bytes).await?;
 
-        let proof = ProofChain::try_from_token_string(&self.proof, did_parser, store).await?;
+        let proof = ProofChain::try_from_token_string(&self.proof, None, did_parser, store).await?;
 
         if proof.ucan().audience() != self.gateway_identity.as_str() {
             return Err(anyhow!("Wrong audience!"));

--- a/rust/noosphere-core/src/authority/author.rs
+++ b/rust/noosphere-core/src/authority/author.rs
@@ -88,7 +88,7 @@ where
                 can: SphereAction::Push,
             };
             let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-            let proof_chain = ProofChain::from_ucan(ucan, &mut did_parser, db).await?;
+            let proof_chain = ProofChain::from_ucan(ucan, None, &mut did_parser, db).await?;
 
             let capability_infos = proof_chain.reduce_capabilities(&SPHERE_SEMANTICS);
 

--- a/rust/noosphere-core/src/authority/verification.rs
+++ b/rust/noosphere-core/src/authority/verification.rs
@@ -60,7 +60,7 @@ pub async fn verify_sphere_cid<S: Storage>(
         credential.verify(&memo.body.to_bytes(), &signature).await?;
 
         // Check the proof's provenance and that it enables the signer to sign
-        let proof = ProofChain::from_ucan(ucan, did_parser, &ucan_store).await?;
+        let proof = ProofChain::from_ucan(ucan, None, did_parser, &ucan_store).await?;
 
         let desired_capability = Capability {
             with: With::Resource {

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -509,11 +509,12 @@ impl<S: BlockStore> Sphere<S> {
 
         let proof_chain = match current_authorization {
             Authorization::Ucan(ucan) => {
-                ProofChain::from_ucan(ucan.clone(), did_parser, &ucan_store).await?
+                ProofChain::from_ucan(ucan.clone(), None, did_parser, &ucan_store).await?
             }
             Authorization::Cid(cid) => {
                 ProofChain::try_from_token_string(
                     &ucan_store.require_token(cid).await?,
+                    None,
                     did_parser,
                     &ucan_store,
                 )

--- a/rust/noosphere-gateway/src/authority.rs
+++ b/rust/noosphere-gateway/src/authority.rs
@@ -126,16 +126,17 @@ where
         let proof_chain = {
             let mut sphere_context = sphere_context.lock().await;
             let did_parser = sphere_context.did_parser_mut();
-            let proof_chain = ProofChain::try_from_token_string(bearer.token(), did_parser, &db)
-                .await
-                .map_err(|error| {
-                    error!("{:?}", error);
-                    StatusCode::BAD_REQUEST
-                })?;
+            let proof_chain =
+                ProofChain::try_from_token_string(bearer.token(), None, did_parser, &db)
+                    .await
+                    .map_err(|error| {
+                        error!("{:?}", error);
+                        StatusCode::BAD_REQUEST
+                    })?;
 
             proof_chain
                 .ucan()
-                .validate(did_parser)
+                .validate(None, did_parser)
                 .await
                 .map_err(|error| {
                     error!("{:?}", error);

--- a/rust/noosphere-ns/tests/ns_test.rs
+++ b/rust/noosphere-ns/tests/ns_test.rs
@@ -187,8 +187,8 @@ async fn test_name_system_validation() -> Result<()> {
             1
         )
         .await
-        .is_err(),
-        "invalid (expired) records cannot be propagated"
+        .is_ok(),
+        "expired records can be propagated"
     );
     Ok(())
 }


### PR DESCRIPTION
Thanks to @cdata and https://github.com/ucan-wg/rs-ucan/pull/83, we can construct a ProofChain with a valid, yet expired, record. Add a test, and change the behavior of other tests: this is now allowed!