### PR TITLE
feat: Get petnames assigned to a DID for a sphere

### DIFF
--- a/rust/noosphere-sphere/src/has.rs
+++ b/rust/noosphere-sphere/src/has.rs
@@ -151,6 +151,21 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<K, S, T> HasSphereContext<K, S> for &T
+where
+    T: HasSphereContext<K, S>,
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    type SphereContext = T::SphereContext;
+
+    async fn sphere_context(&self) -> Result<Self::SphereContext> {
+        (*self).sphere_context().await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<K, S> HasSphereContext<K, S> for Arc<SphereContext<K, S>>
 where
     K: KeyMaterial + Clone + 'static,

--- a/rust/noosphere-sphere/src/petname/read.rs
+++ b/rust/noosphere-sphere/src/petname/read.rs
@@ -34,13 +34,16 @@ where
 
 fn assigned_petnames_cache_key(origin: &Did, peer: &Did, origin_version: &Cid) -> String {
     format!(
-        "cache:petname:assigned:{}:{}:{}",
+        "noosphere:cache:petname:assigned:{}:{}:{}",
         origin, peer, origin_version
     )
 }
 
 fn sphere_checkpoint_cache_key(origin: &Did, origin_version: &Cid) -> String {
-    format!("cache:petname:checkpoint:{}:{}", origin, origin_version)
+    format!(
+        "noosphere:cache:petname:checkpoint:{}:{}",
+        origin, origin_version
+    )
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/rust/noosphere-sphere/src/petname/read.rs
+++ b/rust/noosphere-sphere/src/petname/read.rs
@@ -1,11 +1,14 @@
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use cid::Cid;
+use futures_util::TryStreamExt;
 use noosphere_core::data::Did;
-use noosphere_storage::Storage;
+use noosphere_storage::{KeyValueStore, Storage};
 use ucan::crypto::KeyMaterial;
 
-use crate::HasSphereContext;
+use crate::{HasSphereContext, SphereWalker};
 
 /// Anything that provides read access to petnames in a sphere should implement
 /// [SpherePetnameRead]. A blanket implementation is provided for any container
@@ -23,6 +26,21 @@ where
     /// Resolve the petname via its assigned [Did] to a [Cid] that refers to a
     /// point in history of a sphere
     async fn resolve_petname(&self, name: &str) -> Result<Option<Cid>>;
+
+    /// Given a [Did], get all the petnames that have been assigned to it
+    /// in this sphere
+    async fn get_assigned_petnames(&self, did: &Did) -> Result<Vec<String>>;
+}
+
+fn assigned_petnames_cache_key(origin: &Did, peer: &Did, origin_version: &Cid) -> String {
+    format!(
+        "cache:petname:assigned:{}:{}:{}",
+        origin, peer, origin_version
+    )
+}
+
+fn sphere_checkpoint_cache_key(origin: &Did, origin_version: &Cid) -> String {
+    format!("cache:petname:checkpoint:{}:{}", origin, origin_version)
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -33,6 +51,60 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
+    #[instrument(skip(self))]
+    async fn get_assigned_petnames(&self, peer: &Did) -> Result<Vec<String>> {
+        let version = self.version().await?;
+        let origin = self.identity().await?;
+
+        debug!("Getting petnames assigned in {origin} at version {version}");
+
+        let mut db = self.sphere_context().await?.db().clone();
+        let key = assigned_petnames_cache_key(&origin, peer, &version);
+
+        if let Some(names) = db.get_key::<_, Vec<String>>(key).await? {
+            return Ok(names);
+        }
+
+        let checkpoint_key = sphere_checkpoint_cache_key(&origin, &version);
+
+        if db.get_key::<_, u8>(&checkpoint_key).await?.is_some() {
+            warn!("No names were assigned to {peer}",);
+            return Ok(vec![]);
+        }
+
+        let walker = SphereWalker::from(self);
+        let petname_stream = walker.petname_stream();
+        let mut did_petnames: BTreeMap<Did, Vec<String>> = BTreeMap::new();
+
+        tokio::pin!(petname_stream);
+
+        while let Some((petname, identity)) = petname_stream.try_next().await? {
+            match did_petnames.get_mut(&identity.did) {
+                Some(petnames) => {
+                    petnames.push(petname);
+                }
+                None => {
+                    did_petnames.insert(identity.did, vec![petname]);
+                }
+            };
+        }
+
+        let mut assigned_petnames = None;
+
+        for (did, petnames) in did_petnames {
+            if &did == peer {
+                assigned_petnames = Some(petnames.clone());
+            }
+
+            let key = assigned_petnames_cache_key(&origin, &did, &version);
+            db.set_key(key, petnames).await?;
+        }
+
+        db.set_key(checkpoint_key, 1u8).await?;
+
+        Ok(assigned_petnames.unwrap_or_default())
+    }
+
     async fn get_petname(&self, name: &str) -> Result<Option<Did>> {
         let sphere = self.to_sphere().await?;
         let identities = sphere.get_address_book().await?.get_identities().await?;

--- a/rust/noosphere-sphere/src/walker.rs
+++ b/rust/noosphere-sphere/src/walker.rs
@@ -59,11 +59,11 @@ where
         try_stream! {
             let sphere = self.has_sphere_context.to_sphere().await?;
             let petnames = sphere.get_address_book().await?.get_identities().await?;
-            let stream = petnames.stream().await?;
+            let stream = petnames.into_stream().await?;
 
             for await entry in stream {
                 let (petname, address) = entry?;
-                yield (petname.clone(), address.clone());
+                yield (petname, address);
             }
         }
     }

--- a/swift/Sources/SwiftNoosphere/Noosphere.swift
+++ b/swift/Sources/SwiftNoosphere/Noosphere.swift
@@ -51,6 +51,26 @@ public func nsSphereFileContentsRead(_ noosphere: OpaquePointer!, _ sphere_file:
 }
 
 
+public typealias NsSpherePetnamesAssignedGetHandler = (OpaquePointer?, slice_boxed_char_ptr_t) -> ()
+
+/// See: ns_sphere_petnames_assigned_get
+public func nsSpherePetnamesAssignedGet(_ noosphere: OpaquePointer!, _ sphere_file: OpaquePointer!, _ peer_identity: UnsafePointer<CChar>!, handler: @escaping NsSpherePetnamesAssignedGetHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_petnames_assigned_get(noosphere, sphere_file, peer_identity, context) {
+        (context, error, petnames) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSpherePetnamesAssignedGetHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error, petnames)
+    }
+}
+
+
 public typealias NsSphereTraverseByPetnameHandler = (OpaquePointer?, OpaquePointer?) -> ()
 
 /// See: ns_sphere_traverse_by_petname


### PR DESCRIPTION
This introduces a built-in facility for getting all of the petnames assigned to a DID at a given version of a sphere. The discovery is limited to petnames and DIDs that are in the current sphere's address book.

Since petnames are encoded `petname -> DID` in the data structure, we compute the inverse assignments on-demand and cache the results for a given version of the sphere. This represents a basic optimization over an expensive operation. In time, we may be able to optimize by only computing updates based on sphere history deltas (https://github.com/subconsciousnetwork/noosphere/issues/383).

Also included in this change is the corresponding callback-based C FFI, and a Swift helper and example test.

Fixes #358 