### PR TITLE
feat: Authorize and revoke APIs

### DIFF
--- a/rust/noosphere-api/src/client.rs
+++ b/rust/noosphere-api/src/client.rs
@@ -132,7 +132,7 @@ where
         let authorization = author.require_authorization()?;
         let authorization_cid = Cid::try_from(authorization)?;
 
-        match authorization.resolve_ucan(store).await {
+        match authorization.as_ucan(store).await {
             Ok(ucan) => {
                 if let Some(ucan_proofs) = ucan.proofs() {
                     // TODO(ucan-wg/rs-ucan#37): We should integrate a helper for this kind of stuff into rs-ucan

--- a/rust/noosphere-cli/src/native/commands/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/auth.rs
@@ -71,7 +71,7 @@ You will be able to add a new one after the old one is revoked"#,
     let latest_sphere_cid = db.require_version(&sphere_did).await?;
     let authorization = workspace.authorization().await?;
     let authorization_expiry: Option<u64> = {
-        let ucan = authorization.resolve_ucan(&db).await?;
+        let ucan = authorization.as_ucan(&db).await?;
         ucan.expires_at().to_owned()
     };
 
@@ -80,13 +80,15 @@ You will be able to add a new one after the old one is revoked"#,
         .for_audience(did)
         .claiming_capability(&generate_capability(&sphere_did, SphereAbility::Authorize))
         .with_nonce();
-    // TODO(ucan-wg/rs-ucan#32): Clean this up when we can use a CID as an authorization
-    // .witnessed_by(&authorization)
 
+    // TODO(ucan-wg/rs-ucan#114): Clean this up when
+    // `UcanBuilder::with_expiration` accepts `Option<u64>`
     if let Some(exp) = authorization_expiry {
         builder = builder.with_expiration(exp);
     }
 
+    // TODO(ucan-wg/rs-ucan#32): Clean this up when we can use a CID as an authorization
+    // .witnessed_by(&authorization)
     let mut signable = builder.build()?;
     signable
         .proofs

--- a/rust/noosphere-cli/src/native/commands/sphere.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere.rs
@@ -21,7 +21,7 @@ pub async fn sphere_create(owner_key: &str, workspace: &Workspace) -> Result<()>
         .await?;
 
     let mnemonic = sphere_context_artifacts.require_mnemonic()?.to_string();
-    let sphere_context: SphereContext<_, _> = sphere_context_artifacts.into();
+    let sphere_context: SphereContext<_> = sphere_context_artifacts.into();
     let sphere_identity = sphere_context.identity();
 
     info!(

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -37,7 +37,7 @@ use tempfile::TempDir;
 const SPHERE_DIRECTORY: &str = ".sphere";
 const NOOSPHERE_DIRECTORY: &str = ".noosphere";
 
-pub type CliSphereContext = SphereContext<Ed25519KeyMaterial, NativeStorage>;
+pub type CliSphereContext = SphereContext<NativeStorage>;
 
 /// A delta manifest of changes to the local content space
 #[derive(Default)]

--- a/rust/noosphere-cli/tests/helpers/mod.rs
+++ b/rust/noosphere-cli/tests/helpers/mod.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use noosphere_ipfs::{IpfsStore, KuboClient};
 use noosphere_storage::{BlockStoreRetry, MemoryStore, NativeStorage, UcanStore};
 use std::{net::TcpListener, sync::Arc, time::Duration};
-use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
 use noosphere_cli::native::{
     commands::{config::config_set, key::key_create, sphere::sphere_create},
@@ -192,18 +191,14 @@ impl SpherePair {
     }
 
     /// Returns a [SphereContext] for the client sphere.
-    pub async fn sphere_context(
-        &self,
-    ) -> Result<Arc<Mutex<SphereContext<Ed25519KeyMaterial, NativeStorage>>>> {
+    pub async fn sphere_context(&self) -> Result<Arc<Mutex<SphereContext<NativeStorage>>>> {
         self.client.workspace.sphere_context().await
     }
 
     pub async fn spawn<T, F, Fut>(&self, f: F) -> Result<T>
     where
         T: Send + 'static,
-        F: FnOnce(Arc<Mutex<SphereContext<Ed25519KeyMaterial, NativeStorage>>>) -> Fut
-            + Send
-            + 'static,
+        F: FnOnce(Arc<Mutex<SphereContext<NativeStorage>>>) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<T>> + Send + 'static,
     {
         let context = self.sphere_context().await?;

--- a/rust/noosphere-core/src/authority/author.rs
+++ b/rust/noosphere-core/src/authority/author.rs
@@ -3,6 +3,7 @@ use crate::{
         generate_ed25519_key, Authorization, SphereAbility, SPHERE_SEMANTICS, SUPPORTED_KEYS,
     },
     data::Did,
+    view::Sphere,
 };
 use anyhow::{anyhow, Result};
 use noosphere_storage::{SphereDb, Storage};
@@ -66,22 +67,44 @@ where
     }
 
     /// Determine the level of access that the author has to a given sphere
-    pub async fn access_to<S: Storage>(
-        &self,
-        sphere_identity: &Did,
-        db: &SphereDb<S>,
-    ) -> Result<Access> {
+    pub async fn access_to<S>(&self, sphere_identity: &Did, db: &SphereDb<S>) -> Result<Access>
+    where
+        S: Storage,
+    {
+        let author_did = Did(self.key.get_did().await?);
+
+        // Check if this author _is_ the root sphere authority (e.g., when performing surgery on
+        // the authority section of a sphere)
+        if &author_did == sphere_identity {
+            return Ok(Access::ReadWrite);
+        }
+
         if let Some(authorization) = &self.authorization {
-            let author_did = Did(self.key.get_did().await?);
-            let ucan = authorization.resolve_ucan(db).await?;
+            let ucan = authorization.as_ucan(db).await?;
 
             if ucan.audience() != author_did.as_str() {
                 return Ok(Access::ReadOnly);
             }
 
+            let sphere = Sphere::at(&db.require_version(sphere_identity).await?.into(), db);
+            match sphere.verify_authorization(authorization).await {
+                Ok(_) => (),
+                Err(error) => {
+                    warn!("Could not verify authorization: {}", error);
+                    return Ok(Access::ReadOnly);
+                }
+            };
+
             let read_write_capability = generate_capability(sphere_identity, SphereAbility::Push);
+
             let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-            let proof_chain = ProofChain::from_ucan(ucan, None, &mut did_parser, db).await?;
+            let proof_chain = match ProofChain::from_ucan(ucan, None, &mut did_parser, db).await {
+                Ok(proof_chain) => proof_chain,
+                Err(error) => {
+                    warn!("Could not construct a verified proof chain: {}", error);
+                    return Ok(Access::ReadOnly);
+                }
+            };
 
             let capability_infos = proof_chain.reduce_capabilities(&SPHERE_SEMANTICS);
 
@@ -96,10 +119,42 @@ where
 
         Ok(Access::ReadOnly)
     }
+
+    /// Get that DID that corresponds to the underlying credential of this [Author]
+    pub async fn did(&self) -> Result<Did> {
+        Ok(Did(self.key.get_did().await?))
+    }
+
+    /// Returns true if this author is in the delegation chain of authority for
+    /// the given [Authorization], otherwise false.
+    // BEFORE MERGE: Test this
+    pub async fn is_authorizer_of<S>(
+        &self,
+        authorization: &Authorization,
+        db: &SphereDb<S>,
+    ) -> Result<bool>
+    where
+        S: Storage,
+    {
+        let proof_chain = authorization.as_proof_chain(db).await?;
+        let mut links_to_check = vec![&proof_chain];
+        let author_did = self.did().await?;
+
+        while let Some(link) = links_to_check.pop() {
+            if link.ucan().issuer() == author_did {
+                return Ok(true);
+            }
+
+            links_to_check.extend(link.proofs().iter());
+        }
+
+        Ok(false)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use noosphere_storage::{MemoryStorage, SphereDb};
     use ucan::crypto::KeyMaterial;
 
@@ -115,28 +170,37 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_gives_read_only_access_when_there_is_no_authorization() {
+    async fn it_gives_read_only_access_when_there_is_no_authorization() -> Result<()> {
         let author = Author::anonymous();
-        let mut db = SphereDb::new(&MemoryStorage::default()).await.unwrap();
+        let mut db = SphereDb::new(&MemoryStorage::default()).await?;
 
-        let (sphere, _, _) = Sphere::generate("did:key:foo", &mut db).await.unwrap();
+        let (sphere, _, _) = Sphere::generate("did:key:foo", &mut db).await?;
+
+        db.set_version(&sphere.get_identity().await?, sphere.cid())
+            .await?;
 
         let access = author
-            .access_to(&sphere.get_identity().await.unwrap(), &db)
+            .access_to(&sphere.get_identity().await?, &db)
             .await
             .unwrap();
 
         assert_eq!(access, Access::ReadOnly);
+
+        Ok(())
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_gives_read_write_access_if_the_key_is_authorized() {
+    async fn it_gives_read_write_access_if_the_key_is_authorized() -> Result<()> {
         let owner_key = generate_ed25519_key();
         let owner_did = Did(owner_key.get_did().await.unwrap());
         let mut db = SphereDb::new(&MemoryStorage::default()).await.unwrap();
 
         let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut db).await.unwrap();
+
+        db.set_version(&sphere.get_identity().await?, sphere.cid())
+            .await?;
+
         let author = Author {
             key: owner_key,
             authorization: Some(authorization),
@@ -148,5 +212,35 @@ mod tests {
             .unwrap();
 
         assert_eq!(access, Access::ReadWrite);
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_gives_read_write_access_to_the_root_sphere_credential() -> Result<()> {
+        let owner_key = generate_ed25519_key();
+        let owner_did = Did(owner_key.get_did().await.unwrap());
+        let mut db = SphereDb::new(&MemoryStorage::default()).await.unwrap();
+
+        let (sphere, authorization, mnemonic) =
+            Sphere::generate(&owner_did, &mut db).await.unwrap();
+
+        let root_credential = mnemonic.to_credential()?;
+
+        db.set_version(&sphere.get_identity().await?, sphere.cid())
+            .await?;
+
+        let author = Author {
+            key: root_credential,
+            authorization: Some(authorization),
+        };
+
+        let access = author
+            .access_to(&sphere.get_identity().await.unwrap(), &db)
+            .await
+            .unwrap();
+
+        assert_eq!(access, Access::ReadWrite);
+        Ok(())
     }
 }

--- a/rust/noosphere-core/src/authority/key_material.rs
+++ b/rust/noosphere-core/src/authority/key_material.rs
@@ -1,5 +1,6 @@
+use crate::data::Mnemonic;
 use anyhow::{anyhow, Result};
-use bip39::{Language, Mnemonic};
+use bip39::{Language, Mnemonic as BipMnemonic};
 use ed25519_zebra::{SigningKey as Ed25519PrivateKey, VerificationKey as Ed25519PublicKey};
 use ucan::crypto::did::KeyConstructorSlice;
 use ucan_key_support::{
@@ -20,21 +21,21 @@ pub fn generate_ed25519_key() -> Ed25519KeyMaterial {
 }
 
 pub fn restore_ed25519_key(mnemonic: &str) -> Result<Ed25519KeyMaterial> {
-    let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)?;
+    let mnemonic = BipMnemonic::from_phrase(mnemonic, Language::English)?;
     let private_key = Ed25519PrivateKey::try_from(mnemonic.entropy())?;
     let public_key = Ed25519PublicKey::try_from(&private_key)?;
 
     Ok(Ed25519KeyMaterial(public_key, Some(private_key)))
 }
 
-pub fn ed25519_key_to_mnemonic(key_material: &Ed25519KeyMaterial) -> Result<String> {
+pub fn ed25519_key_to_mnemonic(key_material: &Ed25519KeyMaterial) -> Result<Mnemonic> {
     let private_key = &key_material.1.ok_or_else(|| {
         anyhow!(
             "A mnemonic can only be generated for the key material if a private key is configured"
         )
     })?;
-    let mnemonic = Mnemonic::from_entropy(private_key.as_ref(), Language::English)?;
-    Ok(mnemonic.into_phrase())
+    let mnemonic = BipMnemonic::from_entropy(private_key.as_ref(), Language::English)?;
+    Ok(Mnemonic(mnemonic.into_phrase()))
 }
 
 pub const ED25519_KEYPAIR_LENGTH: usize = 64;

--- a/rust/noosphere-core/src/data/address.rs
+++ b/rust/noosphere-core/src/data/address.rs
@@ -662,7 +662,7 @@ mod tests {
         let mut ucan_store = UcanStore(db.clone());
 
         let (sphere, proof, _) = Sphere::generate(&owner_did, &mut db).await?;
-        let ucan = proof.resolve_ucan(&db).await?;
+        let ucan = proof.as_ucan(&db).await?;
 
         let sphere_identity = sphere.get_identity().await?;
 

--- a/rust/noosphere-core/src/data/authority.rs
+++ b/rust/noosphere-core/src/data/authority.rs
@@ -47,7 +47,7 @@ impl AuthorityIpld {
 /// sphere. The name of the delegation is for display purposes only, and helps
 /// the user identify the client device or application that the delegation is
 /// intended for.
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Hash)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Serialize, Deserialize, Hash)]
 pub struct DelegationIpld {
     pub name: String,
     pub jwt: Cid,

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -41,7 +41,7 @@ impl<S: BlockStore> SphereRevision<S> {
         let proof = match authorization {
             Some(authorization) => {
                 let witness_ucan = authorization
-                    .resolve_ucan(&UcanStore(self.store.clone()))
+                    .as_ucan(&UcanStore(self.store.clone()))
                     .await?;
 
                 Some(

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     data::{
         Bundle, ChangelogIpld, ContentType, DelegationIpld, Did, Header, IdentityIpld, Link,
-        MapOperation, MemoIpld, RevocationIpld, SphereIpld, TryBundle, Version,
+        MapOperation, MemoIpld, Mnemonic, RevocationIpld, SphereIpld, TryBundle, Version,
     },
     view::{Content, SphereMutation, SphereRevision, Timeline},
 };
@@ -224,6 +224,10 @@ impl<S: BlockStore> Sphere<S> {
 
     pub fn store(&self) -> &S {
         &self.store
+    }
+
+    pub fn store_mut(&mut self) -> &mut S {
+        &mut self.store
     }
 
     /// Get the CID that points to the sphere's wrapping memo that corresponds
@@ -604,7 +608,7 @@ impl<S: BlockStore> Sphere<S> {
     pub async fn generate(
         owner_did: &str,
         store: &mut S,
-    ) -> Result<(Sphere<S>, Authorization, String)> {
+    ) -> Result<(Sphere<S>, Authorization, Mnemonic)> {
         let sphere_key = generate_ed25519_key();
         let mnemonic = ed25519_key_to_mnemonic(&sphere_key)?;
         let sphere_did = Did(sphere_key.get_did().await?);
@@ -656,6 +660,7 @@ impl<S: BlockStore> Sphere<S> {
     /// Change ownership of the sphere, producing a new UCAN authorization for
     /// the new owner and registering a revocation of the previous owner's
     /// authorization within the sphere.
+    #[deprecated(note = "Use SphereAuthorityWrite::recover_authority instead")]
     pub async fn change_owner(
         &self,
         mnemonic: &str,
@@ -774,7 +779,65 @@ impl<S: BlockStore> Sphere<S> {
         }
     }
 
-    // Validate this sphere revision's signature and proof chain
+    /// Verify that a given authorization is a valid with regards to operating
+    /// on this [Sphere]; it is issued by the sphere (or appropriately
+    /// delegated), and it has not been revoked.
+    pub async fn verify_authorization(&self, authorization: &Authorization) -> Result<()> {
+        let proof_chain = authorization
+            .as_proof_chain(&UcanStore(self.store.clone()))
+            .await?;
+
+        let authority = self.get_authority().await?;
+        let delegations = authority.get_delegations().await?;
+        let revocations = authority.get_revocations().await?;
+        let sphere_identity = self.get_identity().await?;
+        let sphere_credential = sphere_identity.to_credential()?;
+
+        let mut remaining_links = vec![&proof_chain];
+
+        while let Some(chain_link) = remaining_links.pop() {
+            let link = Link::from(chain_link.ucan().to_cid(cid::multihash::Code::Blake3_256)?);
+
+            if delegations.get(&link).await?.is_none() {
+                return Err(anyhow!(
+                    "Authorization {} not found in sphere authority",
+                    link
+                ));
+            }
+
+            if let Some(revocation) = revocations.get(&link).await? {
+                // NOTE: The implication here is that only the sphere itself can
+                // issue revocations The follow-on implicationis that a user
+                // must provide the sphere mnemonic in order to issue a
+                // revocation
+                if revocation.iss != sphere_identity {
+                    warn!("Revocation for {} had an invalid issuer; expected {}, but found {}; skipping...", link, sphere_identity, revocation.iss);
+                    continue;
+                }
+
+                if let Err(error) = revocation.verify(&sphere_credential).await {
+                    warn!("Unverifiable revocation: {}", error);
+                    continue;
+                }
+
+                return Err(anyhow!("Authorization revoked by {}", link));
+            }
+
+            for proof in chain_link.proofs() {
+                remaining_links.push(proof);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate this sphere revision's signature and proof chain
+    // TODO(#421): Allow this to be done at a specific "now" time, to cover the
+    // case when we are verifying a historical revision with a possibly expired
+    // credential
+    //
+    // TODO(#422): This also needs to take revocations into account, probably by
+    // calling to `Sphere::verify_authorization`
     pub async fn verify_signature(&self) -> Result<()> {
         let memo = self.to_memo().await?;
 
@@ -902,13 +965,11 @@ impl<S: BlockStore> Sphere<S> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use cid::Cid;
     use libipld_cbor::DagCborCodec;
     use tokio_stream::StreamExt;
-    use ucan::{
-        builder::UcanBuilder,
-        crypto::{did::DidParser, KeyMaterial},
-    };
+    use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -918,12 +979,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        authority::{
-            ed25519_key_to_mnemonic, generate_ed25519_key, Authorization, SphereAbility,
-            SUPPORTED_KEYS,
-        },
+        authority::{generate_ed25519_key, Authorization, SphereAbility},
         data::{Bundle, DelegationIpld, IdentityIpld, Link, MemoIpld, RevocationIpld},
-        view::{Sphere, SphereMutation, Timeline},
+        view::{Sphere, SphereMutation, Timeline, SPHERE_LIFETIME},
     };
     use noosphere_storage::{BlockStore, MemoryStore, Store, UcanStore};
 
@@ -968,158 +1026,6 @@ mod tests {
                 jwt: ucan_jwt_cid
             })
         );
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_may_authorize_a_different_key_after_being_created() {
-        let mut store = MemoryStore::default();
-
-        let (sphere, authorization, mnemonic) = {
-            let owner_key = generate_ed25519_key();
-            let owner_did = owner_key.get_did().await.unwrap();
-            Sphere::generate(&owner_did, &mut store).await.unwrap()
-        };
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let (_, new_authorization) = sphere
-            .change_owner(&mnemonic, &next_owner_did, &authorization, &mut did_parser)
-            .await
-            .unwrap();
-
-        let ucan_store = UcanStore(store);
-        let ucan = authorization.resolve_ucan(&ucan_store).await.unwrap();
-        let new_ucan = new_authorization.resolve_ucan(&ucan_store).await.unwrap();
-
-        assert_ne!(ucan.audience(), new_ucan.audience());
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_delegates_to_a_new_owner_and_revokes_the_old_delegation() {
-        let mut store = MemoryStore::default();
-        let owner_key = generate_ed25519_key();
-        let owner_did = owner_key.get_did().await.unwrap();
-
-        let (sphere, original_authorization, mnemonic) =
-            { Sphere::generate(&owner_did, &mut store).await.unwrap() };
-
-        let sphere_identity = sphere.get_identity().await.unwrap();
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let (sphere, new_authorization) = sphere
-            .change_owner(
-                &mnemonic,
-                &next_owner_did,
-                &original_authorization,
-                &mut did_parser,
-            )
-            .await
-            .unwrap();
-
-        let original_jwt_cid = Cid::try_from(&original_authorization).unwrap();
-        let new_jwt_cid = Cid::try_from(&new_authorization).unwrap();
-
-        let authority = sphere.get_authority().await.unwrap();
-
-        let delegations = authority.get_delegations().await.unwrap();
-        let revocations = authority.get_revocations().await.unwrap();
-
-        let new_delegation = delegations.get(&Link::new(new_jwt_cid)).await.unwrap();
-        let new_revocation = revocations.get(&Link::new(original_jwt_cid)).await.unwrap();
-
-        assert_eq!(
-            new_delegation,
-            Some(&DelegationIpld {
-                name: "(OWNER)".into(),
-                jwt: new_jwt_cid
-            })
-        );
-
-        assert!(new_revocation.is_some());
-
-        let new_revocation = new_revocation.unwrap();
-
-        assert_eq!(new_revocation.iss, sphere.get_identity().await.unwrap());
-        assert_eq!(new_revocation.revoke, original_jwt_cid.to_string());
-
-        let sphere_key = did_parser.parse(&sphere_identity).unwrap();
-
-        new_revocation.verify(&sphere_key).await.unwrap();
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_wont_authorize_a_different_key_if_the_mnemonic_is_wrong() {
-        let mut store = MemoryStore::default();
-
-        let (sphere, ucan, _) = {
-            let owner_key = generate_ed25519_key();
-            let owner_did = owner_key.get_did().await.unwrap();
-            Sphere::generate(&owner_did, &mut store).await.unwrap()
-        };
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-        let incorrect_mnemonic = ed25519_key_to_mnemonic(&next_owner_key).unwrap();
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let authorize_result = sphere
-            .change_owner(&incorrect_mnemonic, &next_owner_did, &ucan, &mut did_parser)
-            .await;
-
-        assert!(authorize_result.is_err());
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn it_wont_authorize_a_different_key_if_the_proof_does_not_authorize_it() {
-        let mut store = MemoryStore::default();
-
-        let owner_key = generate_ed25519_key();
-        let owner_did = owner_key.get_did().await.unwrap();
-        let (sphere, authorization, mnemonic) =
-            Sphere::generate(&owner_did, &mut store).await.unwrap();
-
-        let next_owner_key = generate_ed25519_key();
-        let next_owner_did = next_owner_key.get_did().await.unwrap();
-
-        let ucan = authorization.resolve_ucan(&UcanStore(store)).await.unwrap();
-
-        let insufficient_authorization = Authorization::Ucan(
-            UcanBuilder::default()
-                .issued_by(&owner_key)
-                .for_audience(&next_owner_did)
-                .claiming_capability(&generate_capability(
-                    &sphere.get_identity().await.unwrap().to_string(),
-                    SphereAbility::Publish,
-                ))
-                .witnessed_by(&ucan, None)
-                .with_expiration(ucan.expires_at().unwrap())
-                .build()
-                .unwrap()
-                .sign()
-                .await
-                .unwrap(),
-        );
-
-        let mut did_parser = DidParser::new(SUPPORTED_KEYS);
-        let authorize_result = sphere
-            .change_owner(
-                &mnemonic,
-                &next_owner_did,
-                &insufficient_authorization,
-                &mut did_parser,
-            )
-            .await;
-
-        assert!(authorize_result.is_err());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -1350,6 +1256,51 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_verify_an_authorization_to_write_to_a_sphere() -> Result<()> {
+        let mut store = MemoryStore::default();
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await?;
+
+        let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut store).await?;
+
+        sphere.verify_authorization(&authorization).await?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_wont_verify_an_invalid_authorization_to_write_to_a_sphere() -> Result<()> {
+        let mut store = MemoryStore::default();
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = other_key.get_did().await?;
+
+        let (sphere, _, _) = Sphere::generate(&owner_did, &mut store).await?;
+
+        let invalid_authorization = Authorization::Ucan(
+            UcanBuilder::default()
+                .issued_by(&owner_key)
+                .for_audience(&other_did)
+                .with_lifetime(SPHERE_LIFETIME)
+                .claiming_capability(&generate_capability(&other_did, SphereAbility::Publish))
+                .build()?
+                .sign()
+                .await?,
+        );
+
+        assert!(sphere
+            .verify_authorization(&invalid_authorization)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_hydrate_revisions_of_names_changes() {
         let mut store = MemoryStore::default();
         let owner_key = generate_ed25519_key();
@@ -1453,7 +1404,7 @@ mod tests {
             Sphere::generate(&owner_did, &mut store).await.unwrap();
 
         let ucan = authorization
-            .resolve_ucan(&UcanStore(store.clone()))
+            .as_ucan(&UcanStore(store.clone()))
             .await
             .unwrap();
 

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -1291,10 +1291,13 @@ mod tests {
                 .await?,
         );
 
-        assert!(sphere
-            .verify_authorization(&invalid_authorization)
-            .await
-            .is_err());
+        assert!(
+            sphere
+                .verify_authorization(&invalid_authorization)
+                .await
+                .is_err(),
+            "Authorization is invalid (authorizor has no authority over resource)"
+        );
 
         Ok(())
     }

--- a/rust/noosphere-gateway/src/authority.rs
+++ b/rust/noosphere-gateway/src/authority.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -14,9 +14,7 @@ use noosphere_sphere::SphereContext;
 use noosphere_storage::NativeStorage;
 
 use tokio::sync::Mutex;
-use ucan::{
-    capability::CapabilityView, chain::ProofChain, crypto::KeyMaterial, store::UcanJwtStore,
-};
+use ucan::{capability::CapabilityView, chain::ProofChain, store::UcanJwtStore};
 
 use super::GatewayScope;
 
@@ -25,19 +23,12 @@ use super::GatewayScope;
 /// represented by a UCAN. Any request handler can use a GatewayAuthority
 /// to test if a required capability is satisfied by the authorization
 /// presented by the maker of the request.
-pub struct GatewayAuthority<K>
-where
-    K: KeyMaterial + Clone + 'static,
-{
+pub struct GatewayAuthority {
     proof: ProofChain,
     scope: GatewayScope,
-    key_type: PhantomData<K>,
 }
 
-impl<K> GatewayAuthority<K>
-where
-    K: KeyMaterial + Clone + 'static,
-{
+impl GatewayAuthority {
     pub fn try_authorize(
         &self,
         capability: &CapabilityView<SphereReference, SphereAbility>,
@@ -61,17 +52,16 @@ where
 }
 
 #[async_trait]
-impl<S, K> FromRequestParts<S> for GatewayAuthority<K>
+impl<S> FromRequestParts<S> for GatewayAuthority
 where
     S: Send + Sync,
-    K: KeyMaterial + Clone + 'static,
 {
     type Rejection = StatusCode;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let sphere_context = parts
             .extensions
-            .get::<Arc<Mutex<SphereContext<K, NativeStorage>>>>()
+            .get::<Arc<Mutex<SphereContext<NativeStorage>>>>()
             .ok_or_else(|| {
                 error!("Could not find DidParser in extensions");
                 StatusCode::INTERNAL_SERVER_ERROR
@@ -151,7 +141,6 @@ where
         Ok(GatewayAuthority {
             scope: gateway_scope.clone(),
             proof: proof_chain,
-            key_type: PhantomData::default(),
         })
     }
 }

--- a/rust/noosphere-gateway/src/route/fetch.rs
+++ b/rust/noosphere-gateway/src/route/fetch.rs
@@ -14,21 +14,19 @@ use noosphere_ipfs::{IpfsStore, KuboClient};
 use noosphere_sphere::{car_stream, memo_history_stream, HasSphereContext};
 use noosphere_storage::{BlockStoreRetry, SphereDb, Storage};
 use tokio_stream::{Stream, StreamExt};
-use ucan::crypto::KeyMaterial;
 
 use crate::{authority::GatewayAuthority, GatewayScope};
 
 #[instrument(level = "debug", skip(authority, scope, sphere_context, ipfs_client))]
-pub async fn fetch_route<C, K, S>(
-    authority: GatewayAuthority<K>,
+pub async fn fetch_route<C, S>(
+    authority: GatewayAuthority,
     Query(FetchParameters { since }): Query<FetchParameters>,
     Extension(scope): Extension<GatewayScope>,
     Extension(ipfs_client): Extension<KuboClient>,
     Extension(sphere_context): Extension<C>,
 ) -> Result<StreamBody<impl Stream<Item = Result<Bytes, std::io::Error>>>, StatusCode>
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
     authority.try_authorize(&generate_capability(

--- a/rust/noosphere-gateway/src/route/push.rs
+++ b/rust/noosphere-gateway/src/route/push.rs
@@ -14,7 +14,6 @@ use noosphere_sphere::{HasMutableSphereContext, SphereContentWrite, SphereCursor
 use noosphere_storage::Storage;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::StreamExt;
-use ucan::crypto::KeyMaterial;
 
 use crate::{
     authority::GatewayAuthority,
@@ -35,8 +34,8 @@ use crate::{
         request_body
     )
 )]
-pub async fn push_route<C, K, S>(
-    authority: GatewayAuthority<K>,
+pub async fn push_route<C, S>(
+    authority: GatewayAuthority,
     Extension(sphere_context): Extension<C>,
     Extension(gateway_scope): Extension<GatewayScope>,
     Extension(syndication_tx): Extension<UnboundedSender<SyndicationJob<C>>>,
@@ -44,8 +43,7 @@ pub async fn push_route<C, K, S>(
     Cbor(request_body): Cbor<PushBody>,
 ) -> Result<Cbor<PushResponse>, StatusCode>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     debug!("Invoking push route...");
@@ -67,17 +65,15 @@ where
         syndication_tx,
         name_system_tx,
         request_body,
-        key_type: PhantomData,
         storage_type: PhantomData,
     };
 
     Ok(Cbor(gateway_push_routine.invoke().await?))
 }
 
-pub struct GatewayPushRoutine<C, K, S>
+pub struct GatewayPushRoutine<C, S>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     sphere_context: C,
@@ -85,14 +81,12 @@ where
     syndication_tx: UnboundedSender<SyndicationJob<C>>,
     name_system_tx: UnboundedSender<NameSystemJob<C>>,
     request_body: PushBody,
-    key_type: PhantomData<K>,
     storage_type: PhantomData<S>,
 }
 
-impl<C, K, S> GatewayPushRoutine<C, K, S>
+impl<C, S> GatewayPushRoutine<C, S>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     pub async fn invoke(mut self) -> Result<PushResponse, PushError> {

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -30,7 +30,6 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_stream::{Stream, StreamExt};
-use ucan::crypto::KeyMaterial;
 use url::Url;
 
 const PERIODIC_PUBLISH_INTERVAL_SECONDS: u64 = 5 * 60;
@@ -89,13 +88,12 @@ pub enum NameSystemJob<C> {
     Publish { context: C, record: LinkRecord },
 }
 
-pub fn start_name_system<C, K, S>(
+pub fn start_name_system<C, S>(
     configuration: NameSystemConfiguration,
     local_spheres: Vec<C>,
 ) -> (UnboundedSender<NameSystemJob<C>>, JoinHandle<Result<()>>)
 where
-    C: HasMutableSphereContext<K, S> + 'static,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S> + 'static,
     S: Storage + 'static,
 {
     let (tx, rx) = unbounded_channel();
@@ -118,12 +116,9 @@ where
 /// Run once on gateway start and every PERIODIC_PUBLISH_INTERVAL_SECONDS,
 /// republish all stored link records in gateway spheres that map to
 /// counterpart managed spheres.
-async fn periodic_publisher_task<C, K, S>(
-    tx: UnboundedSender<NameSystemJob<C>>,
-    local_spheres: Vec<C>,
-) where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+async fn periodic_publisher_task<C, S>(tx: UnboundedSender<NameSystemJob<C>>, local_spheres: Vec<C>)
+where
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     loop {
@@ -136,13 +131,12 @@ async fn periodic_publisher_task<C, K, S>(
     }
 }
 
-async fn periodic_publish_record<C, K, S>(
+async fn periodic_publish_record<C, S>(
     tx: &UnboundedSender<NameSystemJob<C>>,
     local_sphere: &C,
 ) -> Result<()>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     match get_counterpart_record(local_sphere).await {
@@ -162,12 +156,9 @@ where
     Ok(())
 }
 
-async fn periodic_resolver_task<C, K, S>(
-    tx: UnboundedSender<NameSystemJob<C>>,
-    local_spheres: Vec<C>,
-) where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+async fn periodic_resolver_task<C, S>(tx: UnboundedSender<NameSystemJob<C>>, local_spheres: Vec<C>)
+where
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     for sphere in local_spheres.iter().cycle() {
@@ -184,13 +175,12 @@ async fn periodic_resolver_task<C, K, S>(
     }
 }
 
-async fn name_system_task<C, K, S>(
+async fn name_system_task<C, S>(
     configuration: NameSystemConfiguration,
     mut receiver: UnboundedReceiver<NameSystemJob<C>>,
 ) -> Result<()>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     info!(
@@ -215,14 +205,13 @@ where
     Ok(())
 }
 
-async fn process_job<C, K, S, I, O, F>(
+async fn process_job<C, S, I, O, F>(
     job: NameSystemJob<C>,
     with_client: &mut TryOrReset<I, O, F>,
     ipfs_api: &Url,
 ) -> Result<()>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
     I: Fn() -> F,
     O: NameResolver + 'static,
@@ -329,15 +318,14 @@ where
 
 /// Consumes a stream of name / address tuples, resolving them one at a time
 /// and updating the provided [SphereContext] with the latest resolved values
-async fn resolve_all<C, K, S, N>(
+async fn resolve_all<C, S, N>(
     client: Arc<dyn NameResolver>,
     mut context: C,
     stream: N,
     ipfs_api: &Url,
 ) -> Result<()>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
     N: Stream<Item = Result<(String, IdentityIpld)>>,
 {
@@ -447,10 +435,9 @@ impl<H> OnDemandNameResolver<H> {
     }
 }
 
-async fn set_counterpart_record<C, K, S>(context: C, record: &LinkRecord) -> Result<()>
+async fn set_counterpart_record<C, S>(context: C, record: &LinkRecord) -> Result<()>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     debug!("Setting counterpart record...");
@@ -474,10 +461,9 @@ where
     Ok(())
 }
 
-async fn get_counterpart_record<C, K, S>(context: &C) -> Result<Option<LinkRecord>>
+async fn get_counterpart_record<C, S>(context: &C) -> Result<Option<LinkRecord>>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     debug!("Getting counterpart record...");
@@ -512,7 +498,7 @@ mod tests {
     #[tokio::test]
     async fn it_publishes_to_the_name_system() -> Result<()> {
         let ipfs_url: Url = "http://127.0.0.1:5000".parse()?;
-        let sphere = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+        let (sphere, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let record: LinkRecord = {
             let context = sphere.lock().await;
             let identity: &str = context.identity().into();

--- a/rust/noosphere-into/examples/notes-to-html/implementation.rs
+++ b/rust/noosphere-into/examples/notes-to-html/implementation.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use axum::{http::StatusCode, response::IntoResponse, routing::get_service};
 use noosphere_into::{sphere_into_html, NativeFs};
-use noosphere_sphere::{HasMutableSphereContext, SphereContentWrite, SphereContext, SphereCursor};
+use noosphere_sphere::{
+    HasMutableSphereContext, SphereContentWrite, SphereContext, SphereContextKey, SphereCursor,
+};
 use std::{ffi::OsStr, net::SocketAddr, path::Path, sync::Arc};
 use tempfile::TempDir;
 use tokio::{
@@ -27,7 +29,7 @@ pub async fn main() -> Result<()> {
     let storage_provider = MemoryStorage::default();
     let mut db = SphereDb::new(&storage_provider).await.unwrap();
 
-    let owner_key = generate_ed25519_key();
+    let owner_key: SphereContextKey = Arc::new(Box::new(generate_ed25519_key()));
     let owner_did = owner_key.get_did().await?;
 
     let (sphere, proof, _) = Sphere::generate(&owner_did, &mut db).await?;

--- a/rust/noosphere-into/src/into/html/sphere.rs
+++ b/rust/noosphere-into/src/into/html/sphere.rs
@@ -6,7 +6,6 @@ use noosphere_sphere::{HasSphereContext, SphereContentRead, SphereCursor};
 use noosphere_storage::Storage;
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
-use ucan::crypto::KeyMaterial;
 
 use crate::{
     file_to_html_stream, sphere_to_html_document_stream, HtmlOutput, StaticHtmlTransform,
@@ -18,10 +17,9 @@ static DEFAULT_STYLES: &[u8] = include_bytes!("./static/styles.css");
 /// Given a sphere [Did], [SphereDb] and a [WriteTarget], produce rendered HTML
 /// output up to and including the complete historical revisions of the
 /// slug-named content of the sphere.
-pub async fn sphere_into_html<C, K, S, W>(sphere_context: C, write_target: &W) -> Result<()>
+pub async fn sphere_into_html<C, S, W>(sphere_context: C, write_target: &W) -> Result<()>
 where
-    C: HasSphereContext<K, S> + 'static,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S> + 'static,
     S: Storage + 'static,
     W: WriteTarget + 'static,
 {
@@ -180,7 +178,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_writes_a_file_from_the_sphere_to_the_target_as_html() {
-        let context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(context);
@@ -249,7 +247,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_symlinks_a_file_slug_to_the_latest_file_version() {
-        let context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(context);

--- a/rust/noosphere-into/src/transcluder/content.rs
+++ b/rust/noosphere-into/src/transcluder/content.rs
@@ -8,32 +8,27 @@ use noosphere_sphere::{HasSphereContext, SphereContentRead};
 use noosphere_storage::Storage;
 use subtext::{block::Block, primitive::Entity, Peer};
 use tokio_stream::StreamExt;
-use ucan::crypto::KeyMaterial;
 
 /// A [Transcluder] implementation that uses [HasSphereContext] to resolve the content
 /// being transcluded.
 #[derive(Clone)]
-pub struct SphereContentTranscluder<R, K, S>
+pub struct SphereContentTranscluder<R, S>
 where
-    R: HasSphereContext<K, S> + Clone,
-    K: KeyMaterial + Clone + 'static,
+    R: HasSphereContext<S> + Clone,
     S: Storage + 'static,
 {
     content: R,
-    key_type: PhantomData<K>,
     storage_type: PhantomData<S>,
 }
 
-impl<R, K, S> SphereContentTranscluder<R, K, S>
+impl<R, S> SphereContentTranscluder<R, S>
 where
-    R: HasSphereContext<K, S> + Clone,
-    K: KeyMaterial + Clone + 'static,
+    R: HasSphereContext<S> + Clone,
     S: Storage + 'static,
 {
     pub fn new(content: R) -> Self {
         SphereContentTranscluder {
             content,
-            key_type: PhantomData,
             storage_type: PhantomData,
         }
     }
@@ -41,11 +36,10 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<R, K, S> Transcluder for SphereContentTranscluder<R, K, S>
+impl<R, S> Transcluder for SphereContentTranscluder<R, S>
 where
-    R: HasSphereContext<K, S> + Clone,
+    R: HasSphereContext<S> + Clone,
     S: Storage + 'static,
-    K: KeyMaterial + Clone + 'static,
 {
     async fn transclude(&self, link: &ResolvedLink) -> Result<Option<Transclude>> {
         match link {

--- a/rust/noosphere-into/src/transform/sphere/html.rs
+++ b/rust/noosphere-into/src/transform/sphere/html.rs
@@ -5,17 +5,15 @@ use noosphere_core::data::{ContentType, Header};
 use noosphere_core::view::Sphere;
 use noosphere_sphere::{HasSphereContext, SphereFile};
 use noosphere_storage::{BlockStore, Storage};
-use ucan::crypto::KeyMaterial;
 
 /// Given a [Transform] and a [Sphere], produce a stream that yields the file
 /// content as an HTML document
-pub fn sphere_to_html_document_stream<C, K, S, T>(
+pub fn sphere_to_html_document_stream<C, S, T>(
     context: C,
     transform: T,
 ) -> impl Stream<Item = String>
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
     T: Transform,
 {

--- a/rust/noosphere-into/src/transform/transform_implementation.rs
+++ b/rust/noosphere-into/src/transform/transform_implementation.rs
@@ -1,6 +1,5 @@
 use noosphere_sphere::HasSphereContext;
 use noosphere_storage::Storage;
-use ucan::crypto::KeyMaterial;
 
 use crate::{Resolver, SphereContentTranscluder, StaticHtmlResolver, Transcluder};
 
@@ -18,20 +17,18 @@ pub trait Transform: Clone {
 /// A [Transform] that is suitable for converting Noosphere content to
 /// HTML for a basic state website generator.
 #[derive(Clone)]
-pub struct StaticHtmlTransform<R, K, S>
+pub struct StaticHtmlTransform<R, S>
 where
-    R: HasSphereContext<K, S> + Clone,
-    K: KeyMaterial + Clone + 'static,
+    R: HasSphereContext<S> + Clone,
     S: Storage + 'static,
 {
     pub resolver: StaticHtmlResolver,
-    pub transcluder: SphereContentTranscluder<R, K, S>,
+    pub transcluder: SphereContentTranscluder<R, S>,
 }
 
-impl<R, K, S> StaticHtmlTransform<R, K, S>
+impl<R, S> StaticHtmlTransform<R, S>
 where
-    R: HasSphereContext<K, S> + Clone,
-    K: KeyMaterial + Clone + 'static,
+    R: HasSphereContext<S> + Clone,
     S: Storage + 'static,
 {
     pub fn new(content: R) -> Self {
@@ -42,15 +39,14 @@ where
     }
 }
 
-impl<R, K, S> Transform for StaticHtmlTransform<R, K, S>
+impl<R, S> Transform for StaticHtmlTransform<R, S>
 where
-    R: HasSphereContext<K, S> + Clone,
-    K: KeyMaterial + Clone + 'static,
+    R: HasSphereContext<S> + Clone,
     S: Storage + 'static,
 {
     type Resolver = StaticHtmlResolver;
 
-    type Transcluder = SphereContentTranscluder<R, K, S>;
+    type Transcluder = SphereContentTranscluder<R, S>;
 
     fn resolver(&self) -> &Self::Resolver {
         &self.resolver

--- a/rust/noosphere-sphere/src/authority/mod.rs
+++ b/rust/noosphere-sphere/src/authority/mod.rs
@@ -1,0 +1,5 @@
+mod read;
+pub use read::*;
+
+mod write;
+pub use write::*;

--- a/rust/noosphere-sphere/src/authority/read.rs
+++ b/rust/noosphere-sphere/src/authority/read.rs
@@ -1,0 +1,162 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use noosphere_core::{
+    authority::{Author, Authorization},
+    data::{Did, Link, Mnemonic},
+};
+use noosphere_storage::Storage;
+
+use tokio_stream::StreamExt;
+
+use crate::{HasSphereContext, SphereContextKey};
+use async_trait::async_trait;
+
+/// Anything that can read the authority section from a sphere should implement
+/// [SphereAuthorityRead]. A blanket implementation is provided for anything
+/// that implements [HasSphereContext].
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SphereAuthorityRead<S>
+where
+    S: Storage + 'static,
+    Self: Sized,
+{
+    /// For a given [Authorization], checks that the authorization and all of its
+    /// ancester proofs are valid and have not been revoked
+    async fn verify_authorization(&self, authorization: &Authorization) -> Result<()>;
+
+    /// Look up an authorization by a [Did].
+    async fn get_authorization(&self, did: &Did) -> Result<Option<Authorization>>;
+
+    /// Derive a root sphere key from a mnemonic and return a version of this
+    /// [SphereAuthorityRead] whose inner [SphereContext]'s [Author] is using
+    /// that root sphere key.
+    async fn escalate_authority(&self, mnemonic: &Mnemonic) -> Result<Self>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<C, S> SphereAuthorityRead<S> for C
+where
+    C: HasSphereContext<S>,
+    S: Storage + 'static,
+{
+    async fn verify_authorization(&self, authorization: &Authorization) -> Result<()> {
+        self.to_sphere()
+            .await?
+            .verify_authorization(authorization)
+            .await
+    }
+
+    async fn get_authorization(&self, did: &Did) -> Result<Option<Authorization>> {
+        let sphere = self.to_sphere().await?;
+        let authority = sphere.get_authority().await?;
+        let delegations = authority.get_delegations().await?;
+        let delegations_stream = delegations.into_stream().await?;
+
+        tokio::pin!(delegations_stream);
+
+        while let Some((Link { cid, .. }, delegation)) = delegations_stream.try_next().await? {
+            let ucan = delegation.resolve_ucan(sphere.store()).await?;
+            let authorized_did = ucan.audience();
+
+            if authorized_did == did {
+                return Ok(Some(Authorization::Cid(cid)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn escalate_authority(&self, mnemonic: &Mnemonic) -> Result<Self> {
+        let root_key: SphereContextKey = Arc::new(Box::new(mnemonic.to_credential()?));
+        let root_author = Author {
+            key: root_key,
+            authorization: None,
+        };
+
+        let root_identity = root_author.did().await?;
+        let sphere_identity = self.identity().await?;
+
+        if sphere_identity != root_identity {
+            return Err(anyhow!(
+                "Provided mnemonic did not produce the expected credential"
+            ));
+        }
+
+        Ok(Self::wrap(
+            self.sphere_context()
+                .await?
+                .with_author(&root_author)
+                .await?,
+        )
+        .await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use noosphere_core::data::Did;
+
+    use ucan::crypto::KeyMaterial;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use crate::helpers::{simulated_sphere_context, SimulationAccess};
+    use crate::{HasSphereContext, SphereAuthorityRead};
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_get_an_authorization_by_did() -> Result<()> {
+        let (sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let author_did = Did(sphere_context
+            .sphere_context()
+            .await?
+            .author()
+            .key
+            .get_did()
+            .await?);
+
+        let authorization = sphere_context
+            .get_authorization(&author_did)
+            .await?
+            .unwrap();
+
+        let _ucan = authorization
+            .as_ucan(sphere_context.sphere_context().await?.db())
+            .await?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_verify_an_authorization_to_write_to_a_sphere() -> Result<()> {
+        let (sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let author_did = Did(sphere_context
+            .sphere_context()
+            .await?
+            .author()
+            .key
+            .get_did()
+            .await?);
+
+        let authorization = sphere_context
+            .get_authorization(&author_did)
+            .await?
+            .unwrap();
+
+        sphere_context.verify_authorization(&authorization).await?;
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-sphere/src/authority/write.rs
+++ b/rust/noosphere-sphere/src/authority/write.rs
@@ -1,0 +1,382 @@
+use crate::{internal::SphereContextInternal, HasMutableSphereContext, HasSphereContext};
+
+use super::SphereAuthorityRead;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use cid::Cid;
+use noosphere_core::{
+    authority::{generate_capability, Authorization, SphereAbility},
+    data::{DelegationIpld, Did, Jwt, Link, RevocationIpld},
+    view::SPHERE_LIFETIME,
+};
+use noosphere_storage::{Storage, UcanStore};
+use tokio_stream::StreamExt;
+use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
+
+/// Any type which implements [SphereAuthorityWrite] is able to manipulate the
+/// [AuthorityIpld] section of a sphere. This includes authorizing other keys
+/// and revoking prior authorizations.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SphereAuthorityWrite<S>: SphereAuthorityRead<S>
+where
+    S: Storage + 'static,
+{
+    /// Authorize another key by its [Did], associating the authorization with a
+    /// provided display name
+    async fn authorize(&mut self, name: &str, identity: &Did) -> Result<Authorization>;
+
+    /// Revoke a previously granted authorization.
+    ///
+    /// Note that correctly revoking an authorization requires signing with a credential
+    /// that is in the chain of authority that ultimately granted the authorization being
+    /// revoked. Attempting to revoke a credential with any credential that isn't in that
+    /// chain of authority will fail.
+    async fn revoke_authorization(&mut self, authorization: &Authorization) -> Result<()>;
+
+    /// Recover authority by revoking all previously delegated authorizations
+    /// and creating a new one that delegates authority to the specified key
+    /// (given by its [Did]).
+    ///
+    /// Note that correctly recovering authority requires signing with the root
+    /// sphere credential, so generally can only be performed on a type that
+    /// implements [SphereAuthorityEscalate]
+    async fn recover_authority(&mut self, new_owner: &Did) -> Result<Authorization>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<C, S> SphereAuthorityWrite<S> for C
+where
+    C: HasSphereContext<S> + HasMutableSphereContext<S>,
+    S: Storage + 'static,
+{
+    // TODO(#423): We allow optional human-readable names for authorizations,
+    // but this will bear the consequence of leaking personal information about
+    // the user (e.g., a list of their authorized devices). We should encrypt
+    // these names so that they are only readable by the user themselves.
+    async fn authorize(&mut self, name: &str, identity: &Did) -> Result<Authorization> {
+        self.assert_write_access().await?;
+
+        let author = self.sphere_context().await?.author().clone();
+        let mut sphere = self.to_sphere().await?;
+        let authorization = author.require_authorization()?;
+
+        self.verify_authorization(authorization).await?;
+
+        let authorization_expiry: Option<u64> = {
+            let ucan = authorization
+                .as_ucan(&UcanStore(sphere.store().clone()))
+                .await?;
+            *ucan.expires_at()
+        };
+
+        let mut builder = UcanBuilder::default()
+            .issued_by(&author.key)
+            .for_audience(identity)
+            .claiming_capability(&generate_capability(
+                &sphere.get_identity().await?,
+                SphereAbility::Authorize,
+            ))
+            .with_nonce();
+
+        // TODO(ucan-wg/rs-ucan#114): Clean this up when
+        // `UcanBuilder::with_expiration` accepts `Option<u64>`
+        if let Some(expiry) = authorization_expiry {
+            builder = builder.with_expiration(expiry);
+        }
+
+        // TODO(ucan-wg/rs-ucan#32): Clean this up when we can use a CID as an authorization
+        let mut signable = builder.build()?;
+
+        signable
+            .proofs
+            .push(Cid::try_from(authorization)?.to_string());
+
+        let jwt = signable.sign().await?.encode()?;
+
+        let delegation = DelegationIpld::register(name, &jwt, sphere.store_mut()).await?;
+
+        self.sphere_context_mut()
+            .await?
+            .mutation_mut()
+            .delegations_mut()
+            .set(&Link::new(delegation.jwt), &delegation);
+
+        Ok(Authorization::Cid(delegation.jwt))
+    }
+
+    async fn revoke_authorization(&mut self, authorization: &Authorization) -> Result<()> {
+        self.assert_write_access().await?;
+
+        let mut sphere_context = self.sphere_context_mut().await?;
+
+        if !sphere_context
+            .author()
+            .is_authorizer_of(authorization, sphere_context.db())
+            .await?
+        {
+            let author_did = sphere_context.author().did().await?;
+
+            return Err(anyhow!(
+                "{} cannot revoke authorization {} (not a delegating authority)",
+                author_did,
+                authorization
+            ));
+        }
+
+        let authorization_cid = Link::<Jwt>::from(Cid::try_from(authorization)?);
+        let delegations = sphere_context
+            .sphere()
+            .await?
+            .get_authority()
+            .await?
+            .get_delegations()
+            .await?;
+
+        if delegations.get(&authorization_cid).await?.is_none() {
+            return Err(anyhow!(
+                "No authority has been delegated to the authorization being revoked"
+            ));
+        }
+
+        let revocation =
+            RevocationIpld::revoke(&authorization_cid, &sphere_context.author().key).await?;
+
+        sphere_context
+            .mutation_mut()
+            .delegations_mut()
+            .remove(&authorization_cid);
+
+        sphere_context
+            .mutation_mut()
+            .revocations_mut()
+            .set(&authorization_cid, &revocation);
+
+        // TODO(#424): Recursively remove any sub-delegations here (and revoke them?)
+
+        Ok(())
+    }
+
+    async fn recover_authority(&mut self, new_owner: &Did) -> Result<Authorization> {
+        self.assert_write_access().await?;
+
+        let mut sphere_context = self.sphere_context_mut().await?;
+        let author_did = Did(sphere_context.author().key.get_did().await?);
+        let sphere_identity = sphere_context.identity().clone();
+
+        if author_did != sphere_identity {
+            return Err(anyhow!(
+                "Only the root sphere credential can be used to recover authority"
+            ));
+        }
+
+        let sphere = sphere_context.sphere().await?;
+        let authority = sphere.get_authority().await?;
+        let delegations = authority.get_delegations().await?;
+        let delegation_stream = delegations.into_stream().await?;
+
+        tokio::pin!(delegation_stream);
+
+        // First: revoke all current authority
+        while let Some((link, _)) = delegation_stream.try_next().await? {
+            let revocation = RevocationIpld::revoke(&link, &sphere_context.author().key).await?;
+
+            sphere_context
+                .mutation_mut()
+                .delegations_mut()
+                .remove(&link);
+            sphere_context
+                .mutation_mut()
+                .revocations_mut()
+                .set(&link, &revocation);
+        }
+
+        // Then: bless a new owner
+        let ucan = UcanBuilder::default()
+            .issued_by(&sphere_context.author().key)
+            .for_audience(new_owner)
+            .with_lifetime(SPHERE_LIFETIME)
+            .with_nonce()
+            .claiming_capability(&generate_capability(
+                &sphere_identity,
+                SphereAbility::Authorize,
+            ))
+            .build()?
+            .sign()
+            .await?;
+
+        let jwt = ucan.encode()?;
+        let delegation = DelegationIpld::register("(OWNER)", &jwt, sphere_context.db()).await?;
+        let link = Link::new(delegation.jwt);
+
+        sphere_context
+            .mutation_mut()
+            .delegations_mut()
+            .set(&link, &delegation);
+
+        Ok(Authorization::Cid(link.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use noosphere_core::authority::{generate_ed25519_key, Author};
+    use noosphere_core::data::Did;
+
+    use tokio::sync::Mutex;
+    use ucan::crypto::KeyMaterial;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use crate::helpers::{simulated_sphere_context, SimulationAccess};
+    use crate::{
+        HasMutableSphereContext, HasSphereContext, SphereAuthorityRead, SphereAuthorityWrite,
+        SphereContextKey,
+    };
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_allows_an_authorized_key_to_authorize_other_keys() -> Result<()> {
+        let (mut sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        assert!(sphere_context
+            .verify_authorization(&other_authorization)
+            .await
+            .is_ok());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_implicitly_revokes_transitive_authorizations() -> Result<()> {
+        let (mut sphere_context, mnemonic) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key: SphereContextKey = Arc::new(Box::new(generate_ed25519_key()));
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        let mut sphere_context_with_other_credential = Arc::new(Mutex::new(
+            sphere_context
+                .sphere_context()
+                .await?
+                .with_author(&Author {
+                    key: other_key.clone(),
+                    authorization: Some(other_authorization.clone()),
+                })
+                .await?,
+        ));
+
+        let third_key = generate_ed25519_key();
+        let third_did = Did(third_key.get_did().await?);
+
+        let third_authorization = sphere_context_with_other_credential
+            .authorize("third", &third_did)
+            .await?;
+        sphere_context_with_other_credential.save(None).await?;
+
+        let mut root_sphere_context = sphere_context.escalate_authority(&mnemonic).await?;
+
+        root_sphere_context
+            .revoke_authorization(&other_authorization)
+            .await?;
+        root_sphere_context.save(None).await?;
+
+        assert!(sphere_context
+            .verify_authorization(&third_authorization)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_catches_revoked_authorizations_when_verifying() -> Result<()> {
+        let (mut sphere_context, mnemonic) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        let mut root_sphere_context = sphere_context.escalate_authority(&mnemonic).await?;
+
+        root_sphere_context
+            .revoke_authorization(&other_authorization)
+            .await?;
+        root_sphere_context.save(None).await?;
+
+        assert!(sphere_context
+            .verify_authorization(&other_authorization)
+            .await
+            .is_err());
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_can_perform_access_recovery_given_a_mnemonic() -> Result<()> {
+        let (mut sphere_context, mnemonic) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+
+        let owner = sphere_context.sphere_context().await?.author().clone();
+
+        let other_key = generate_ed25519_key();
+        let other_did = Did(other_key.get_did().await?);
+
+        let other_authorization = sphere_context.authorize("other", &other_did).await?;
+        sphere_context.save(None).await?;
+
+        let next_owner_key = generate_ed25519_key();
+        let next_owner_did = Did(next_owner_key.get_did().await?);
+
+        let mut root_sphere_context = sphere_context.escalate_authority(&mnemonic).await?;
+
+        root_sphere_context
+            .recover_authority(&next_owner_did)
+            .await?;
+        root_sphere_context.save(None).await?;
+
+        assert!(sphere_context
+            .verify_authorization(&other_authorization)
+            .await
+            .is_err());
+
+        assert!(sphere_context
+            .verify_authorization(&owner.authorization.unwrap())
+            .await
+            .is_err());
+
+        sphere_context
+            .verify_authorization(
+                &sphere_context
+                    .get_authorization(&next_owner_did)
+                    .await?
+                    .unwrap(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-sphere/src/content/decoder.rs
+++ b/rust/noosphere-sphere/src/content/decoder.rs
@@ -10,6 +10,8 @@ use tokio_stream::Stream;
 pub struct BodyChunkDecoder<'a, 'b, S: BlockStore>(pub &'a Cid, pub &'b S);
 
 impl<'a, 'b, S: BlockStore> BodyChunkDecoder<'a, 'b, S> {
+    /// Consume the [BodyChunkDecoder] and return an async [Stream] of bytes
+    /// representing the raw body contents
     pub fn stream(self) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Unpin {
         let mut next = Some(*self.0);
         let store = self.1.clone();

--- a/rust/noosphere-sphere/src/content/file.rs
+++ b/rust/noosphere-sphere/src/content/file.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use noosphere_core::data::{Did, Link, MemoIpld};
 use tokio::io::AsyncRead;
 
+/// A type that may be used as the contents field in a [SphereFile]
 #[cfg(not(target_arch = "wasm32"))]
 pub trait AsyncFileBody: AsyncRead + Unpin + Send {}
 
@@ -10,6 +11,7 @@ pub trait AsyncFileBody: AsyncRead + Unpin + Send {}
 impl<S> AsyncFileBody for S where S: AsyncRead + Unpin + Send {}
 
 #[cfg(target_arch = "wasm32")]
+/// A type that may be used as the contents field in a [SphereFile]
 pub trait AsyncFileBody: AsyncRead + Unpin {}
 
 #[cfg(target_arch = "wasm32")]
@@ -17,10 +19,15 @@ impl<S> AsyncFileBody for S where S: AsyncRead + Unpin {}
 
 /// A descriptor for contents that is stored in a sphere.
 pub struct SphereFile<C> {
+    /// The identity of the associated sphere from which the file was read
     pub sphere_identity: Did,
+    /// The version of the associated sphere from which the file was read
     pub sphere_version: Link<MemoIpld>,
+    /// The version of the memo that wraps the file's body contents
     pub memo_version: Link<MemoIpld>,
+    /// The memo that wraps the file's body contents
     pub memo: MemoIpld,
+    /// The body contents of the file
     pub contents: C,
 }
 
@@ -28,6 +35,8 @@ impl<C> SphereFile<C>
 where
     C: AsyncFileBody + 'static,
 {
+    /// Consume the file and return a version of it where its body contents have
+    /// been boxed and pinned
     pub fn boxed(self) -> SphereFile<Pin<Box<dyn AsyncFileBody + 'static>>> {
         SphereFile {
             sphere_identity: self.sphere_identity,

--- a/rust/noosphere-sphere/src/content/read.rs
+++ b/rust/noosphere-sphere/src/content/read.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
 use noosphere_storage::Storage;
 
-use ucan::crypto::KeyMaterial;
-
 use crate::HasSphereContext;
 use async_trait::async_trait;
 
@@ -12,9 +10,8 @@ use crate::{internal::SphereContextInternal, AsyncFileBody, SphereFile};
 /// A blanket implementation is provided for anything that implements [HasSphereContext].
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait SphereContentRead<K, S>
+pub trait SphereContentRead<S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Read a file that is associated with a given slug at the revision of the
@@ -32,10 +29,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> SphereContentRead<K, S> for C
+impl<C, S> SphereContentRead<S> for C
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
     async fn read(&self, slug: &str) -> Result<Option<SphereFile<Box<dyn AsyncFileBody>>>> {

--- a/rust/noosphere-sphere/src/content/write.rs
+++ b/rust/noosphere-sphere/src/content/write.rs
@@ -5,7 +5,6 @@ use noosphere_core::data::{BodyChunkIpld, Header, Link, MemoIpld};
 use noosphere_storage::{BlockStore, Storage};
 
 use tokio::io::AsyncReadExt;
-use ucan::crypto::KeyMaterial;
 
 use crate::{internal::SphereContextInternal, HasMutableSphereContext, HasSphereContext};
 use async_trait::async_trait;
@@ -25,9 +24,8 @@ fn validate_slug(slug: &str) -> Result<()> {
 /// implements [HasMutableSphereContext].
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait SphereContentWrite<K, S>: SphereContentRead<K, S>
+pub trait SphereContentWrite<S>: SphereContentRead<S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Like link, this takes a [Link<MemoIpld>] that should be associated
@@ -73,10 +71,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> SphereContentWrite<K, S> for C
+impl<C, S> SphereContentWrite<S> for C
 where
-    C: HasSphereContext<K, S> + HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S> + HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     async fn link_raw(&mut self, slug: &str, cid: &Link<MemoIpld>) -> Result<()> {

--- a/rust/noosphere-sphere/src/cursor.rs
+++ b/rust/noosphere-sphere/src/cursor.rs
@@ -55,7 +55,6 @@ where
     /// effects in the distance, the cursor will still point to the same version
     /// it referred to when it was created.
     pub async fn mounted(has_sphere_context: C) -> Result<Self> {
-        // let sphere_version = has_sphere_context.sphere_context().await?.head().await?;
         let mut cursor = Self::latest(has_sphere_context);
         cursor.mount().await?;
         Ok(cursor)

--- a/rust/noosphere-sphere/src/cursor.rs
+++ b/rust/noosphere-sphere/src/cursor.rs
@@ -7,7 +7,6 @@ use noosphere_core::{
 };
 use noosphere_storage::{BlockStore, Storage};
 use tokio_stream::StreamExt;
-use ucan::crypto::KeyMaterial;
 
 use crate::{HasMutableSphereContext, HasSphereContext, SphereContext, SphereReplicaRead};
 use std::{marker::PhantomData, sync::Arc};
@@ -21,24 +20,22 @@ use std::{marker::PhantomData, sync::Arc};
 /// implementor of [HasSphereContext] and mount it to a specific version of the
 /// sphere.
 #[derive(Clone)]
-pub struct SphereCursor<C, K, S>
+pub struct SphereCursor<C, S>
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
     has_sphere_context: C,
-    key: PhantomData<K>,
     storage: PhantomData<S>,
     sphere_version: Option<Link<MemoIpld>>,
 }
 
-impl<C, K, S> SphereCursor<C, K, S>
+impl<C, S> SphereCursor<C, S>
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
+    /// Consume the [SphereCursor] and return its wrapped [HasSphereContext]
     pub fn to_inner(self) -> C {
         self.has_sphere_context
     }
@@ -48,35 +45,9 @@ where
     pub fn mounted_at(has_sphere_context: C, sphere_version: &Link<MemoIpld>) -> Self {
         SphereCursor {
             has_sphere_context,
-            key: PhantomData,
             storage: PhantomData,
             sphere_version: Some(sphere_version.clone()),
         }
-    }
-
-    /// "Mount" the [SphereCursor] to the latest local version of the sphere it
-    /// refers to. If the [SphereCursor] is already mounted, the version it is
-    /// mounted to will be overwritten. A mounted [SphereCursor] will remain at
-    /// the version it is mounted to even when the latest version of the sphere
-    /// changes.
-    pub async fn mount(&mut self) -> Result<&Self> {
-        let sphere_version = self
-            .has_sphere_context
-            .sphere_context()
-            .await?
-            .version()
-            .await?;
-
-        self.sphere_version = Some(sphere_version);
-
-        Ok(self)
-    }
-
-    /// "Unmount" the [SphereCursor] so that it always uses the latest local
-    /// version of the sphere that it refers to.
-    pub fn unmount(mut self) -> Result<Self> {
-        self.sphere_version = None;
-        Ok(self)
     }
 
     /// Create the [SphereCursor] at the latest local version of the associated
@@ -90,13 +61,43 @@ where
         Ok(cursor)
     }
 
+    /// "Mount" the [SphereCursor] to the given version of the sphere it refers
+    /// to. If the [SphereCursor] is already mounted, the version it is mounted
+    /// to will be overwritten. A mounted [SphereCursor] will remain at the
+    /// version it is mounted to even when the latest version of the sphere
+    /// changes.
+    pub async fn mount_at(&mut self, sphere_version: &Link<MemoIpld>) -> Result<&Self> {
+        self.sphere_version = Some(sphere_version.clone());
+
+        Ok(self)
+    }
+
+    /// Same as [SphereCursor::mount_at] except that it mounts to the latest
+    /// local version of the sphere.
+    pub async fn mount(&mut self) -> Result<&Self> {
+        let sphere_version = self
+            .has_sphere_context
+            .sphere_context()
+            .await?
+            .version()
+            .await?;
+
+        self.mount_at(&sphere_version).await
+    }
+
+    /// "Unmount" the [SphereCursor] so that it always uses the latest local
+    /// version of the sphere that it refers to.
+    pub fn unmount(mut self) -> Result<Self> {
+        self.sphere_version = None;
+        Ok(self)
+    }
+
     /// Create this [SphereCursor] at the latest local version of the associated
     /// sphere. The [SphereCursor] will always point to the latest local
     /// version, unless subsequently mounted.
     pub fn latest(has_sphere_context: C) -> Self {
         SphereCursor {
             has_sphere_context,
-            key: PhantomData,
             storage: PhantomData,
             sphere_version: None,
         }
@@ -122,10 +123,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> HasMutableSphereContext<K, S> for SphereCursor<C, K, S>
+impl<C, S> HasMutableSphereContext<S> for SphereCursor<C, S>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage,
 {
     type MutableSphereContext = C::MutableSphereContext;
@@ -150,10 +150,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> HasSphereContext<K, S> for SphereCursor<C, K, S>
+impl<C, S> HasSphereContext<S> for SphereCursor<C, S>
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
     type SphereContext = C::SphereContext;
@@ -168,13 +167,16 @@ where
             None => self.has_sphere_context.version().await,
         }
     }
+
+    async fn wrap(sphere_context: SphereContext<S>) -> Self {
+        SphereCursor::latest(C::wrap(sphere_context).await)
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S> SphereReplicaRead<K, S> for SphereCursor<Arc<SphereContext<K, S>>, K, S>
+impl<S> SphereReplicaRead<S> for SphereCursor<Arc<SphereContext<S>>, S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     async fn traverse_by_petnames(&self, petname_path: &[String]) -> Result<Option<Self>> {
@@ -268,7 +270,7 @@ where
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use std::sync::Arc;
 
     use anyhow::Result;
@@ -297,7 +299,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_unlink_slugs_from_the_content_space() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -325,7 +327,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_flushes_on_every_save() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let initial_stats = {
@@ -382,7 +384,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_does_not_allow_writes_when_an_author_has_read_only_access() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::Readonly, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::Readonly, None)
             .await
             .unwrap();
 
@@ -403,7 +405,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_write_a_file_and_read_it_back() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -435,7 +437,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_overwrite_a_file_with_new_contents_and_preserve_history() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -492,7 +494,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_throws_an_error_when_saving_without_changes() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -506,7 +508,7 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_throws_an_error_when_saving_with_empty_mutation_and_empty_headers() {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None)
+        let (sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None)
             .await
             .unwrap();
         let mut cursor = SphereCursor::latest(sphere_context);
@@ -520,7 +522,8 @@ pub mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_can_get_all_petnames_assigned_to_an_identity() -> Result<()> {
-        let sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+        let (sphere_context, _) =
+            simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let mut db = UcanStore(sphere_context.sphere_context().await?.db().clone());
 

--- a/rust/noosphere-sphere/src/has.rs
+++ b/rust/noosphere-sphere/src/has.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use noosphere_core::{
+    authority::Author,
     data::{Did, Link, MemoIpld},
     view::Sphere,
 };
@@ -10,16 +11,19 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::{Mutex, OwnedMutexGuard};
-use ucan::crypto::KeyMaterial;
+
+use crate::SphereContextKey;
 
 use super::SphereContext;
 
+#[allow(missing_docs)]
 #[cfg(not(target_arch = "wasm32"))]
 pub trait HasConditionalSendSync: Send + Sync {}
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<S> HasConditionalSendSync for S where S: Send + Sync {}
 
+#[allow(missing_docs)]
 #[cfg(target_arch = "wasm32")]
 pub trait HasConditionalSendSync {}
 
@@ -34,12 +38,12 @@ impl<S> HasConditionalSendSync for S {}
 /// content and petnames.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait HasSphereContext<K, S>: Clone + HasConditionalSendSync
+pub trait HasSphereContext<S>: Clone + HasConditionalSendSync
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage,
 {
-    type SphereContext: Deref<Target = SphereContext<K, S>> + HasConditionalSendSync;
+    /// The type of the internal read-only [SphereContext]
+    type SphereContext: Deref<Target = SphereContext<S>> + HasConditionalSendSync;
 
     /// Get the [SphereContext] that is made available by this container.
     async fn sphere_context(&self) -> Result<Self::SphereContext>;
@@ -62,6 +66,15 @@ where
         let version = self.version().await?;
         Ok(Sphere::at(&version, self.sphere_context().await?.db()))
     }
+
+    /// Create a new [SphereContext] via [SphereContext::with_author] and wrap it in the same
+    /// [HasSphereContext] implementation, returning the result
+    async fn with_author(&self, author: &Author<SphereContextKey>) -> Result<Self> {
+        Ok(Self::wrap(self.sphere_context().await?.with_author(author).await?).await)
+    }
+
+    /// Wrap a given [SphereContext] in this [HasSphereContext]
+    async fn wrap(sphere_context: SphereContext<S>) -> Self;
 }
 
 /// Any container that can provide mutable access to a [SphereContext] should
@@ -72,13 +85,13 @@ where
 /// aspects of a sphere.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait HasMutableSphereContext<K, S>: HasSphereContext<K, S> + HasConditionalSendSync
+pub trait HasMutableSphereContext<S>: HasSphereContext<S> + HasConditionalSendSync
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage,
 {
-    type MutableSphereContext: Deref<Target = SphereContext<K, S>>
-        + DerefMut<Target = SphereContext<K, S>>
+    /// The type of the internal mutable [SphereContext]
+    type MutableSphereContext: Deref<Target = SphereContext<S>>
+        + DerefMut<Target = SphereContext<S>>
         + HasConditionalSendSync;
 
     /// Get a mutable reference to the [SphereContext] that is wrapped by this
@@ -132,39 +145,26 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S> HasSphereContext<K, S> for Arc<Mutex<SphereContext<K, S>>>
+impl<S> HasSphereContext<S> for Arc<Mutex<SphereContext<S>>>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
-    type SphereContext = OwnedMutexGuard<SphereContext<K, S>>;
+    type SphereContext = OwnedMutexGuard<SphereContext<S>>;
 
     async fn sphere_context(&self) -> Result<Self::SphereContext> {
         Ok(self.clone().lock_owned().await)
     }
-}
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S, T> HasSphereContext<K, S> for &T
-where
-    T: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
-    S: Storage + 'static,
-{
-    type SphereContext = T::SphereContext;
-
-    async fn sphere_context(&self) -> Result<Self::SphereContext> {
-        (*self).sphere_context().await
+    async fn wrap(sphere_context: SphereContext<S>) -> Self {
+        Arc::new(Mutex::new(sphere_context))
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S, T> HasSphereContext<K, S> for Box<T>
+impl<S, T> HasSphereContext<S> for Box<T>
 where
-    T: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    T: HasSphereContext<S>,
     S: Storage + 'static,
 {
     type SphereContext = T::SphereContext;
@@ -172,30 +172,36 @@ where
     async fn sphere_context(&self) -> Result<Self::SphereContext> {
         T::sphere_context(self).await
     }
-}
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S> HasSphereContext<K, S> for Arc<SphereContext<K, S>>
-where
-    K: KeyMaterial + Clone + 'static,
-    S: Storage,
-{
-    type SphereContext = Arc<SphereContext<K, S>>;
-
-    async fn sphere_context(&self) -> Result<Self::SphereContext> {
-        Ok(self.clone())
+    async fn wrap(sphere_context: SphereContext<S>) -> Self {
+        Box::new(T::wrap(sphere_context).await)
     }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S> HasMutableSphereContext<K, S> for Arc<Mutex<SphereContext<K, S>>>
+impl<S> HasSphereContext<S> for Arc<SphereContext<S>>
 where
-    K: KeyMaterial + Clone + 'static,
+    S: Storage,
+{
+    type SphereContext = Arc<SphereContext<S>>;
+
+    async fn sphere_context(&self) -> Result<Self::SphereContext> {
+        Ok(self.clone())
+    }
+
+    async fn wrap(sphere_context: SphereContext<S>) -> Self {
+        Arc::new(sphere_context)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S> HasMutableSphereContext<S> for Arc<Mutex<SphereContext<S>>>
+where
     S: Storage + 'static,
 {
-    type MutableSphereContext = OwnedMutexGuard<SphereContext<K, S>>;
+    type MutableSphereContext = OwnedMutexGuard<SphereContext<S>>;
 
     async fn sphere_context_mut(&mut self) -> Result<Self::MutableSphereContext> {
         self.sphere_context().await
@@ -204,10 +210,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<K, S, T> HasMutableSphereContext<K, S> for Box<T>
+impl<S, T> HasMutableSphereContext<S> for Box<T>
 where
-    T: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    T: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     type MutableSphereContext = T::MutableSphereContext;

--- a/rust/noosphere-sphere/src/internal.rs
+++ b/rust/noosphere-sphere/src/internal.rs
@@ -6,7 +6,6 @@ use futures_util::TryStreamExt;
 use noosphere_storage::{BlockStore, Storage};
 use std::str::FromStr;
 use tokio_util::io::StreamReader;
-use ucan::crypto::KeyMaterial;
 
 use cid::Cid;
 use noosphere_core::{
@@ -18,9 +17,8 @@ use noosphere_core::{
 /// the fact that all trait methods are implicitly public implementation
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub(crate) trait SphereContextInternal<K, S>
+pub(crate) trait SphereContextInternal<S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Returns an error result if the configured author of the [SphereContext]
@@ -37,10 +35,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> SphereContextInternal<K, S> for C
+impl<C, S> SphereContextInternal<S> for C
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
     async fn assert_write_access(&self) -> Result<()> {

--- a/rust/noosphere-sphere/src/lib.rs
+++ b/rust/noosphere-sphere/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+//!   let (mut sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 //!
 //!   sphere_context.write("foo", "text/plain", "bar".as_ref(), None).await?;
 //!   sphere_context.save(None).await?;
@@ -38,7 +38,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!   let mut sphere_context = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
+//!   let (mut sphere_context, _) = simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 //!
 //!   sphere_context.set_petname("cdata", Some("did:key:example".into())).await?;
 //!   sphere_context.save(None).await?;
@@ -48,6 +48,8 @@
 //! ```
 //!
 //!
+
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate tracing;
@@ -61,6 +63,7 @@ use noosphere_core::authority::Author;
 #[cfg(doc)]
 use noosphere_storage::Storage;
 
+mod authority;
 mod content;
 mod context;
 mod cursor;
@@ -75,6 +78,7 @@ pub mod metadata;
 mod petname;
 mod sync;
 
+pub use authority::*;
 pub use content::*;
 pub use context::*;
 pub use cursor::*;

--- a/rust/noosphere-sphere/src/metadata.rs
+++ b/rust/noosphere-sphere/src/metadata.rs
@@ -1,6 +1,6 @@
-///! These constants represent the metadata keys used when a [SphereContext] is
-///! is initialized. Since these represent somewhat free-form key/values in the
-///! storage layer, we are make a best effort to document them here.
+//! These constants represent the metadata keys used when a [SphereContext] is
+//! is initialized. Since these represent somewhat free-form key/values in the
+//! storage layer, we are make a best effort to document them here.
 
 #[cfg(doc)]
 use crate::SphereContext;

--- a/rust/noosphere-sphere/src/petname/read.rs
+++ b/rust/noosphere-sphere/src/petname/read.rs
@@ -6,7 +6,6 @@ use cid::Cid;
 use futures_util::TryStreamExt;
 use noosphere_core::data::{Did, Link, MemoIpld};
 use noosphere_storage::{KeyValueStore, Storage};
-use ucan::crypto::KeyMaterial;
 
 use crate::{HasSphereContext, SphereWalker};
 
@@ -15,9 +14,8 @@ use crate::{HasSphereContext, SphereWalker};
 /// that implements [HasSphereContext].
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait SpherePetnameRead<K, S>
+pub trait SpherePetnameRead<S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Get the [Did] that is assigned to a petname, if any
@@ -48,10 +46,9 @@ fn sphere_checkpoint_cache_key(origin: &Did, origin_version: &Cid) -> String {
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> SpherePetnameRead<K, S> for C
+impl<C, S> SpherePetnameRead<S> for C
 where
-    C: HasSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasSphereContext<S>,
     S: Storage + 'static,
 {
     #[instrument(skip(self))]

--- a/rust/noosphere-sphere/src/petname/write.rs
+++ b/rust/noosphere-sphere/src/petname/write.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use noosphere_core::data::{Did, IdentityIpld, LinkRecord};
 use noosphere_storage::Storage;
-use ucan::{crypto::KeyMaterial, store::UcanJwtStore};
+use ucan::store::UcanJwtStore;
 
 use crate::{internal::SphereContextInternal, HasMutableSphereContext, SpherePetnameRead};
 
@@ -21,9 +21,8 @@ fn validate_petname(petname: &str) -> Result<()> {
 /// implements [HasMutableSphereContext]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait SpherePetnameWrite<K, S>: SpherePetnameRead<K, S>
+pub trait SpherePetnameWrite<S>: SpherePetnameRead<S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Configure a petname, by assigning some [Did] to it or none. By assigning
@@ -42,16 +41,16 @@ where
     /// set.
     async fn set_petname_record(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>>;
 
+    /// Deprecated; use [SpherePetnameWrite::set_petname_record] instead
     #[deprecated(note = "Use set_petname_record instead")]
     async fn adopt_petname(&mut self, name: &str, record: &LinkRecord) -> Result<Option<Did>>;
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> SpherePetnameWrite<K, S> for C
+impl<C, S> SpherePetnameWrite<S> for C
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     async fn set_petname(&mut self, name: &str, identity: Option<Did>) -> Result<()> {

--- a/rust/noosphere-sphere/src/replication/car.rs
+++ b/rust/noosphere-sphere/src/replication/car.rs
@@ -12,6 +12,9 @@ use tokio_util::{
     sync::PollSender,
 };
 
+/// Takes a list of roots and a stream of blocks (pairs of [Cid] and
+/// corresponding [Vec<u8>]), and produces an async byte stream that yields a
+/// valid [CARv1](https://ipld.io/specs/transport/car/carv1/)
 pub fn car_stream<S>(
     mut roots: Vec<Cid>,
     block_stream: S,

--- a/rust/noosphere-sphere/src/replication/read.rs
+++ b/rust/noosphere-sphere/src/replication/read.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use noosphere_storage::Storage;
-use ucan::crypto::KeyMaterial;
 
+/// Implementors are able to traverse from one sphere to the next via
+/// the address book entries found in those spheres
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait SphereReplicaRead<K, S>: Sized
+pub trait SphereReplicaRead<S>: Sized
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// Accepts a linear sequence of petnames and attempts to recursively

--- a/rust/noosphere-sphere/src/replication/stream.rs
+++ b/rust/noosphere-sphere/src/replication/stream.rs
@@ -264,7 +264,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let changes = vec![
@@ -343,7 +343,7 @@ mod tests {
     async fn it_can_stream_all_delta_blocks_for_a_range_of_history() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let changes = vec![
@@ -429,7 +429,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_some_sphere_content() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
         let mut db = sphere_context.sphere_context().await?.db_mut().clone();
 
@@ -485,7 +485,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version_as_a_car() -> Result<()> {
         initialize_tracing(None);
 
-        let mut sphere_context =
+        let (mut sphere_context, _) =
             simulated_sphere_context(SimulationAccess::ReadWrite, None).await?;
 
         let changes = vec![

--- a/rust/noosphere-sphere/src/replication/walk.rs
+++ b/rust/noosphere-sphere/src/replication/walk.rs
@@ -7,6 +7,7 @@ use noosphere_storage::BlockStore;
 use std::ops::Fn;
 use tokio_stream::StreamExt;
 
+/// Given a [VersionedMap], visit its changelog and all of its underlying entries
 pub async fn walk_versioned_map_elements<K, V, S>(
     versioned_map: VersionedMap<K, V, S>,
 ) -> Result<()>
@@ -22,6 +23,9 @@ where
     Ok(())
 }
 
+/// Given a [VersionedMap] and [BlockStore], visit the [VersionedMap]'s
+/// changelog and all of its underlying entries, invoking a callback for each
+/// entry
 pub async fn walk_versioned_map_elements_and<K, V, S, F, Fut>(
     versioned_map: VersionedMap<K, V, S>,
     store: S,
@@ -43,6 +47,9 @@ where
     Ok(())
 }
 
+/// Given a [VersionedMap] and [BlockStore], visit the [VersionedMap]'s
+/// changelog; then, invoke the provided callback with each entry associated
+/// with an 'add' operation in the changelog
 pub async fn walk_versioned_map_changes_and<K, V, S, F, Fut>(
     versioned_map: VersionedMap<K, V, S>,
     store: S,

--- a/rust/noosphere-sphere/src/sync/error.rs
+++ b/rust/noosphere-sphere/src/sync/error.rs
@@ -1,10 +1,14 @@
 use noosphere_api::data::PushError;
 use thiserror::Error;
 
+/// Different classes of error that may occur during synchronization with a
+/// gateway
 #[derive(Error, Debug)]
 pub enum SyncError {
+    /// The error was a conflict; this is possibly recoverable
     #[error("There was a conflict during sync")]
     Conflict,
+    /// The error was some other, non-specific error
     #[error("{0}")]
     Other(anyhow::Error),
 }

--- a/rust/noosphere-sphere/src/sync/strategy.rs
+++ b/rust/noosphere-sphere/src/sync/strategy.rs
@@ -9,7 +9,7 @@ use noosphere_core::{
 };
 use noosphere_storage::{KeyValueStore, SphereDb, Storage};
 use tokio_stream::StreamExt;
-use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
+use ucan::builder::UcanBuilder;
 
 use crate::{
     metadata::COUNTERPART, HasMutableSphereContext, SpherePetnameRead, SpherePetnameWrite,
@@ -33,43 +33,38 @@ type CounterpartHistory<S> = Vec<Result<(Link<MemoIpld>, Sphere<SphereDb<S>>)>>;
 /// on the counterpart sphere's reckoning of the authoritative lineage of the
 /// user's sphere. Finally, after the rebase, the reconciled local lineage is
 /// pushed to the gateway.
-pub struct GatewaySyncStrategy<C, K, S>
+pub struct GatewaySyncStrategy<C, S>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     has_context_type: PhantomData<C>,
-    key_type: PhantomData<K>,
     store_type: PhantomData<S>,
 }
 
-impl<C, K, S> Default for GatewaySyncStrategy<C, K, S>
+impl<C, S> Default for GatewaySyncStrategy<C, S>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     fn default() -> Self {
         Self {
             has_context_type: Default::default(),
-            key_type: Default::default(),
             store_type: Default::default(),
         }
     }
 }
 
-impl<C, K, S> GatewaySyncStrategy<C, K, S>
+impl<C, S> GatewaySyncStrategy<C, S>
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     /// Synchronize a local sphere's data with the data in a gateway, and rollback
     /// if there is an error.
     pub async fn sync(&self, context: &mut C) -> Result<Link<MemoIpld>, SyncError>
     where
-        C: HasMutableSphereContext<K, S>,
+        C: HasMutableSphereContext<S>,
     {
         let (local_sphere_version, counterpart_sphere_identity, counterpart_sphere_version) =
             self.handshake(context).await?;
@@ -344,7 +339,7 @@ where
         let authorization = context
             .author()
             .require_authorization()?
-            .resolve_ucan(context.db())
+            .as_ucan(context.db())
             .await?;
 
         let name_record = Jwt(UcanBuilder::default()

--- a/rust/noosphere-sphere/src/sync/write.rs
+++ b/rust/noosphere-sphere/src/sync/write.rs
@@ -2,17 +2,16 @@ use anyhow::Result;
 use async_trait::async_trait;
 use noosphere_core::data::{Link, MemoIpld};
 use noosphere_storage::Storage;
-use ucan::crypto::KeyMaterial;
 
 use crate::{HasMutableSphereContext, SyncError, SyncRecovery};
 
 use crate::GatewaySyncStrategy;
 
+/// Implementors of [SphereSync] are able to sychronize with a Noosphere gateway
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-pub trait SphereSync<K, S>
+pub trait SphereSync<S>
 where
-    K: KeyMaterial + Clone + 'static,
     S: Storage + 'static,
 {
     /// If a gateway URL has been configured, attempt to synchronize local
@@ -25,10 +24,9 @@ where
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<C, K, S> SphereSync<K, S> for C
+impl<C, S> SphereSync<S> for C
 where
-    C: HasMutableSphereContext<K, S>,
-    K: KeyMaterial + Clone + 'static,
+    C: HasMutableSphereContext<S>,
     S: Storage + 'static,
 {
     #[instrument(level = "debug", skip(self))]

--- a/rust/noosphere/src/ffi/authority.rs
+++ b/rust/noosphere/src/ffi/authority.rs
@@ -1,0 +1,335 @@
+use anyhow::anyhow;
+use cid::Cid;
+use noosphere_core::{
+    authority::Authorization,
+    data::{Did, Jwt, Link, Mnemonic},
+};
+use noosphere_sphere::{HasSphereContext, SphereAuthorityRead, SphereAuthorityWrite, SphereWalker};
+use safer_ffi::{char_p::InvalidNulTerminator, prelude::*};
+use std::ffi::c_void;
+
+use crate::{
+    error::NoosphereError,
+    ffi::{NsError, NsNoosphere, NsSphere},
+};
+
+#[ffi_export]
+/// @memberof ns_sphere_t
+///
+/// Authorize another key to manipulate this sphere, given a display name for
+/// the authorization and the DID of the key to be authorized.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///  3. An owned pointer to constant string (the authorization CID) if the call
+///     was successful, otherwise NULL
+pub fn ns_sphere_authority_authorize(
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
+    name: char_p::Ref<'_>,
+    did: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(
+        Option<repr_c::Box<c_void>>,
+        Option<repr_c::Box<NsError>>,
+        Option<char_p::Box>,
+    ),
+) {
+    let mut sphere = sphere.inner_mut().clone();
+    let name = name.to_string();
+    let did = Did(did.to_string());
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let authorization: char_p::Box = sphere
+                .authorize(&name, &did)
+                .await?
+                .to_string()
+                .try_into()?;
+
+            Ok(authorization) as Result<_, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(authorization) => {
+                async_runtime.spawn_blocking(move || callback(context, None, Some(authorization)))
+            }
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()), None)
+            }),
+        };
+    });
+}
+
+#[ffi_export]
+/// @memberof ns_sphere_t
+///
+/// Given the CID of a previously delegated authorization, revoke the
+/// authorization.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+pub fn ns_sphere_authority_authorization_revoke(
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
+    cid: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(Option<repr_c::Box<c_void>>, Option<repr_c::Box<NsError>>),
+) {
+    let mut sphere = sphere.inner_mut().clone();
+    let cid = cid.to_string();
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let authorization = Authorization::Cid(Cid::try_from(cid.as_str())?);
+
+            sphere.revoke_authorization(&authorization).await?;
+
+            Ok(()) as Result<_, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(_) => async_runtime.spawn_blocking(move || callback(context, None)),
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()))
+            }),
+        };
+    });
+}
+
+#[ffi_export]
+/// @memberof ns_sphere_t
+///
+/// List all of the authorizations. Authorizations are given as an array of
+/// base64-encoded CIDv1 strings. The name and/or authorized DID of each
+/// authorization can by looked up by futher calls to
+/// ns_sphere_authority_authorization_name and/or
+/// ns_sphere_authority_authorization_identity respectively.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///  3. An owned pointer to a slice_boxed_char_ptr_t
+pub fn ns_sphere_authority_authorizations_list(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(
+        Option<repr_c::Box<c_void>>,
+        Option<repr_c::Box<NsError>>,
+        c_slice::Box<char_p::Box>,
+    ),
+) {
+    let sphere = sphere.inner().clone();
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let authorizations = SphereWalker::from(&sphere).list_authorizations().await?;
+
+            let mut all_authorizations: Vec<char_p::Box> = Vec::new();
+
+            for authorization in authorizations.into_iter() {
+                all_authorizations.push(
+                    authorization
+                        .to_string()
+                        .try_into()
+                        .map_err(|error: InvalidNulTerminator<String>| anyhow!(error))?,
+                )
+            }
+
+            Ok(all_authorizations.into_boxed_slice().into())
+                as Result<c_slice::Box<char_p::Box>, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(authorizations) => {
+                async_runtime.spawn_blocking(move || callback(context, None, authorizations))
+            }
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(
+                    context,
+                    Some(NoosphereError::from(error).into()),
+                    Vec::new().into_boxed_slice().into(),
+                )
+            }),
+        };
+    });
+}
+
+/// @memberof ns_sphere_t
+///
+/// Get the name associated with the given authorization. The authorization
+/// should be provided as a base64-encoded CIDv1 string.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///  3. An owned pointer to constant string (the name of the authorization) if
+///     the call was successful, otherwise NULL
+pub fn ns_sphere_authority_authorization_name(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
+    authorization: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(
+        Option<repr_c::Box<c_void>>,
+        Option<repr_c::Box<NsError>>,
+        Option<char_p::Box>,
+    ),
+) {
+    let sphere = sphere.inner().clone();
+    let authorization = authorization.to_string();
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let link = Link::<Jwt>::from(Cid::try_from(authorization)?);
+
+            let name: char_p::Box = sphere
+                .to_sphere()
+                .await?
+                .get_authority()
+                .await?
+                .get_delegations()
+                .await?
+                .require(&link)
+                .await?
+                .name
+                .clone()
+                .try_into()?;
+
+            Ok(name) as Result<_, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(name) => async_runtime.spawn_blocking(move || callback(context, None, Some(name))),
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()), None)
+            }),
+        };
+    });
+}
+
+/// @memberof ns_sphere_t
+///
+/// Get the DID associated with the given authorization. The authorization should be
+/// provided as a base64-encoded CIDv1 string.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///  3. An owned pointer to constant string (the authorized DID) if the call
+///     was successful, otherwise NULL
+pub fn ns_sphere_authority_authorization_identity(
+    noosphere: &NsNoosphere,
+    sphere: &NsSphere,
+    authorization: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(
+        Option<repr_c::Box<c_void>>,
+        Option<repr_c::Box<NsError>>,
+        Option<char_p::Box>,
+    ),
+) {
+    let sphere = sphere.inner().clone();
+    let authorization = authorization.to_string();
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let link = Link::<Jwt>::from(Cid::try_from(authorization)?);
+
+            let ucan = Authorization::Cid(link.into())
+                .as_ucan(sphere.sphere_context().await?.db())
+                .await?;
+
+            let identity: char_p::Box = ucan.audience().to_string().try_into()?;
+
+            Ok(identity) as Result<_, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(identity) => {
+                async_runtime.spawn_blocking(move || callback(context, None, Some(identity)))
+            }
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()), None)
+            }),
+        };
+    });
+}
+
+#[ffi_export]
+/// @memberof ns_sphere_t
+///
+/// Given a sphere root credential recovery mnemonic, get back a ns_sphere_t
+/// with an escalated credential that allows signing changes as the sphere
+/// itself.
+///
+/// This function call will return an error if the mnemonic is invalid or if the
+/// credential it represents is not the sphere's key.
+///
+/// The callback arguments are (in order):
+///
+///  1. The context argument provided in the original call to
+///     ns_sphere_authority_authorize
+///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
+///  3. An owned pointer to an ns_sphere_t with the root sphere credential,
+///     otherwise NULL
+#[allow(clippy::type_complexity)]
+pub fn ns_sphere_authority_escalate(
+    noosphere: &NsNoosphere,
+    sphere: &mut NsSphere,
+    mnemonic: char_p::Ref<'_>,
+    context: Option<repr_c::Box<c_void>>,
+    callback: extern "C" fn(
+        Option<repr_c::Box<c_void>>,
+        Option<repr_c::Box<NsError>>,
+        Option<repr_c::Box<NsSphere>>,
+    ),
+) {
+    let sphere = sphere.inner().clone();
+    let mnemonic = Mnemonic(mnemonic.to_string());
+    let async_runtime = noosphere.async_runtime();
+
+    noosphere.async_runtime().spawn(async move {
+        let result = async {
+            let root_sphere_context = sphere.escalate_authority(&mnemonic).await?;
+
+            Ok(Box::new(NsSphere {
+                inner: root_sphere_context.into(),
+            })
+            .into()) as Result<repr_c::Box<NsSphere>, anyhow::Error>
+        }
+        .await;
+
+        match result {
+            Ok(sphere) => {
+                async_runtime.spawn_blocking(move || callback(context, None, Some(sphere)))
+            }
+            Err(error) => async_runtime.spawn_blocking(move || {
+                callback(context, Some(NoosphereError::from(error).into()), None)
+            }),
+        };
+    });
+}

--- a/rust/noosphere/src/ffi/authority.rs
+++ b/rust/noosphere/src/ffi/authority.rs
@@ -75,7 +75,7 @@ pub fn ns_sphere_authority_authorize(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_authority_authorize
+///     ns_sphere_authority_authorization_revoke
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 pub fn ns_sphere_authority_authorization_revoke(
     noosphere: &NsNoosphere,
@@ -119,7 +119,7 @@ pub fn ns_sphere_authority_authorization_revoke(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_authority_authorize
+///     ns_sphere_authority_authorizations_list
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to a slice_boxed_char_ptr_t
 pub fn ns_sphere_authority_authorizations_list(
@@ -178,7 +178,7 @@ pub fn ns_sphere_authority_authorizations_list(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_authority_authorize
+///     ns_sphere_authority_authorization_name
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to constant string (the name of the authorization) if
 ///     the call was successful, otherwise NULL
@@ -235,7 +235,7 @@ pub fn ns_sphere_authority_authorization_name(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_authority_authorize
+///     ns_sphere_authority_authorization_identity
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to constant string (the authorized DID) if the call
 ///     was successful, otherwise NULL
@@ -292,7 +292,7 @@ pub fn ns_sphere_authority_authorization_identity(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_authority_authorize
+///     ns_sphere_authority_escalate
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to an ns_sphere_t with the root sphere credential,
 ///     otherwise NULL

--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -99,33 +99,6 @@ pub fn ns_sphere_open(
 #[ffi_export]
 /// @memberof ns_sphere_t
 ///
-/// Initialize an ns_sphere_t instance.
-///
-pub fn ns_sphere_open_as_root(
-    noosphere: &NsNoosphere,
-    sphere_identity: char_p::Ref<'_>,
-    error_out: Option<Out<'_, repr_c::Box<NsError>>>,
-) -> Option<repr_c::Box<NsSphere>> {
-    error_out.try_or_initialize(|| {
-        let fs = noosphere.async_runtime().block_on(async {
-            let sphere_channel = noosphere
-                .inner()
-                .get_sphere_channel(&Did(sphere_identity.to_str().into()))
-                .await?;
-
-            Ok(Box::new(NsSphere {
-                inner: sphere_channel,
-            })
-            .into()) as Result<_, anyhow::Error>
-        })?;
-
-        Ok(fs)
-    })
-}
-
-#[ffi_export]
-/// @memberof ns_sphere_t
-///
 /// Deallocate an ns_sphere_t instance.
 pub fn ns_sphere_free(sphere: repr_c::Box<NsSphere>) {
     drop(sphere)

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,3 +1,4 @@
+mod authority;
 mod context;
 mod error;
 mod headers;
@@ -9,6 +10,7 @@ mod tracing;
 
 pub use crate::ffi::noosphere::*;
 pub use crate::ffi::tracing::*;
+pub use authority::*;
 pub use context::*;
 pub use error::*;
 pub use headers::*;

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -84,7 +84,7 @@ pub fn ns_sphere_petname_get(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_content_read
+///     ns_sphere_petnames_assigned_Get
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to a slice_boxed_char_ptr_t if the call was successful,
 ///     otherwise NULL
@@ -212,9 +212,7 @@ pub fn ns_sphere_petname_list(
 ) -> c_slice::Box<char_p::Box> {
     let possible_output = error_out.try_or_initialize(|| {
         noosphere.async_runtime().block_on(async {
-            let petname_set = SphereWalker::from(sphere.inner().clone())
-                .list_petnames()
-                .await?;
+            let petname_set = SphereWalker::from(sphere.inner()).list_petnames().await?;
             let mut all_petnames: Vec<char_p::Box> = Vec::new();
 
             for petname in petname_set.into_iter() {
@@ -270,7 +268,7 @@ pub fn ns_sphere_petname_changes(
                 None => None,
             };
 
-            let changed_petname_set = SphereWalker::from(sphere.inner().clone())
+            let changed_petname_set = SphereWalker::from(sphere.inner())
                 .petname_changes(since.as_ref())
                 .await?;
             let mut changed_petnames: Vec<char_p::Box> = Vec::new();

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -84,7 +84,7 @@ pub fn ns_sphere_petname_get(
 /// The callback arguments are (in order):
 ///
 ///  1. The context argument provided in the original call to
-///     ns_sphere_petnames_assigned_Get
+///     ns_sphere_petnames_assigned_get
 ///  2. An owned pointer to an ns_error_t if there was an error, otherwise NULL
 ///  3. An owned pointer to a slice_boxed_char_ptr_t if the call was successful,
 ///     otherwise NULL

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -154,17 +154,8 @@ use crate::sphere::SphereChannel;
 // NOTE: We may someday define the 3rd and 4th terms of this type differently on
 // web, where `Arc` and `Mutex` are currently overkill for our needs and may be
 // substituted for `Rc` and `RwLock`, respectively.
-pub type PlatformSphereContext = SphereCursor<
-    Arc<SphereContext<PlatformKeyMaterial, PlatformStorage>>,
-    PlatformKeyMaterial,
-    PlatformStorage,
->;
-pub type PlatformMutableSphereContext =
-    Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>;
+pub type PlatformSphereContext = SphereCursor<Arc<SphereContext<PlatformStorage>>, PlatformStorage>;
+pub type PlatformMutableSphereContext = Arc<Mutex<SphereContext<PlatformStorage>>>;
 
-pub type PlatformSphereChannel = SphereChannel<
-    PlatformKeyMaterial,
-    PlatformStorage,
-    PlatformSphereContext,
-    PlatformMutableSphereContext,
->;
+pub type PlatformSphereChannel =
+    SphereChannel<PlatformStorage, PlatformSphereContext, PlatformMutableSphereContext>;

--- a/rust/noosphere/src/wasm/file.rs
+++ b/rust/noosphere/src/wasm/file.rs
@@ -12,14 +12,11 @@ use js_sys::{Function, Promise, Uint8Array};
 use noosphere_sphere::{
     AsyncFileBody, HasSphereContext, SphereContext, SphereCursor, SphereFile as SphereFileImpl,
 };
-use tokio::{
-    io::{AsyncRead, AsyncReadExt},
-    sync::Mutex,
-};
+use tokio::{io::AsyncReadExt, sync::Mutex};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::platform::{PlatformKeyMaterial, PlatformStorage};
+use crate::platform::PlatformStorage;
 
 /// A `SphereFile` contains metadata about a file, and accessors that enable
 /// the user to defer reading the file's content until such time as it is
@@ -30,11 +27,7 @@ pub struct SphereFile {
     pub inner: SphereFileImpl<Pin<Box<dyn AsyncFileBody>>>,
 
     #[wasm_bindgen(skip)]
-    pub cursor: SphereCursor<
-        Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>,
-        PlatformKeyMaterial,
-        PlatformStorage,
-    >,
+    pub cursor: SphereCursor<Arc<Mutex<SphereContext<PlatformStorage>>>, PlatformStorage>,
 }
 
 #[wasm_bindgen]
@@ -132,14 +125,14 @@ impl SphereFile {
 /// A [JavaScriptTransform] is a [Transform] implementation that is suitable
 /// for converting sphere content using JavaScript and DOM-aware APIs.
 #[derive(Clone)]
-pub struct JavaScriptTransform<R: HasSphereContext<PlatformKeyMaterial, PlatformStorage>> {
+pub struct JavaScriptTransform<R: HasSphereContext<PlatformStorage>> {
     resolver: JavaScriptResolver,
-    transcluder: SphereContentTranscluder<R, PlatformKeyMaterial, PlatformStorage>,
+    transcluder: SphereContentTranscluder<R, PlatformStorage>,
 }
 
 impl<R> JavaScriptTransform<R>
 where
-    R: HasSphereContext<PlatformKeyMaterial, PlatformStorage>,
+    R: HasSphereContext<PlatformStorage>,
 {
     pub fn new(callback: Function, context: R) -> Self {
         JavaScriptTransform {
@@ -151,10 +144,10 @@ where
 
 impl<R> Transform for JavaScriptTransform<R>
 where
-    R: HasSphereContext<PlatformKeyMaterial, PlatformStorage>,
+    R: HasSphereContext<PlatformStorage>,
 {
     type Resolver = JavaScriptResolver;
-    type Transcluder = SphereContentTranscluder<R, PlatformKeyMaterial, PlatformStorage>;
+    type Transcluder = SphereContentTranscluder<R, PlatformStorage>;
 
     fn resolver(&self) -> &Self::Resolver {
         &self.resolver

--- a/rust/noosphere/src/wasm/fs.rs
+++ b/rust/noosphere/src/wasm/fs.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use crate::{
-    platform::{PlatformKeyMaterial, PlatformStorage},
-    wasm::SphereFile,
-};
+use crate::{platform::PlatformStorage, wasm::SphereFile};
 use js_sys::{Array, Function};
 use noosphere_sphere::{
     HasMutableSphereContext, SphereContentRead, SphereContentWrite, SphereContext, SphereCursor,
@@ -21,11 +18,7 @@ use wasm_bindgen::prelude::*;
 /// or raw bytes.
 pub struct SphereFs {
     #[wasm_bindgen(skip)]
-    pub inner: SphereCursor<
-        Arc<Mutex<SphereContext<PlatformKeyMaterial, PlatformStorage>>>,
-        PlatformKeyMaterial,
-        PlatformStorage,
-    >,
+    pub inner: SphereCursor<Arc<Mutex<SphereContext<PlatformStorage>>>, PlatformStorage>,
 }
 
 #[wasm_bindgen]
@@ -114,7 +107,7 @@ impl SphereFs {
     /// after the callback has been invoked once for each entry in the sphere's
     /// namespace.
     pub async fn stream(&self, callback: Function) -> Result<(), String> {
-        let stream = SphereWalker::from(self.inner.clone()).into_content_stream();
+        let stream = SphereWalker::from(&self.inner).into_content_stream();
         let this = JsValue::null();
 
         tokio::pin!(stream);

--- a/swift/Sources/SwiftNoosphere/Noosphere.swift
+++ b/swift/Sources/SwiftNoosphere/Noosphere.swift
@@ -109,3 +109,60 @@ public func nsSphereSync(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, 
         handler.contents(error, new_version)
     }
 }
+
+public typealias NsSphereAuthorityEscalateHandler = (OpaquePointer?, OpaquePointer?) -> ()
+
+/// See: ns_sphere_authority_escalate
+public func nsSphereAuthorityEscalate(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, _ mnemonic: UnsafePointer<CChar>!, handler: @escaping NsSphereAuthorityEscalateHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_authority_escalate(noosphere, sphere, mnemonic, context) {
+        (context, error, escalated_sphere) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereAuthorityEscalateHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error, escalated_sphere)
+    }
+}
+
+public typealias NsSphereAuthorityAuthorizeHandler = (OpaquePointer?, UnsafeMutablePointer<CChar>?) -> ()
+
+/// See: ns_sphere_authority_authorize
+public func nsSphereAuthorityAuthorize(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, _ name: UnsafePointer<CChar>!, _ did: UnsafePointer<CChar>!, handler: @escaping NsSphereAuthorityAuthorizeHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_authority_authorize(noosphere, sphere, name, did, context) {
+        (context, error, authorization) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereAuthorityAuthorizeHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error, authorization)
+    }
+}
+
+public typealias NsSphereAuthorityAuthorizationRevokeHandler = (OpaquePointer?) -> ()
+
+/// See: ns_sphere_authority_authorization_revoke
+public func nsSphereAuthorityAuthorizationRevoke(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, _ authorization: UnsafePointer<CChar>!, handler: @escaping NsSphereAuthorityAuthorizationRevokeHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_authority_authorization_revoke(noosphere, sphere, authorization, context) {
+        (context, error) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereAuthorityAuthorizationRevokeHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error)
+    }
+}


### PR DESCRIPTION
This change proposes high-level APIs to authorize keys and revoke authorizations for both SphereContext wrappers and the C FFI. In addition to the proposed APIs, a bunch of docs have been backfilled.

A provisional implementation of sphere "recovery" has also been introduced here. This recovery mechanism is intended for the case when the user loses an authorized credential (due to theft or otherwise) and wishes to complete reset all authorizations via their recovery mnemonic. However, given the provisional nature of this implementation, no C FFI is provided for this functionality at this time.

Fixes https://github.com/subconsciousnetwork/noosphere/issues/325
Fixes #307 