### PR TITLE
chore: Commit and tag Package.swift during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,12 +142,41 @@ jobs:
 
           sed -i -e "s#url: \"[^\"]*\",#url: \"$URL\",#" ./Package.swift
           sed -i -e "s#checksum: \"[^\"]*\"),#checksum: \"${{ steps.generate-checksum.outputs.checksum }}\"),#" ./Package.swift
-      # TODO(#135): Evaluate if we want to automatically check this change in
-      # and push it to the project repository
       - uses: actions/upload-artifact@v3
         with:
           name: swift-package-manifest
           path: ./Package.swift
+      - name: 'Commit and tag Package.swift for latest release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOOSPHERE_VERSION: ${{ needs.release-please.outputs.noosphere_release_tag_name }}
+        run: |
+          # Adapted from https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c
+
+          # Turn off history expansion so that Bash doesn't freak out about $MESSAGE contents
+          # https://stackoverflow.com/a/11816138
+          set +H
+
+          export MESSAGE="feat!: Update Swift Package Noosphere dependency to $NOOSPHERE_VERSION"
+          export SHA=$(git rev-parse main:Package.swift)
+          export CONTENT=$(base64 -i Package.swift)
+
+          # Update Package.swift via the Github API (we do it this way to get 'easy' commit signing)
+          # https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents
+
+          export COMMIT_SHA_TO_TAG=$(gh api --method PUT /repos/subconsciousnetwork/noosphere/contents/Package.swift \
+            --field message="$MESSAGE" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="main" \
+            --field sha="$SHA" | jq .commit.sha | xargs echo)
+
+          # Also add a tag for the SwiftNoosphere release that correlates with the latest Noosphere release
+          # https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference
+
+          gh api --method POST /repos/subconsciousnetwork/noosphere/git/refs \
+            --field ref="refs/tags/swift-$NOOSPHERE_VERSION" \
+            --field sha="$COMMIT_SHA_TO_TAG"
 
   # Publishes crates to crates.io in dependency order. This command is
   # idempotent and won't re-publish crates that are already published, so it's
@@ -161,7 +190,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: 'Setup Rust'
-        run: | 
+        run: |
           curl -sSf https://sh.rustup.rs | sh -s -- -y
       - name: 'Install environment packages'
         run: |


### PR DESCRIPTION
This change adds a step to our release that commits and tags `Package.swift` so that it points to the latest Noosphere release. The latest Noosphere release is tagged as `noosphere-$VERSION`, and the corresponding SwiftNoosphere release is tagged as `swift-noosphere-$VERSION`.

Fixes #135 