### PR TITLE
feat: return `None` instead of throwing in `ns_sphere_petname_resolve()` when a petname cannot be resolved.

### DIFF
--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -532,7 +532,8 @@ final class NoosphereTests: XCTestCase {
         
         ns_sphere_petname_set(noosphere, sphere, "alice", "did:key:alice", nil)
         ns_sphere_save(noosphere, sphere, nil, nil)
-        
+        assert(ns_sphere_petname_resolve(noosphere, sphere, "alice", nil) == nil)
+
         let has_alice = ns_sphere_petname_is_set(noosphere, sphere, "alice", nil) == 1
         
         assert(has_alice)


### PR DESCRIPTION
Fixes #393