### PR TITLE
fix: Cargo workspace inheritance in `release-please`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: chainguard-dev/actions/setup-gitsign@main
       - name: 'Run release-please'
         id: release
-        uses: cdata/release-please-action@main
+        uses: cdata/release-please-action@fix/support-cargo-workspace-dependency-inheritance
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           default-branch: main


### PR DESCRIPTION
During the latest release (last week), we hit a really lame bug in `release-please`: https://github.com/googleapis/release-please/issues/1896

TL;DR, `release-please` doesn't currently detect that a Cargo workspace member has changed, if that member uses [workspace dependency inheritance](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) and also one of its inherited dependencies changed at the workspace level.

This bug led to a bad release where `noosphere-storage` technically should have had a release due to a version change in an inherited dependency. Since it didn't have a release, it is now incompatible with all the other crates that did get released.

This PR switches us to use a patched version of `release-please` that supports detecting changes in inherited dependencies. As this change makes its way into upstream `release-please`, we will switch back.