### PR TITLE
fix: Resolve petnames in correct order

### DIFF
--- a/rust/noosphere-gateway/src/route/push.rs
+++ b/rust/noosphere-gateway/src/route/push.rs
@@ -260,7 +260,7 @@ where
                         // can ignore changes to names in the past that we have
                         // already encountered in the future
                         if updated_names.contains(&key) {
-                            trace!("Skipping name add for {}...", key);
+                            trace!("Skipping name add for '{}' (already seen)...", key);
                             continue;
                         }
 
@@ -270,7 +270,7 @@ where
                         // changed to avoid redundantly recording updates made
                         // on the client due to a previous sync
                         if my_value != Some(&value) {
-                            debug!("Adding name {}...", key);
+                            debug!("Adding name '{}' ({})...", key, value.did);
                             self.sphere_context
                                 .sphere_context_mut()
                                 .await?
@@ -283,11 +283,11 @@ where
                     }
                     MapOperation::Remove { key } => {
                         if updated_names.contains(&key) {
-                            trace!("Skipping name removal for {}...", key);
+                            trace!("Skipping name removal for '{}' (already seen)...", key);
                             continue;
                         }
 
-                        debug!("Removing name {}...", key);
+                        debug!("Removing name '{}'...", key);
                         self.sphere_context
                             .sphere_context_mut()
                             .await?

--- a/rust/noosphere-ns/src/bin/orb-ns/cli/mod.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/cli/mod.rs
@@ -160,7 +160,7 @@ mod test {
         let value = res.value().unwrap();
         let fetched = serde_json::from_str::<LinkRecord>(value).unwrap();
         assert_eq!(fetched.get_link().unwrap(), cid_link.into());
-        assert_eq!(fetched.sphere_identity(), &id_b);
+        assert_eq!(fetched.to_sphere_identity(), id_b);
 
         Ok(())
     }

--- a/rust/noosphere-ns/src/dht_client.rs
+++ b/rust/noosphere-ns/src/dht_client.rs
@@ -195,7 +195,7 @@ pub mod test {
             .await?
             .expect("should be some");
 
-        assert_eq!(retrieved.sphere_identity(), sphere_identity);
+        assert_eq!(retrieved.to_sphere_identity(), sphere_identity);
         assert_eq!(retrieved.get_link(), Some(link.into()));
         Ok(())
     }

--- a/rust/noosphere-ns/src/helpers.rs
+++ b/rust/noosphere-ns/src/helpers.rs
@@ -92,7 +92,7 @@ impl Default for KeyValueNameResolver {
 impl NameResolver for KeyValueNameResolver {
     async fn publish(&self, record: LinkRecord) -> Result<()> {
         let mut store = self.store.lock().await;
-        let did_id = Did(record.sphere_identity().into());
+        let did_id = Did(record.to_sphere_identity().into());
         store.insert(did_id, record);
         Ok(())
     }

--- a/rust/noosphere-ns/src/name_system.rs
+++ b/rust/noosphere-ns/src/name_system.rs
@@ -133,7 +133,7 @@ impl DhtClient for NameSystem {
     }
 
     async fn put_record(&self, record: LinkRecord, quorum: usize) -> Result<()> {
-        let identity = Did::from(record.sphere_identity());
+        let identity = record.to_sphere_identity();
         let record_bytes: Vec<u8> = record.try_into()?;
         match self
             .dht

--- a/rust/noosphere-sphere/src/content/write.rs
+++ b/rust/noosphere-sphere/src/content/write.rs
@@ -30,9 +30,9 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    /// Like link, this takes a [Link<MemoIpld>] that should be associated directly with
-    /// a slug, but in this case the [Link<MemoIpld>] is assumed to refer to a memo, so
-    /// no wrapping memo is created.
+    /// Like link, this takes a [Link<MemoIpld>] that should be associated
+    /// directly with a slug, but in this case the [Link<MemoIpld>] is assumed
+    /// to refer to a memo, so no wrapping memo is created.
     async fn link_raw(&mut self, slug: &str, cid: &Link<MemoIpld>) -> Result<()>;
 
     /// Similar to write, but instead of generating blocks from some provided

--- a/rust/noosphere-sphere/src/context.rs
+++ b/rust/noosphere-sphere/src/context.rs
@@ -243,7 +243,7 @@ pub mod tests {
 
     use crate::{
         helpers::{make_valid_link_record, simulated_sphere_context, SimulationAccess},
-        HasSphereContext, SphereContentWrite, SpherePetnameWrite,
+        HasMutableSphereContext, HasSphereContext, SphereContentWrite, SpherePetnameWrite,
     };
 
     #[cfg(target_arch = "wasm32")]
@@ -290,7 +290,7 @@ pub mod tests {
 
         for invalid_name in invalid_names {
             assert!(sphere_context
-                .adopt_petname(invalid_name, &link_record)
+                .set_petname_record(invalid_name, &link_record)
                 .await
                 .is_err());
             assert!(sphere_context
@@ -301,11 +301,12 @@ pub mod tests {
 
         for valid_name in valid_names {
             assert!(sphere_context
-                .adopt_petname(valid_name, &link_record)
+                .set_petname(valid_name, Some(other_identity.clone()))
                 .await
                 .is_ok());
+            sphere_context.save(None).await?;
             assert!(sphere_context
-                .set_petname(valid_name, Some(other_identity.clone()))
+                .set_petname_record(valid_name, &link_record)
                 .await
                 .is_ok());
         }

--- a/rust/noosphere-sphere/src/cursor.rs
+++ b/rust/noosphere-sphere/src/cursor.rs
@@ -530,11 +530,26 @@ pub mod tests {
 
         let mut cursor = SphereCursor::latest(sphere_context);
 
-        cursor.adopt_petname("foo1", &link_record_1).await?;
-        cursor.adopt_petname("bar1", &link_record_1).await?;
-        cursor.adopt_petname("baz1", &link_record_1).await?;
+        cursor
+            .set_petname("foo1", Some(link_record_1.to_sphere_identity()))
+            .await?;
+        cursor
+            .set_petname("bar1", Some(link_record_1.to_sphere_identity()))
+            .await?;
+        cursor
+            .set_petname("baz1", Some(link_record_1.to_sphere_identity()))
+            .await?;
 
-        cursor.adopt_petname("foo2", &link_record_2).await?;
+        cursor
+            .set_petname("foo2", Some(link_record_2.to_sphere_identity()))
+            .await?;
+        cursor.save(None).await?;
+
+        cursor.set_petname_record("foo1", &link_record_1).await?;
+        cursor.set_petname_record("bar1", &link_record_1).await?;
+        cursor.set_petname_record("baz1", &link_record_1).await?;
+
+        cursor.set_petname_record("foo2", &link_record_2).await?;
 
         cursor.save(None).await?;
 
@@ -567,8 +582,16 @@ pub mod tests {
             ]
         );
 
-        cursor.adopt_petname("bar2", &link_record_2).await?;
-        cursor.adopt_petname("foo3", &link_record_3).await?;
+        cursor
+            .set_petname("bar2", Some(link_record_2.to_sphere_identity()))
+            .await?;
+        cursor
+            .set_petname("foo3", Some(link_record_3.to_sphere_identity()))
+            .await?;
+        cursor.save(None).await?;
+
+        cursor.set_petname_record("bar2", &link_record_2).await?;
+        cursor.set_petname_record("foo3", &link_record_3).await?;
         cursor.save(None).await?;
 
         assert_eq!(

--- a/rust/noosphere-sphere/src/helpers.rs
+++ b/rust/noosphere-sphere/src/helpers.rs
@@ -236,9 +236,13 @@ pub async fn make_sphere_context_with_peer_chain(
             file.contents.read_to_string(&mut name).await.unwrap();
 
             debug!("Adopting {name}");
+            sphere_context
+                .set_petname(&name, Some(next_identity))
+                .await?;
+            sphere_context.save(None).await?;
 
             sphere_context
-                .adopt_petname(&name, &link_record)
+                .set_petname_record(&name, &link_record)
                 .await
                 .unwrap();
             let identity = sphere_context.identity().await?;

--- a/rust/noosphere-sphere/src/petname/write.rs
+++ b/rust/noosphere-sphere/src/petname/write.rs
@@ -24,17 +24,23 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    /// Configure a petname, by assigning some [Did] to it or none. By assigning none,
-    /// the petname is implicitly removed from the address space (note: this does not
-    /// erase the name from historical versions of the sphere). If a name is set that
-    /// already exists, the previous name shall be overwritten by the new one, and any
-    /// associated [Jwt] shall be unset.
+    /// Configure a petname, by assigning some [Did] to it or none. By assigning
+    /// none, the petname is implicitly removed from the address space (note:
+    /// this does not erase the name from historical versions of the sphere). If
+    /// a name is set that already exists, the previous name shall be
+    /// overwritten by the new one, and any associated [Jwt] shall be unset.
     async fn set_petname(&mut self, name: &str, identity: Option<Did>) -> Result<()>;
 
-    /// Configure a petname, assigning some [Did] to it and setting its
-    /// associated [Jwt] to a known value. The [Jwt] must be a valid UCAN that
-    /// publishes a name record and grants sufficient authority from the
-    /// configured [Did] to the publisher.
+    /// Set the [LinkRecord] associated with a petname.  The [LinkRecord] must
+    /// resolve a valid UCAN that authorizes the corresponding sphere to be
+    /// published and grants sufficient authority from the configured [Did] to
+    /// the publisher. The audience of the UCAN must match the [Did] that was
+    /// most recently assigned the associated petname. Note that a petname
+    /// _must_ be assigned to the audience [Did] in order for the record to be
+    /// set.
+    async fn set_petname_record(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>>;
+
+    #[deprecated(note = "Use set_petname_record instead")]
     async fn adopt_petname(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>>;
 }
 
@@ -77,10 +83,48 @@ where
     }
 
     async fn adopt_petname(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>> {
+        self.set_petname_record(name, record).await
+    }
+
+    async fn set_petname_record(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>> {
+        // NOTE: it is not safe for us to blindly adopt link records that don't
+        // match up with the petname we are adopting them against. For example,
+        // consider the following sequence of events:
+        //
+        //  1. A petname is assigned to a DID
+        //  2. During sync, the gateway kicks off a parallel job to resolve the
+        //     petname
+        //  3. Meanwhile, we unassign the petname
+        //  4. We sync, the gateway takes no action (no new names to resolve)
+        //  5. Then, the original resolve job finishes and comes back with a
+        //     record
+        //
+        // Record adoption is not able to disambiguate between between a new
+        // record being added and a race condition like the one described above.
         self.assert_write_access().await?;
         validate_petname(name)?;
 
-        let identity = Did::from(record.audience());
+        let identity = record.to_sphere_identity();
+        let expected_identity = self.get_petname(name).await?;
+
+        match expected_identity {
+            Some(expected_identity) => {
+                if expected_identity != identity {
+                    return Err(anyhow!(
+                        "Cannot adopt petname record for '{}'; expected record for {} but got record for {}",
+                        name,
+                        expected_identity,
+                        identity
+                    ));
+                }
+            }
+            None => {
+                return Err(anyhow!(
+                    "Cannot adopt petname record for '{}' (not assigned to a sphere identity)",
+                    name
+                ));
+            }
+        };
 
         let cid = self
             .sphere_context_mut()

--- a/rust/noosphere-sphere/src/replication/stream.rs
+++ b/rust/noosphere-sphere/src/replication/stream.rs
@@ -369,14 +369,11 @@ mod tests {
             }
 
             for petname in petname_change {
-                sphere_context
-                    .adopt_petname(
-                        petname,
-                        &make_valid_link_record(&mut UcanStore(original_store.clone()))
-                            .await?
-                            .1,
-                    )
-                    .await?;
+                let (id, record, _) =
+                    make_valid_link_record(&mut UcanStore(original_store.clone())).await?;
+                sphere_context.set_petname(petname, Some(id)).await?;
+                versions.push(sphere_context.save(None).await?);
+                sphere_context.set_petname_record(petname, &record).await?;
             }
 
             versions.push(sphere_context.save(None).await?);
@@ -520,9 +517,11 @@ mod tests {
         }
 
         let mut db = sphere_context.sphere_context().await?.db().clone();
-        let (_, link_record, _) = make_valid_link_record(&mut db).await?;
+        let (id, link_record, _) = make_valid_link_record(&mut db).await?;
+        sphere_context.set_petname("hasrecord", Some(id)).await?;
+        sphere_context.save(None).await?;
         sphere_context
-            .adopt_petname("hasrecord", &link_record)
+            .set_petname_record("hasrecord", &link_record)
             .await?;
         sphere_context.save(None).await?;
 

--- a/rust/noosphere-sphere/src/sync/strategy.rs
+++ b/rust/noosphere-sphere/src/sync/strategy.rs
@@ -294,8 +294,12 @@ where
 
         for (name, address) in updated_names.into_iter() {
             if let Some(link_record) = address.link_record(&db).await {
-                if context.get_petname(&name).await?.is_some() {
-                    context.adopt_petname(&name, &link_record).await?;
+                if let Some(identity) = context.get_petname(&name).await? {
+                    if identity != address.did {
+                        warn!("Updated link record for {name} referred to unexpected sphere; expected {identity}, but record referred to {}; skipping...", address.did);
+                        continue;
+                    }
+                    context.set_petname_record(&name, &link_record).await?;
                 } else {
                     debug!("Not adopting link record for {name}, which is no longer present in the address book")
                 }


### PR DESCRIPTION
After investigating https://github.com/subconsciousnetwork/subconscious/issues/608, a few issues were uncovered related to how petnames are resolved in the gateway. Most importantly, the gateway was suffering from the effects of a race condition when adopting petnames. But, addressing this uncovered a more subtle problem: it is not safe for us to blindly adopt link records that don't match up with the petname we are adopting them against. For example, consider the following sequence of events:

1. A petname is assigned to a DID
2. During sync, the gateway kicks off a parallel job to resolve the petname
3. Meanwhile, we unassign the petname
4. We sync, the gateway takes no action (no new names to resolve)
5. Then, the original resolve job finishes and comes back with a record

Prior to this change, we would just adopt the record, and eventually so would the client. After all, record adoption is not able to disambiguate between between a new record being added and a race condition like the one described above.

Now, it is mandatory that a petname be assigned to a DID before a record be adopted. And, `adopt_petname` has been renamed `set_petname_record` to better communicate the semantics. The old method remains but is marked as deprecated.

Fixes #411 