### PR TITLE
feat: Authorize and revoke authorization APIs

### DIFF
--- a/rust/noosphere-api/src/client.rs
+++ b/rust/noosphere-api/src/client.rs
@@ -139,7 +139,7 @@ where
         let authorization = author.require_authorization()?;
         let authorization_cid = Cid::try_from(authorization)?;
 
-        match authorization.resolve_ucan(store).await {
+        match authorization.as_ucan(store).await {
             Ok(ucan) => {
                 if let Some(ucan_proofs) = ucan.proofs() {
                     // TODO(ucan-wg/rs-ucan#37): We should integrate a helper for this kind of stuff into rs-ucan

--- a/rust/noosphere-cli/src/native/commands/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/auth.rs
@@ -77,7 +77,7 @@ You will be able to add a new one after the old one is revoked"#,
     let latest_sphere_cid = db.require_version(&sphere_did).await?;
     let authorization = workspace.authorization().await?;
     let authorization_expiry: u64 = {
-        let ucan = authorization.resolve_ucan(&db).await?;
+        let ucan = authorization.as_ucan(&db).await?;
         *ucan.expires_at()
     };
 

--- a/rust/noosphere-core/src/authority/author.rs
+++ b/rust/noosphere-core/src/authority/author.rs
@@ -1,18 +1,19 @@
 use crate::{
     authority::{
-        generate_ed25519_key, Authorization, SphereAction, SphereReference, SPHERE_SEMANTICS,
-        SUPPORTED_KEYS,
+        generate_ed25519_key, Authorization, SphereAction, SPHERE_SEMANTICS, SUPPORTED_KEYS,
     },
     data::Did,
+    view::Sphere,
 };
 use anyhow::{anyhow, Result};
 use noosphere_storage::{SphereDb, Storage};
 use ucan::{
-    capability::{Capability, Resource, With},
     chain::ProofChain,
     crypto::{did::DidParser, KeyMaterial},
 };
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
+
+use super::generate_capability;
 
 /// The level of access that a given user has to a related resource. Broadly,
 /// a user will always have either read/write access (to their own sphere) or
@@ -71,24 +72,40 @@ where
         sphere_identity: &Did,
         db: &SphereDb<S>,
     ) -> Result<Access> {
+        let author_did = Did(self.key.get_did().await?);
+
+        // Check if this author _is_ the root sphere authority (e.g., when performing surgery on
+        // the authority section of a sphere)
+        if &author_did == sphere_identity {
+            return Ok(Access::ReadWrite);
+        }
+
         if let Some(authorization) = &self.authorization {
-            let author_did = Did(self.key.get_did().await?);
-            let ucan = authorization.resolve_ucan(db).await?;
+            let ucan = authorization.as_ucan(db).await?;
 
             if ucan.audience() != author_did.as_str() {
                 return Ok(Access::ReadOnly);
             }
 
-            let read_write_capability = Capability {
-                with: With::Resource {
-                    kind: Resource::Scoped(SphereReference {
-                        did: sphere_identity.to_string(),
-                    }),
-                },
-                can: SphereAction::Push,
+            let sphere = Sphere::at(&db.require_version(sphere_identity).await?.into(), db);
+            match sphere.verify_authorization(authorization).await {
+                Ok(_) => (),
+                Err(error) => {
+                    warn!("Could not verify authorization: {}", error);
+                    return Ok(Access::ReadOnly);
+                }
             };
+
+            let read_write_capability = generate_capability(sphere_identity, SphereAction::Push);
+
             let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-            let proof_chain = ProofChain::from_ucan(ucan, None, &mut did_parser, db).await?;
+            let proof_chain = match ProofChain::from_ucan(ucan, None, &mut did_parser, db).await {
+                Ok(proof_chain) => proof_chain,
+                Err(error) => {
+                    warn!("Could not construct a verified proof chain: {}", error);
+                    return Ok(Access::ReadOnly);
+                }
+            };
 
             let capability_infos = proof_chain.reduce_capabilities(&SPHERE_SEMANTICS);
 
@@ -107,6 +124,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use noosphere_storage::{MemoryStorage, SphereDb};
     use ucan::crypto::KeyMaterial;
 
@@ -122,28 +140,37 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_gives_read_only_access_when_there_is_no_authorization() {
+    async fn it_gives_read_only_access_when_there_is_no_authorization() -> Result<()> {
         let author = Author::anonymous();
-        let mut db = SphereDb::new(&MemoryStorage::default()).await.unwrap();
+        let mut db = SphereDb::new(&MemoryStorage::default()).await?;
 
-        let (sphere, _, _) = Sphere::generate("did:key:foo", &mut db).await.unwrap();
+        let (sphere, _, _) = Sphere::generate("did:key:foo", &mut db).await?;
+
+        db.set_version(&sphere.get_identity().await?, sphere.cid())
+            .await?;
 
         let access = author
-            .access_to(&sphere.get_identity().await.unwrap(), &db)
+            .access_to(&sphere.get_identity().await?, &db)
             .await
             .unwrap();
 
         assert_eq!(access, Access::ReadOnly);
+
+        Ok(())
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_gives_read_write_access_if_the_key_is_authorized() {
+    async fn it_gives_read_write_access_if_the_key_is_authorized() -> Result<()> {
         let owner_key = generate_ed25519_key();
         let owner_did = Did(owner_key.get_did().await.unwrap());
         let mut db = SphereDb::new(&MemoryStorage::default()).await.unwrap();
 
         let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut db).await.unwrap();
+
+        db.set_version(&sphere.get_identity().await?, sphere.cid())
+            .await?;
+
         let author = Author {
             key: owner_key,
             authorization: Some(authorization),
@@ -155,5 +182,35 @@ mod tests {
             .unwrap();
 
         assert_eq!(access, Access::ReadWrite);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_gives_read_write_access_to_the_root_sphere_credential() -> Result<()> {
+        let owner_key = generate_ed25519_key();
+        let owner_did = Did(owner_key.get_did().await.unwrap());
+        let mut db = SphereDb::new(&MemoryStorage::default()).await.unwrap();
+
+        let (sphere, authorization, mnemonic) =
+            Sphere::generate(&owner_did, &mut db).await.unwrap();
+
+        let root_credential = mnemonic.to_credential()?;
+
+        db.set_version(&sphere.get_identity().await?, sphere.cid())
+            .await?;
+
+        let author = Author {
+            key: root_credential,
+            authorization: Some(authorization),
+        };
+
+        let access = author
+            .access_to(&sphere.get_identity().await.unwrap(), &db)
+            .await
+            .unwrap();
+
+        assert_eq!(access, Access::ReadWrite);
+        Ok(())
     }
 }

--- a/rust/noosphere-core/src/authority/key_material.rs
+++ b/rust/noosphere-core/src/authority/key_material.rs
@@ -1,5 +1,6 @@
+use crate::data::Mnemonic;
 use anyhow::{anyhow, Result};
-use bip39::{Language, Mnemonic};
+use bip39::{Language, Mnemonic as BipMnemonic};
 use ed25519_zebra::{SigningKey as Ed25519PrivateKey, VerificationKey as Ed25519PublicKey};
 use ucan::crypto::did::KeyConstructorSlice;
 use ucan_key_support::{
@@ -20,21 +21,21 @@ pub fn generate_ed25519_key() -> Ed25519KeyMaterial {
 }
 
 pub fn restore_ed25519_key(mnemonic: &str) -> Result<Ed25519KeyMaterial> {
-    let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)?;
+    let mnemonic = BipMnemonic::from_phrase(mnemonic, Language::English)?;
     let private_key = Ed25519PrivateKey::try_from(mnemonic.entropy())?;
     let public_key = Ed25519PublicKey::try_from(&private_key)?;
 
     Ok(Ed25519KeyMaterial(public_key, Some(private_key)))
 }
 
-pub fn ed25519_key_to_mnemonic(key_material: &Ed25519KeyMaterial) -> Result<String> {
+pub fn ed25519_key_to_mnemonic(key_material: &Ed25519KeyMaterial) -> Result<Mnemonic> {
     let private_key = &key_material.1.ok_or_else(|| {
         anyhow!(
             "A mnemonic can only be generated for the key material if a private key is configured"
         )
     })?;
-    let mnemonic = Mnemonic::from_entropy(private_key.as_ref(), Language::English)?;
-    Ok(mnemonic.into_phrase())
+    let mnemonic = BipMnemonic::from_entropy(private_key.as_ref(), Language::English)?;
+    Ok(Mnemonic(mnemonic.into_phrase()))
 }
 
 pub const ED25519_KEYPAIR_LENGTH: usize = 64;

--- a/rust/noosphere-core/src/data/address.rs
+++ b/rust/noosphere-core/src/data/address.rs
@@ -671,7 +671,7 @@ mod tests {
         let mut ucan_store = UcanStore(db.clone());
 
         let (sphere, proof, _) = Sphere::generate(&owner_did, &mut db).await?;
-        let ucan = proof.resolve_ucan(&db).await?;
+        let ucan = proof.as_ucan(&db).await?;
 
         let sphere_identity = sphere.get_identity().await?;
 

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -41,7 +41,7 @@ impl<S: BlockStore> SphereRevision<S> {
         let proof = match authorization {
             Some(authorization) => {
                 let witness_ucan = authorization
-                    .resolve_ucan(&UcanStore(self.store.clone()))
+                    .as_ucan(&UcanStore(self.store.clone()))
                     .await?;
 
                 Some(

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     data::{
         Bundle, ChangelogIpld, ContentType, DelegationIpld, Did, Header, IdentityIpld, Link,
-        MapOperation, MemoIpld, RevocationIpld, SphereIpld, TryBundle, Version,
+        MapOperation, MemoIpld, Mnemonic, RevocationIpld, SphereIpld, TryBundle, Version,
     },
     view::{Content, SphereMutation, SphereRevision, Timeline},
 };
@@ -225,6 +225,10 @@ impl<S: BlockStore> Sphere<S> {
 
     pub fn store(&self) -> &S {
         &self.store
+    }
+
+    pub fn store_mut(&mut self) -> &mut S {
+        &mut self.store
     }
 
     /// Get the CID that points to the sphere's wrapping memo that corresponds
@@ -605,7 +609,7 @@ impl<S: BlockStore> Sphere<S> {
     pub async fn generate(
         owner_did: &str,
         store: &mut S,
-    ) -> Result<(Sphere<S>, Authorization, String)> {
+    ) -> Result<(Sphere<S>, Authorization, Mnemonic)> {
         let sphere_key = generate_ed25519_key();
         let mnemonic = ed25519_key_to_mnemonic(&sphere_key)?;
         let sphere_did = Did(sphere_key.get_did().await?);
@@ -665,6 +669,7 @@ impl<S: BlockStore> Sphere<S> {
     /// Change ownership of the sphere, producing a new UCAN authorization for
     /// the new owner and registering a revocation of the previous owner's
     /// authorization within the sphere.
+    #[deprecated(note = "Use SphereAuthorityWrite::recover_authority instead")]
     pub async fn change_owner(
         &self,
         mnemonic: &str,
@@ -789,6 +794,58 @@ impl<S: BlockStore> Sphere<S> {
                 yield (cid, Sphere::from_memo(&memo, &self.store)?);
             }
         }
+    }
+
+    /// Verify that a given authorization is a valid with regards to operating
+    /// on this [Sphere]; it is issued by the sphere (or appropriately
+    /// delegated), and it has not been revoked.
+    pub async fn verify_authorization(&self, authorization: &Authorization) -> Result<()> {
+        let proof_chain = authorization
+            .as_proof_chain(&UcanStore(self.store.clone()))
+            .await?;
+
+        let authority = self.get_authority().await?;
+        let delegations = authority.get_delegations().await?;
+        let revocations = authority.get_revocations().await?;
+        let sphere_identity = self.get_identity().await?;
+        let sphere_credential = sphere_identity.to_credential()?;
+
+        let mut remaining_links = vec![&proof_chain];
+
+        while let Some(chain_link) = remaining_links.pop() {
+            let link = Link::from(Cid::try_from(chain_link.ucan())?);
+
+            if delegations.get(&link).await?.is_none() {
+                return Err(anyhow!(
+                    "Authorization {} not found in sphere authority",
+                    link
+                ));
+            }
+
+            if let Some(revocation) = revocations.get(&link).await? {
+                // NOTE: The implication here is that only the sphere itself can
+                // issue revocations The follow-on implicationis that a user
+                // must provide the sphere mnemonic in order to issue a
+                // revocation
+                if revocation.iss != sphere_identity {
+                    warn!("Revocation for {} had an invalid issuer; expected {}, but found {}; skipping...", link, sphere_identity, revocation.iss);
+                    continue;
+                }
+
+                if let Err(error) = revocation.verify(&sphere_credential).await {
+                    warn!("Unverifiable revocation: {}", error);
+                    continue;
+                }
+
+                return Err(anyhow!("Authorization revoked by {}", link));
+            }
+
+            for proof in chain_link.proofs() {
+                remaining_links.push(proof);
+            }
+        }
+
+        Ok(())
     }
 
     // Validate this sphere revision's signature and proof chain
@@ -919,14 +976,11 @@ impl<S: BlockStore> Sphere<S> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use cid::Cid;
     use libipld_cbor::DagCborCodec;
     use tokio_stream::StreamExt;
-    use ucan::{
-        builder::UcanBuilder,
-        capability::{Capability, Resource, With},
-        crypto::{did::DidParser, KeyMaterial},
-    };
+    use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -935,12 +989,9 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use crate::{
-        authority::{
-            ed25519_key_to_mnemonic, generate_ed25519_key, Authorization, SphereAction,
-            SphereReference, SUPPORTED_KEYS,
-        },
+        authority::{generate_capability, generate_ed25519_key, Authorization, SphereAction},
         data::{Bundle, DelegationIpld, IdentityIpld, Link, MemoIpld, RevocationIpld},
-        view::{Sphere, SphereMutation, Timeline},
+        view::{Sphere, SphereMutation, Timeline, SPHERE_LIFETIME},
     };
 
     use noosphere_storage::{BlockStore, MemoryStore, Store, UcanStore};
@@ -986,162 +1037,6 @@ mod tests {
                 jwt: ucan_jwt_cid
             })
         );
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_may_authorize_a_different_key_after_being_created() {
-        let mut store = MemoryStore::default();
-
-        let (sphere, authorization, mnemonic) = {
-            let owner_key = generate_ed25519_key();
-            let owner_did = owner_key.get_did().await.unwrap();
-            Sphere::generate(&owner_did, &mut store).await.unwrap()
-        };
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let (_, new_authorization) = sphere
-            .change_owner(&mnemonic, &next_owner_did, &authorization, &mut did_parser)
-            .await
-            .unwrap();
-
-        let ucan_store = UcanStore(store);
-        let ucan = authorization.resolve_ucan(&ucan_store).await.unwrap();
-        let new_ucan = new_authorization.resolve_ucan(&ucan_store).await.unwrap();
-
-        assert_ne!(ucan.audience(), new_ucan.audience());
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_delegates_to_a_new_owner_and_revokes_the_old_delegation() {
-        let mut store = MemoryStore::default();
-        let owner_key = generate_ed25519_key();
-        let owner_did = owner_key.get_did().await.unwrap();
-
-        let (sphere, original_authorization, mnemonic) =
-            { Sphere::generate(&owner_did, &mut store).await.unwrap() };
-
-        let sphere_identity = sphere.get_identity().await.unwrap();
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let (sphere, new_authorization) = sphere
-            .change_owner(
-                &mnemonic,
-                &next_owner_did,
-                &original_authorization,
-                &mut did_parser,
-            )
-            .await
-            .unwrap();
-
-        let original_jwt_cid = Cid::try_from(&original_authorization).unwrap();
-        let new_jwt_cid = Cid::try_from(&new_authorization).unwrap();
-
-        let authority = sphere.get_authority().await.unwrap();
-
-        let delegations = authority.get_delegations().await.unwrap();
-        let revocations = authority.get_revocations().await.unwrap();
-
-        let new_delegation = delegations.get(&Link::new(new_jwt_cid)).await.unwrap();
-        let new_revocation = revocations.get(&Link::new(original_jwt_cid)).await.unwrap();
-
-        assert_eq!(
-            new_delegation,
-            Some(&DelegationIpld {
-                name: "(OWNER)".into(),
-                jwt: new_jwt_cid
-            })
-        );
-
-        assert!(new_revocation.is_some());
-
-        let new_revocation = new_revocation.unwrap();
-
-        assert_eq!(new_revocation.iss, sphere.get_identity().await.unwrap());
-        assert_eq!(new_revocation.revoke, original_jwt_cid.to_string());
-
-        let sphere_key = did_parser.parse(&sphere_identity).unwrap();
-
-        new_revocation.verify(&sphere_key).await.unwrap();
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_wont_authorize_a_different_key_if_the_mnemonic_is_wrong() {
-        let mut store = MemoryStore::default();
-
-        let (sphere, ucan, _) = {
-            let owner_key = generate_ed25519_key();
-            let owner_did = owner_key.get_did().await.unwrap();
-            Sphere::generate(&owner_did, &mut store).await.unwrap()
-        };
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-        let incorrect_mnemonic = ed25519_key_to_mnemonic(&next_owner_key).unwrap();
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let authorize_result = sphere
-            .change_owner(&incorrect_mnemonic, &next_owner_did, &ucan, &mut did_parser)
-            .await;
-
-        assert!(authorize_result.is_err());
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_wont_authorize_a_different_key_if_the_proof_does_not_authorize_it() {
-        let mut store = MemoryStore::default();
-
-        let owner_key = generate_ed25519_key();
-        let owner_did = owner_key.get_did().await.unwrap();
-        let (sphere, authorization, mnemonic) =
-            Sphere::generate(&owner_did, &mut store).await.unwrap();
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-
-        let ucan = authorization.resolve_ucan(&UcanStore(store)).await.unwrap();
-
-        let insufficient_authorization = Authorization::Ucan(
-            UcanBuilder::default()
-                .issued_by(&owner_key)
-                .for_audience(&next_owner_did)
-                .claiming_capability(&Capability {
-                    with: With::Resource {
-                        kind: Resource::Scoped(SphereReference {
-                            did: sphere.get_identity().await.unwrap().to_string(),
-                        }),
-                    },
-                    can: SphereAction::Publish,
-                })
-                .witnessed_by(&ucan)
-                .with_expiration(*ucan.expires_at())
-                .build()
-                .unwrap()
-                .sign()
-                .await
-                .unwrap(),
-        );
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let authorize_result = sphere
-            .change_owner(
-                &mnemonic,
-                &next_owner_did,
-                &insufficient_authorization,
-                &mut did_parser,
-            )
-            .await;
-
-        assert!(authorize_result.is_err());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -1372,6 +1267,51 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_verify_an_authorization_to_write_to_a_sphere() -> Result<()> {
+        let mut store = MemoryStore::default();
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await?;
+
+        let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut store).await?;
+
+        sphere.verify_authorization(&authorization).await?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_wont_verify_an_invalid_authorization_to_write_to_a_sphere() -> Result<()> {
+        let mut store = MemoryStore::default();
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = other_key.get_did().await?;
+
+        let (sphere, _, _) = Sphere::generate(&owner_did, &mut store).await?;
+
+        let invalid_authorization = Authorization::Ucan(
+            UcanBuilder::default()
+                .issued_by(&owner_key)
+                .for_audience(&other_did)
+                .with_lifetime(SPHERE_LIFETIME)
+                .claiming_capability(&generate_capability(&other_did, SphereAction::Publish))
+                .build()?
+                .sign()
+                .await?,
+        );
+
+        assert!(sphere
+            .verify_authorization(&invalid_authorization)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_hydrate_revisions_of_names_changes() {
         let mut store = MemoryStore::default();
         let owner_key = generate_ed25519_key();
@@ -1475,7 +1415,7 @@ mod tests {
             Sphere::generate(&owner_did, &mut store).await.unwrap();
 
         let ucan = authorization
-            .resolve_ucan(&UcanStore(store.clone()))
+            .as_ucan(&UcanStore(store.clone()))
             .await
             .unwrap();
 

--- a/rust/noosphere-gateway/src/route/identify.rs
+++ b/rust/noosphere-gateway/src/route/identify.rs
@@ -38,13 +38,10 @@ where
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;
 
-    let ucan = gateway_authorization
-        .resolve_ucan(db)
-        .await
-        .map_err(|error| {
-            error!("{:?}", error);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let ucan = gateway_authorization.as_ucan(db).await.map_err(|error| {
+        error!("{:?}", error);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     Ok(Json(
         IdentifyResponse::sign(&scope.identity, gateway_key, &ucan)

--- a/rust/noosphere-gateway/src/route/replicate.rs
+++ b/rust/noosphere-gateway/src/route/replicate.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_only_allows_incremental_replication_of_causally_ordered_revisions() -> Result<()> {
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let db = sphere_context.sphere_context().await?.db().clone();
 
@@ -211,7 +211,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_only_allows_incremental_replication_of_revisions_from_same_sphere() -> Result<()> {
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let db = sphere_context.sphere_context().await?.db().clone();
 
@@ -226,7 +226,7 @@ mod tests {
         let memo_1 = version_1.load_from(&db).await?;
         let memo_2 = version_2.load_from(&db).await?;
 
-        let mut other_sphere_context =
+        let (mut other_sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, Some(db.clone())).await?;
 
         let other_version_1 = other_sphere_context
@@ -271,7 +271,7 @@ mod tests {
         let to_be_revoked_key = generate_ed25519_key();
         let to_be_revoked_did = to_be_revoked_key.get_did().await?;
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let db = sphere_context.sphere_context().await?.db().clone();
 
@@ -281,7 +281,7 @@ mod tests {
 
         let author = sphere_context.sphere_context().await?.author().clone();
         let author_key = author.key.clone();
-        let author_ucan = author.require_authorization()?.resolve_ucan(&db).await?;
+        let author_ucan = author.require_authorization()?.as_ucan(&db).await?;
 
         let to_be_revoked_jwt = UcanBuilder::default()
             .issued_by(&author_key)

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -525,7 +525,7 @@ mod tests {
     #[tokio::test]
     async fn it_publishes_to_the_name_system() -> Result<()> {
         let ipfs_url: Url = "http://127.0.0.1:5000".parse()?;
-        let sphere = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+        let (sphere, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let record: LinkRecord = {
             let context = sphere.lock().await;
             let identity: &str = context.identity().into();

--- a/rust/noosphere-into/src/into/html/sphere.rs
+++ b/rust/noosphere-into/src/into/html/sphere.rs
@@ -180,7 +180,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_writes_a_file_from_the_sphere_to_the_target_as_html() {
-        let context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(context);
@@ -249,7 +249,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_symlinks_a_file_slug_to_the_latest_file_version() {
-        let context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(context);

--- a/rust/noosphere-sphere/src/authority/escalate.rs
+++ b/rust/noosphere-sphere/src/authority/escalate.rs
@@ -1,0 +1,85 @@
+use crate::{HasMutableSphereContext, SphereContext};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use noosphere_core::{
+    authority::Author,
+    data::{Did, Link, MemoIpld, Mnemonic},
+};
+use noosphere_storage::Storage;
+use std::future::Future;
+use tokio::sync::Mutex;
+use ucan::crypto::KeyMaterial;
+
+#[allow(missing_docs)]
+#[cfg(not(target_arch = "wasm32"))]
+pub trait SphereAuthoritySend: Send {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T> SphereAuthoritySend for T where T: Send {}
+
+#[allow(missing_docs)]
+#[cfg(target_arch = "wasm32")]
+pub trait SphereAuthoritySend {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> SphereAuthoritySend for T {}
+
+/// Any wrapper over [SphereContext] that implements [SphereAuthorityEscalate]
+/// has the ability to do some work on the [SphereContext] using a higher-privilege
+/// credential (in most cases, the root sphere credential).
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SphereAuthorityEscalate<C, K, S>
+where
+    C: HasMutableSphereContext<K, S>,
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    /// Given the recovery mnemonic for a sphere and a callback, invoke the
+    /// callback with a mutable [SphereContext] wrapper. The optional return
+    /// value of the callback should be the latest version of the sphere after
+    /// the work of the callback is performed
+    async fn with_root_authority<F, Fut>(&mut self, mnemonic: &Mnemonic, callback: F) -> Result<()>
+    where
+        Fut: Future<Output = Result<Option<Link<MemoIpld>>>> + SphereAuthoritySend,
+        F: FnOnce(C) -> Fut + SphereAuthoritySend;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<K, S>
+    SphereAuthorityEscalate<
+        Arc<Mutex<SphereContext<Arc<Box<dyn KeyMaterial>>, S>>>,
+        Arc<Box<dyn KeyMaterial>>,
+        S,
+    > for Arc<Mutex<SphereContext<K, S>>>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    async fn with_root_authority<F, Fut>(&mut self, mnemonic: &Mnemonic, callback: F) -> Result<()>
+    where
+        Fut: Future<Output = Result<Option<Link<MemoIpld>>>> + SphereAuthoritySend,
+        F: FnOnce(Arc<Mutex<SphereContext<Arc<Box<dyn KeyMaterial>>, S>>>) -> Fut
+            + SphereAuthoritySend,
+    {
+        let sphere_context = self.sphere_context_mut().await?;
+        let root_sphere_author = Author {
+            key: mnemonic.to_credential()?,
+            authorization: None,
+        };
+
+        if &Did(root_sphere_author.key.get_did().await?) != sphere_context.identity() {
+            return Err(anyhow!("Provided mnemonic produced an invalid credential"));
+        }
+
+        let root_sphere_context = Arc::new(Mutex::new(
+            sphere_context.with_author(&root_sphere_author).await?,
+        ));
+
+        callback(root_sphere_context).await?;
+        Ok(())
+    }
+}

--- a/rust/noosphere-sphere/src/authority/mod.rs
+++ b/rust/noosphere-sphere/src/authority/mod.rs
@@ -1,0 +1,8 @@
+mod read;
+pub use read::*;
+
+mod write;
+pub use write::*;
+
+mod escalate;
+pub use escalate::*;

--- a/rust/noosphere-sphere/src/authority/read.rs
+++ b/rust/noosphere-sphere/src/authority/read.rs
@@ -1,0 +1,132 @@
+use anyhow::Result;
+use noosphere_core::{
+    authority::Authorization,
+    data::{Did, Link},
+};
+use noosphere_storage::Storage;
+
+use tokio_stream::StreamExt;
+use ucan::crypto::KeyMaterial;
+
+use crate::HasSphereContext;
+use async_trait::async_trait;
+
+/// Anything that can read the authority section from a sphere should implement
+/// [SphereAuthorityRead]. A blanket implementation is provided for anything
+/// that implements [HasSphereContext].
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SphereAuthorityRead<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    /// For a given [Authorization], checks that the authorization and all of its
+    /// ancester proofs are valid and have not been revoked
+    async fn verify_authorization(&self, authorization: &Authorization) -> Result<()>;
+
+    /// Look up an authorization by a [Did].
+    async fn get_authorization(&self, did: &Did) -> Result<Option<Authorization>>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<C, K, S> SphereAuthorityRead<K, S> for C
+where
+    C: HasSphereContext<K, S>,
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    async fn verify_authorization(&self, authorization: &Authorization) -> Result<()> {
+        self.to_sphere()
+            .await?
+            .verify_authorization(authorization)
+            .await
+    }
+
+    async fn get_authorization(&self, did: &Did) -> Result<Option<Authorization>> {
+        let sphere = self.to_sphere().await?;
+        let authority = sphere.get_authority().await?;
+        let delegations = authority.get_delegations().await?;
+        let delegations_stream = delegations.into_stream().await?;
+
+        tokio::pin!(delegations_stream);
+
+        while let Some((Link { cid, .. }, delegation)) = delegations_stream.try_next().await? {
+            let ucan = delegation.resolve_ucan(sphere.store()).await?;
+            let authorized_did = ucan.audience();
+
+            if authorized_did == did {
+                return Ok(Some(Authorization::Cid(cid)));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use noosphere_core::data::Did;
+
+    use ucan::crypto::KeyMaterial;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use crate::helpers::{simulated_sphere_context, SimulationAccess};
+    use crate::{HasSphereContext, SphereAuthorityRead};
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_get_an_authorization_by_did() -> Result<()> {
+        let (sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let author_did = Did(sphere_context
+            .sphere_context()
+            .await?
+            .author()
+            .key
+            .get_did()
+            .await?);
+
+        let authorization = sphere_context
+            .get_authorization(&author_did)
+            .await?
+            .unwrap();
+
+        let _ucan = authorization
+            .as_ucan(sphere_context.sphere_context().await?.db())
+            .await?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_verify_an_authorization_to_write_to_a_sphere() -> Result<()> {
+        let (sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let author_did = Did(sphere_context
+            .sphere_context()
+            .await?
+            .author()
+            .key
+            .get_did()
+            .await?);
+
+        let authorization = sphere_context
+            .get_authorization(&author_did)
+            .await?
+            .unwrap();
+
+        sphere_context.verify_authorization(&authorization).await?;
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-sphere/src/authority/write.rs
+++ b/rust/noosphere-sphere/src/authority/write.rs
@@ -1,0 +1,410 @@
+use crate::{internal::SphereContextInternal, HasMutableSphereContext, HasSphereContext};
+
+use super::SphereAuthorityRead;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use cid::Cid;
+use noosphere_core::{
+    authority::{generate_capability, Authorization, SphereAction, SphereReference},
+    data::{DelegationIpld, Did, Jwt, Link, RevocationIpld},
+    view::SPHERE_LIFETIME,
+};
+use noosphere_storage::{Storage, UcanStore};
+use tokio_stream::StreamExt;
+use ucan::{
+    builder::UcanBuilder,
+    capability::{Capability, Resource, With},
+    crypto::KeyMaterial,
+};
+
+/// Any type which implements [SphereAuthorityWrite] is able to manipulate the
+/// [AuthorityIpld] section of a sphere. This includes authorizing other keys
+/// and revoking prior authorizations.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SphereAuthorityWrite<K, S>: SphereAuthorityRead<K, S>
+where
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    /// Authorize another key by its [Did], associating the authorization with a
+    /// provided display name
+    async fn authorize(&mut self, name: &str, identity: &Did) -> Result<Authorization>;
+
+    /// Revoke a previously granted authorization.
+    ///
+    /// Note that correctly revoking an authorization requires signing with the
+    /// root sphere credential, so generally can only be performed on a type
+    /// that implements [SphereAuthorityEscalate].
+    async fn revoke_authorization(&mut self, authorization: &Authorization) -> Result<()>;
+
+    /// Recover authority by revoking all previously delegated authorizations
+    /// and creating a new one that delegates authority to the specified key
+    /// (given by its [Did]).
+    ///
+    /// Note that correctly recovering authority requires signing with the root
+    /// sphere credential, so generally can only be performed on a type that
+    /// implements [SphereAuthorityEscalate]
+    async fn recover_authority(&mut self, new_owner: &Did) -> Result<Authorization>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<C, K, S> SphereAuthorityWrite<K, S> for C
+where
+    C: HasSphereContext<K, S> + HasMutableSphereContext<K, S>,
+    K: KeyMaterial + Clone + 'static,
+    S: Storage + 'static,
+{
+    // TODO: We allow optional human-readable names for authorizations, but this
+    // will bear the consequence of leaking personal information about the user
+    // (e.g., a list of their authorized devices). We should encrypt these
+    // names so that they are only readable by the user themselves.
+    async fn authorize(&mut self, name: &str, identity: &Did) -> Result<Authorization> {
+        self.assert_write_access().await?;
+
+        let author = self.sphere_context().await?.author().clone();
+        let mut sphere = self.to_sphere().await?;
+        let authorization = author.require_authorization()?;
+
+        self.verify_authorization(authorization).await?;
+
+        let authorization_expiry: u64 = {
+            let ucan = authorization
+                .as_ucan(&UcanStore(sphere.store().clone()))
+                .await?;
+            *ucan.expires_at()
+        };
+
+        let mut signable = UcanBuilder::default()
+            .issued_by(&author.key)
+            .for_audience(identity)
+            .claiming_capability(&Capability {
+                with: With::Resource {
+                    kind: Resource::Scoped(SphereReference {
+                        did: sphere.get_identity().await?.to_string(),
+                    }),
+                },
+                can: SphereAction::Authorize,
+            })
+            .with_expiration(authorization_expiry)
+            .with_nonce()
+            // TODO(ucan-wg/rs-ucan#32): Clean this up when we can use a CID as an authorization
+            // .witnessed_by(&authorization)
+            .build()?;
+
+        signable
+            .proofs
+            .push(Cid::try_from(authorization)?.to_string());
+
+        let jwt = signable.sign().await?.encode()?;
+
+        let delegation = DelegationIpld::register(name, &jwt, sphere.store_mut()).await?;
+
+        self.sphere_context_mut()
+            .await?
+            .mutation_mut()
+            .delegations_mut()
+            .set(&Link::new(delegation.jwt), &delegation);
+
+        Ok(Authorization::Cid(delegation.jwt))
+    }
+
+    async fn revoke_authorization(&mut self, authorization: &Authorization) -> Result<()> {
+        self.assert_write_access().await?;
+
+        let mut sphere_context = self.sphere_context_mut().await?;
+        let author_did = Did(sphere_context.author().key.get_did().await?);
+        let sphere_identity = sphere_context.identity().clone();
+
+        if author_did != sphere_identity {
+            return Err(anyhow!(
+                "Only the root sphere credential can be used to revoke an authorization"
+            ));
+        }
+
+        let authorization_cid = Link::<Jwt>::from(Cid::try_from(authorization)?);
+        let delegations = sphere_context
+            .sphere()
+            .await?
+            .get_authority()
+            .await?
+            .get_delegations()
+            .await?;
+
+        if delegations.get(&authorization_cid).await?.is_none() {
+            return Err(anyhow!(
+                "No authority has been delegated to the authorization being revoked"
+            ));
+        }
+
+        let revocation =
+            RevocationIpld::revoke(&authorization_cid, &sphere_context.author().key).await?;
+
+        sphere_context
+            .mutation_mut()
+            .delegations_mut()
+            .remove(&authorization_cid);
+
+        sphere_context
+            .mutation_mut()
+            .revocations_mut()
+            .set(&authorization_cid, &revocation);
+
+        Ok(())
+    }
+
+    async fn recover_authority(&mut self, new_owner: &Did) -> Result<Authorization> {
+        self.assert_write_access().await?;
+
+        let mut sphere_context = self.sphere_context_mut().await?;
+        let author_did = Did(sphere_context.author().key.get_did().await?);
+        let sphere_identity = sphere_context.identity().clone();
+
+        if author_did != sphere_identity {
+            return Err(anyhow!(
+                "Only the root sphere credential can be used to recover authority"
+            ));
+        }
+
+        let sphere = sphere_context.sphere().await?;
+        let authority = sphere.get_authority().await?;
+        let delegations = authority.get_delegations().await?;
+        let delegation_stream = delegations.into_stream().await?;
+
+        tokio::pin!(delegation_stream);
+
+        // First: revoke all current authority
+        while let Some((link, _)) = delegation_stream.try_next().await? {
+            let revocation = RevocationIpld::revoke(&link, &sphere_context.author().key).await?;
+
+            sphere_context
+                .mutation_mut()
+                .delegations_mut()
+                .remove(&link);
+            sphere_context
+                .mutation_mut()
+                .revocations_mut()
+                .set(&link, &revocation);
+        }
+
+        // Then: bless a new owner
+        let ucan = UcanBuilder::default()
+            .issued_by(&sphere_context.author().key)
+            .for_audience(new_owner)
+            .with_lifetime(SPHERE_LIFETIME)
+            .with_nonce()
+            .claiming_capability(&generate_capability(
+                &sphere_identity,
+                SphereAction::Authorize,
+            ))
+            .build()?
+            .sign()
+            .await?;
+
+        let jwt = ucan.encode()?;
+        let delegation = DelegationIpld::register("(OWNER)", &jwt, sphere_context.db()).await?;
+        let link = Link::new(delegation.jwt);
+
+        sphere_context
+            .mutation_mut()
+            .delegations_mut()
+            .set(&link, &delegation);
+
+        Ok(Authorization::Cid(link.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use noosphere_core::authority::{ed25519_key_to_mnemonic, generate_ed25519_key, Author};
+    use noosphere_core::data::Did;
+
+    use tokio::sync::Mutex;
+    use ucan::crypto::KeyMaterial;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use crate::helpers::{simulated_sphere_context, SimulationAccess};
+    use crate::{
+        HasMutableSphereContext, HasSphereContext, SphereAuthorityEscalate, SphereAuthorityRead,
+        SphereAuthorityWrite,
+    };
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_allows_an_authorized_key_to_authorize_other_keys() -> Result<()> {
+        let (mut sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        assert!(sphere_context
+            .verify_authorization(&other_authorization)
+            .await
+            .is_ok());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_implicitly_revokes_transitive_authorizations() -> Result<()> {
+        let (mut sphere_context, mnemonic) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        let mut sphere_context_with_other_credential = Arc::new(Mutex::new(
+            sphere_context
+                .sphere_context()
+                .await?
+                .with_author(&Author {
+                    key: other_key.clone(),
+                    authorization: Some(other_authorization.clone()),
+                })
+                .await?,
+        ));
+
+        let third_key = generate_ed25519_key();
+        let third_did = Did(third_key.get_did().await?);
+
+        let third_authorization = sphere_context_with_other_credential
+            .authorize("third", &third_did)
+            .await?;
+        sphere_context_with_other_credential.save(None).await?;
+
+        sphere_context
+            .with_root_authority(&mnemonic, move |mut root_sphere_context| async move {
+                root_sphere_context
+                    .revoke_authorization(&other_authorization)
+                    .await?;
+                Ok(Some(root_sphere_context.save(None).await?))
+            })
+            .await?;
+
+        assert!(sphere_context
+            .verify_authorization(&third_authorization)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_catches_revoked_authorizations_when_verifying() -> Result<()> {
+        let (mut sphere_context, mnemonic) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        sphere_context
+            .with_root_authority(&mnemonic, |mut root_sphere_context| {
+                let other_authorization = other_authorization.clone();
+                async move {
+                    root_sphere_context
+                        .revoke_authorization(&other_authorization)
+                        .await?;
+                    Ok(Some(root_sphere_context.save(None).await?))
+                }
+            })
+            .await?;
+
+        assert!(sphere_context
+            .verify_authorization(&other_authorization)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_perform_access_recovery_given_a_mnemonic() -> Result<()> {
+        let (mut sphere_context, mnemonic) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let owner = sphere_context.sphere_context().await?.author().clone();
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        let next_owner_key = generate_ed25519_key();
+        let next_owner_did = Did(next_owner_key.get_did().await?);
+
+        sphere_context
+            .with_root_authority(&mnemonic, |mut root_sphere_context| {
+                let next_owner_did = next_owner_did.clone();
+                async move {
+                    root_sphere_context
+                        .recover_authority(&next_owner_did)
+                        .await?;
+                    Ok(Some(root_sphere_context.save(None).await?))
+                }
+            })
+            .await?;
+
+        assert!(sphere_context
+            .verify_authorization(&other_authorization)
+            .await
+            .is_err());
+
+        assert!(sphere_context
+            .verify_authorization(&owner.authorization.unwrap())
+            .await
+            .is_err());
+
+        sphere_context
+            .verify_authorization(
+                &sphere_context
+                    .get_authorization(&next_owner_did)
+                    .await?
+                    .unwrap(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_wont_escalate_authority_if_the_mnemonic_is_wrong() -> Result<()> {
+        let (mut sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key = generate_ed25519_key();
+        let incorrect_mnemonic = ed25519_key_to_mnemonic(&other_key)?;
+
+        assert!(sphere_context
+            .with_root_authority(&incorrect_mnemonic, |_| async {
+                assert!(false, "Called back with incorrect mnemonic");
+                Ok(None)
+            })
+            .await
+            .is_err());
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-sphere/src/content/decoder.rs
+++ b/rust/noosphere-sphere/src/content/decoder.rs
@@ -10,6 +10,8 @@ use tokio_stream::Stream;
 pub struct BodyChunkDecoder<'a, 'b, S: BlockStore>(pub &'a Cid, pub &'b S);
 
 impl<'a, 'b, S: BlockStore> BodyChunkDecoder<'a, 'b, S> {
+    /// Consume the [BodyChunkDecoder] and return an async [Stream] of bytes
+    /// representing the raw body contents
     pub fn stream(self) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Unpin {
         let mut next = Some(*self.0);
         let store = self.1.clone();

--- a/rust/noosphere-sphere/src/content/file.rs
+++ b/rust/noosphere-sphere/src/content/file.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use noosphere_core::data::{Did, Link, MemoIpld};
 use tokio::io::AsyncRead;
 
+/// A type that may be used as the contents field in a [SphereFile]
 #[cfg(not(target_arch = "wasm32"))]
 pub trait AsyncFileBody: AsyncRead + Unpin + Send {}
 
@@ -17,10 +18,15 @@ impl<S> AsyncFileBody for S where S: AsyncRead + Unpin {}
 
 /// A descriptor for contents that is stored in a sphere.
 pub struct SphereFile<C> {
+    /// The identity of the associated sphere from which the file was read
     pub sphere_identity: Did,
+    /// The version of the associated sphere from which the file was read
     pub sphere_version: Link<MemoIpld>,
+    /// The version of the memo that wraps the file's body contents
     pub memo_version: Link<MemoIpld>,
+    /// The memo that wraps the file's body contents
     pub memo: MemoIpld,
+    /// The body contents of the file
     pub contents: C,
 }
 
@@ -28,6 +34,8 @@ impl<C> SphereFile<C>
 where
     C: AsyncFileBody + 'static,
 {
+    /// Consume the file and return a version of it where its body contents have
+    /// been boxed and pinned
     pub fn boxed(self) -> SphereFile<Pin<Box<dyn AsyncFileBody + 'static>>> {
         SphereFile {
             sphere_identity: self.sphere_identity,

--- a/rust/noosphere-sphere/src/context.rs
+++ b/rust/noosphere-sphere/src/context.rs
@@ -67,6 +67,12 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage,
 {
+    /// Instantiate a new [SphereContext] given a sphere [Did], an [Author], a
+    /// [SphereDb] and an optional origin sphere [Did]. The origin sphere [Did]
+    /// is intended to signify whether the [SphereContext] is a local sphere, or
+    /// a global sphere that is being visited by a local author. In most cases,
+    /// a [SphereContext] with _some_ value set as the origin sphere [Did] will
+    /// be read-only.
     pub async fn new(
         sphere_identity: Did,
         author: Author<K>,
@@ -89,12 +95,27 @@ where
         })
     }
 
+    /// Clone this [SphereContext], setting the sphere identity to a peer's [Did]
     pub async fn to_visitor(&self, peer_identity: &Did) -> Result<Self> {
         self.db().require_version(peer_identity).await?;
 
         SphereContext::new(
             peer_identity.clone(),
             self.author.clone(),
+            self.db.clone(),
+            Some(self.origin_sphere_identity.clone()),
+        )
+        .await
+    }
+
+    /// Clone this [SphereContext], replacing the [Author] with the provided one
+    pub async fn with_author<J>(&self, author: &Author<J>) -> Result<SphereContext<J, S>>
+    where
+        J: KeyMaterial + Clone + 'static,
+    {
+        SphereContext::new(
+            self.sphere_identity.clone(),
+            author.clone(),
             self.db.clone(),
             Some(self.origin_sphere_identity.clone()),
         )
@@ -179,10 +200,14 @@ where
         &mut self.db
     }
 
+    /// Get a read-only reference to the underlying [SphereMutation] that this
+    /// [SphereContext] is tracking
     pub fn mutation(&self) -> &SphereMutation {
         &self.mutation
     }
 
+    /// Get a mutable reference to the underlying [SphereMutation] that this
+    /// [SphereContext] is tracking
     pub fn mutation_mut(&mut self) -> &mut SphereMutation {
         &mut self.mutation
     }
@@ -233,7 +258,7 @@ where
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use anyhow::Result;
 
     use noosphere_core::{data::ContentType, tracing::initialize_tracing};
@@ -256,7 +281,7 @@ pub mod tests {
         let valid_names: &[&str] = &["j@__/_大", "/"];
         let invalid_names: &[&str] = &[""];
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         for invalid_name in invalid_names {
@@ -283,7 +308,7 @@ pub mod tests {
         let valid_names: &[&str] = &["j@__/_大"];
         let invalid_names: &[&str] = &[""];
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let mut db = sphere_context.sphere_context().await?.db().clone();
         let (other_identity, link_record, _) = make_valid_link_record(&mut db).await?;

--- a/rust/noosphere-sphere/src/has.rs
+++ b/rust/noosphere-sphere/src/has.rs
@@ -14,12 +14,14 @@ use ucan::crypto::KeyMaterial;
 
 use super::SphereContext;
 
+#[allow(missing_docs)]
 #[cfg(not(target_arch = "wasm32"))]
 pub trait HasConditionalSendSync: Send + Sync {}
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<S> HasConditionalSendSync for S where S: Send + Sync {}
 
+#[allow(missing_docs)]
 #[cfg(target_arch = "wasm32")]
 pub trait HasConditionalSendSync {}
 
@@ -39,6 +41,7 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage,
 {
+    /// The type of the internal read-only [SphereContext]
     type SphereContext: Deref<Target = SphereContext<K, S>> + HasConditionalSendSync;
 
     /// Get the [SphereContext] that is made available by this container.
@@ -77,6 +80,7 @@ where
     K: KeyMaterial + Clone + 'static,
     S: Storage,
 {
+    /// The type of the internal mutable [SphereContext]
     type MutableSphereContext: Deref<Target = SphereContext<K, S>>
         + DerefMut<Target = SphereContext<K, S>>
         + HasConditionalSendSync;

--- a/rust/noosphere-sphere/src/lib.rs
+++ b/rust/noosphere-sphere/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+//!   let (mut sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 //!
 //!   sphere_context.write("foo", "text/plain", "bar".as_ref(), None).await?;
 //!   sphere_context.save(None).await?;
@@ -38,7 +38,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+//!   let (mut sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 //!
 //!   sphere_context.set_petname("cdata", Some("did:key:example".into())).await?;
 //!   sphere_context.save(None).await?;
@@ -48,6 +48,8 @@
 //! ```
 //!
 //!
+
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate tracing;
@@ -61,6 +63,7 @@ use noosphere_core::authority::Author;
 #[cfg(doc)]
 use noosphere_storage::Storage;
 
+mod authority;
 mod content;
 mod context;
 mod cursor;
@@ -75,6 +78,7 @@ pub mod metadata;
 mod petname;
 mod sync;
 
+pub use authority::*;
 pub use content::*;
 pub use context::*;
 pub use cursor::*;

--- a/rust/noosphere-sphere/src/metadata.rs
+++ b/rust/noosphere-sphere/src/metadata.rs
@@ -1,6 +1,6 @@
-///! These constants represent the metadata keys used when a [SphereContext] is
-///! is initialized. Since these represent somewhat free-form key/values in the
-///! storage layer, we are make a best effort to document them here.
+//! These constants represent the metadata keys used when a [SphereContext] is
+//! is initialized. Since these represent somewhat free-form key/values in the
+//! storage layer, we are make a best effort to document them here.
 
 #[cfg(doc)]
 use crate::SphereContext;

--- a/rust/noosphere-sphere/src/petname/write.rs
+++ b/rust/noosphere-sphere/src/petname/write.rs
@@ -40,6 +40,7 @@ where
     /// set.
     async fn set_petname_record(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>>;
 
+    /// Deprecated; use [SpherePetnameWrite::set_petname_record] instead
     #[deprecated(note = "Use set_petname_record instead")]
     async fn adopt_petname(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>>;
 }

--- a/rust/noosphere-sphere/src/replication/car.rs
+++ b/rust/noosphere-sphere/src/replication/car.rs
@@ -12,6 +12,9 @@ use tokio_util::{
     sync::PollSender,
 };
 
+/// Takes a list of roots and a stream of blocks (pairs of [Cid] and
+/// corresponding [Vec<u8>]), and produces an async byte stream that yields a
+/// valid [CARv1](https://ipld.io/specs/transport/car/carv1/)
 pub fn car_stream<S>(
     mut roots: Vec<Cid>,
     block_stream: S,

--- a/rust/noosphere-sphere/src/replication/read.rs
+++ b/rust/noosphere-sphere/src/replication/read.rs
@@ -3,6 +3,8 @@ use async_trait::async_trait;
 use noosphere_storage::Storage;
 use ucan::crypto::KeyMaterial;
 
+/// Implementors are able to traverse from one sphere to the next via
+/// the address book entries found in those spheres
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait SphereReplicaRead<K, S>: Sized

--- a/rust/noosphere-sphere/src/replication/stream.rs
+++ b/rust/noosphere-sphere/src/replication/stream.rs
@@ -264,7 +264,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let changes = vec![
@@ -343,7 +343,7 @@ mod tests {
     async fn it_can_stream_all_delta_blocks_for_a_range_of_history() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let changes = vec![
@@ -429,7 +429,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_some_sphere_content() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let mut db = sphere_context.sphere_context().await?.db_mut().clone();
 
@@ -485,7 +485,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version_as_a_car() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let changes = vec![

--- a/rust/noosphere-sphere/src/replication/walk.rs
+++ b/rust/noosphere-sphere/src/replication/walk.rs
@@ -7,6 +7,7 @@ use noosphere_storage::BlockStore;
 use std::ops::Fn;
 use tokio_stream::StreamExt;
 
+/// Given a [VersionedMap], visit its changelog and all of its underlying entries
 pub async fn walk_versioned_map_elements<K, V, S>(
     versioned_map: VersionedMap<K, V, S>,
 ) -> Result<()>
@@ -22,6 +23,9 @@ where
     Ok(())
 }
 
+/// Given a [VersionedMap] and [BlockStore], visit the [VersionedMap]'s
+/// changelog and all of its underlying entries, invoking a callback for each
+/// entry
 pub async fn walk_versioned_map_elements_and<K, V, S, F, Fut>(
     versioned_map: VersionedMap<K, V, S>,
     store: S,
@@ -43,6 +47,9 @@ where
     Ok(())
 }
 
+/// Given a [VersionedMap] and [BlockStore], visit the [VersionedMap]'s
+/// changelog; then, invoke the provided callback with each entry associated
+/// with an 'add' operation in the changelog
 pub async fn walk_versioned_map_changes_and<K, V, S, F, Fut>(
     versioned_map: VersionedMap<K, V, S>,
     store: S,

--- a/rust/noosphere-sphere/src/sync/error.rs
+++ b/rust/noosphere-sphere/src/sync/error.rs
@@ -1,10 +1,14 @@
 use noosphere_api::data::PushError;
 use thiserror::Error;
 
+/// Different classes of error that may occur during synchronization with a
+/// gateway
 #[derive(Error, Debug)]
 pub enum SyncError {
+    /// The error was a conflict; this is possibly recoverable
     #[error("There was a conflict during sync")]
     Conflict,
+    /// The error was some other, non-specific error
     #[error("{0}")]
     Other(anyhow::Error),
 }

--- a/rust/noosphere-sphere/src/sync/strategy.rs
+++ b/rust/noosphere-sphere/src/sync/strategy.rs
@@ -349,7 +349,7 @@ where
         let authorization = context
             .author()
             .require_authorization()?
-            .resolve_ucan(context.db())
+            .as_ucan(context.db())
             .await?;
 
         let name_record = Jwt(UcanBuilder::default()

--- a/rust/noosphere-sphere/src/sync/write.rs
+++ b/rust/noosphere-sphere/src/sync/write.rs
@@ -8,6 +8,7 @@ use crate::{HasMutableSphereContext, SyncError, SyncRecovery};
 
 use crate::GatewaySyncStrategy;
 
+/// Implementors of [SphereSync] are able to sychronize with a Noosphere gateway
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait SphereSync<K, S>

--- a/rust/noosphere-sphere/src/walker.rs
+++ b/rust/noosphere-sphere/src/walker.rs
@@ -331,7 +331,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_be_initialized_with_a_context_or_a_cursor() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context.clone());
@@ -367,7 +367,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_list_all_slugs_currently_in_a_sphere() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -406,7 +406,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_stream_the_whole_index() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);

--- a/rust/noosphere/src/ffi/authority.rs
+++ b/rust/noosphere/src/ffi/authority.rs
@@ -1,0 +1,125 @@
+use std::ffi::c_void;
+
+use cid::Cid;
+use noosphere_core::{
+    authority::Authorization,
+    data::{Did, Mnemonic},
+};
+use noosphere_sphere::{HasMutableSphereContext, SphereAuthorityEscalate, SphereAuthorityWrite};
+use safer_ffi::prelude::*;
+
+use crate::{
+    error::NoosphereError,
+    ffi::{NsError, NsNoosphere, NsSphere},
+};
+
+#[ffi_export]
+/// @memberof ns_sphere_t
+///
+/// Authorize another key to manipulate this sphere, given a display name for
+/// the authorization and the DID of the key to be authorized.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///  3. An owned pointer to constant string (the authorization CID) if the call
+///     was successful, otherwise NULL
+pub fn ns_sphere_authority_authorize(
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
+    name: char_p::Ref<'_>,
+    did: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(
+        Option<repr_c::Box<c_void>>,
+        Option<repr_c::Box<NsError>>,
+        Option<char_p::Box>,
+    ),
+) {
+    let mut sphere = sphere.inner_mut().clone();
+    let name = name.to_string();
+    let did = Did(did.to_string());
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let authorization: char_p::Box = sphere
+                .authorize(&name, &did)
+                .await?
+                .to_string()
+                .try_into()?;
+
+            Ok(authorization) as Result<_, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(authorization) => {
+                async_runtime.spawn_blocking(move || callback(context, None, Some(authorization)))
+            }
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()), None)
+            }),
+        };
+    });
+}
+
+#[ffi_export]
+/// @memberof ns_sphere_t
+///
+/// Given a recovery mnemonic and the CID of a previously delegated
+/// authorization, revoke the authorization.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///
+/// NOTE: The revocation must be performed by the root sphere credential
+/// (derived from the recovery mnemonic), and the sphere revision that revokes
+/// the authorization must be signed by same, so the revocation and a save is
+/// all performed in one step by this function call. If there are pending writes
+/// to the sphere, they will still be pending after this call, but any attempt
+/// to save them will operate on the version of this sphere _after_ the
+/// authorization is revoked.
+pub fn ns_sphere_authority_authorization_revoke(
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
+    mnemonic: char_p::Ref<'_>,
+    cid: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(Option<repr_c::Box<c_void>>, Option<repr_c::Box<NsError>>),
+) {
+    let mut sphere = sphere.inner_mut().clone();
+    let mnemonic = Mnemonic(mnemonic.to_string());
+    let cid = cid.to_string();
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let authorization = Authorization::Cid(Cid::try_from(cid.as_str())?);
+
+            sphere
+                .with_root_authority(&mnemonic, move |mut root_sphere_context| async move {
+                    root_sphere_context
+                        .revoke_authorization(&authorization)
+                        .await?;
+                    Ok(Some(root_sphere_context.save(None).await?))
+                })
+                .await?;
+
+            Ok(()) as Result<_, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(_) => async_runtime.spawn_blocking(move || callback(context, None)),
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()))
+            }),
+        };
+    });
+}

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,3 +1,4 @@
+mod authority;
 mod context;
 mod error;
 mod headers;
@@ -9,6 +10,7 @@ mod tracing;
 
 pub use crate::ffi::noosphere::*;
 pub use crate::ffi::tracing::*;
+pub use authority::*;
 pub use context::*;
 pub use error::*;
 pub use headers::*;

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -84,7 +84,7 @@ pub fn ns_sphere_petname_get(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_content_read
+///     ns_sphere_petnames_assigned_Get
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to a slice_boxed_char_ptr_t if the call was successful,
 ///     otherwise NULL

--- a/rust/noosphere/src/sphere/builder.rs
+++ b/rust/noosphere/src/sphere/builder.rs
@@ -5,7 +5,7 @@ use cid::Cid;
 
 use noosphere_core::{
     authority::{Author, Authorization},
-    data::Did,
+    data::{Did, Mnemonic},
     view::Sphere,
 };
 
@@ -46,7 +46,7 @@ impl Default for SphereInitialization {
 pub enum SphereContextBuilderArtifacts {
     SphereCreated {
         context: SphereContext<PlatformKeyMaterial, PlatformStorage>,
-        mnemonic: String,
+        mnemonic: Mnemonic,
     },
     SphereOpened(SphereContext<PlatformKeyMaterial, PlatformStorage>),
 }

--- a/swift/Sources/SwiftNoosphere/Noosphere.swift
+++ b/swift/Sources/SwiftNoosphere/Noosphere.swift
@@ -109,3 +109,41 @@ public func nsSphereSync(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, 
         handler.contents(error, new_version)
     }
 }
+
+public typealias NsSphereAuthorityAuthorizeHandler = (OpaquePointer?, UnsafeMutablePointer<CChar>?) -> ()
+
+/// See: ns_sphere_authority_authorize
+public func nsSphereAuthorityAuthorize(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, name: UnsafePointer<CChar>!, did: UnsafePointer<CChar>!, handler: @escaping NsSphereAuthorityAuthorizeHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_authority_authorize(noosphere, sphere, name, did, context) {
+        (context, error, authorization) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereAuthorityAuthorizeHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error, authorization)
+    }
+}
+
+public typealias NsSphereAuthorityAuthorizationRevokeHandler = (OpaquePointer?) -> ()
+
+/// See: ns_sphere_authority_authorization_revoke
+public func nsSphereAuthorityAuthorizationRevoke(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, mnemonic: UnsafePointer<CChar>!, authorization: UnsafePointer<CChar>!, handler: @escaping NsSphereAuthorityAuthorizationRevokeHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_authority_authorization_revoke(noosphere, sphere, mnemonic, authorization, context) {
+        (context, error) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereAuthorityAuthorizationRevokeHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error)
+    }
+}

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -517,6 +517,70 @@ final class NoosphereTests: XCTestCase {
         ns_free(noosphere)
     }
     
+    func testAuthorizeKeyAndRevokeAnAuthorization() throws {
+        let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil, nil)
+
+        ns_key_create(noosphere, "bob", nil)
+
+        let sphere_receipt = ns_sphere_create(noosphere, "bob", nil)
+
+        let sphere_identity_ptr = ns_sphere_receipt_identity(sphere_receipt, nil)
+        let sphere_mnemonic_ptr = ns_sphere_receipt_mnemonic(sphere_receipt, nil)
+        
+        let sphere = ns_sphere_open(noosphere, sphere_identity_ptr, nil)
+        
+        let expectation = self.expectation(description: "File contents are read")
+
+        nsSphereAuthorityAuthorize(noosphere, sphere, name: "alice", did: "did:key:alice") {
+            (error, authorization_ptr) in
+            
+            if error != nil {
+                let error_message_ptr = ns_error_message_get(error)
+                let error_message = String.init(cString: error_message_ptr!)
+
+                print(error_message)
+
+                ns_string_free(error_message_ptr)
+                ns_error_free(error)
+                return
+            }
+            
+            let authorization = String.init(cString: authorization_ptr!)
+            print(authorization)
+            
+            ns_sphere_save(noosphere, sphere, nil, nil)
+            
+            nsSphereAuthorityAuthorizationRevoke(noosphere, sphere, mnemonic: sphere_mnemonic_ptr, authorization: authorization_ptr) {
+                (error) in
+                
+                if error != nil {
+                    let error_message_ptr = ns_error_message_get(error)
+                    let error_message = String.init(cString: error_message_ptr!)
+
+                    print(error_message)
+
+                    ns_string_free(error_message_ptr)
+                    ns_error_free(error)
+                    return
+                }
+                
+                ns_string_free(authorization_ptr)
+                
+                print("Authorization revoked!")
+                
+                expectation.fulfill()
+            }
+        }
+        
+        self.waitForExpectations(timeout: 5)
+        
+        ns_string_free(sphere_mnemonic_ptr)
+        ns_string_free(sphere_identity_ptr)
+        ns_sphere_receipt_free(sphere_receipt)
+        ns_sphere_free(sphere)
+        ns_free(noosphere)
+    }
+    
     func testSettingAndGettingAPetname() throws {
         let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil, nil)
         


### PR DESCRIPTION
This change proposes high-level APIs to authorize keys and revoke authorizations for both `SphereContext` wrappers and the C FFI. In addition to the proposed APIs, a bunch of docs have been backfilled.

A provisional implementation of sphere "recovery" has also been introduced here. This recovery mechanism is intended for the case when the user loses an authorized credential (due to theft or otherwise) and wishes to complete reset all authorizations via their recovery mnemonic. However, given the provisional nature of this implementation, no C FFI is provided for this functionality at this time.

Fixes #325 