### PR TITLE
Bump noosphere-core

### DIFF
--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noosphere-core"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "Core data types of the Rust Noosphere implementation"
 keywords = ["hamt", "ipld", "noosphere", "p2p", "async"]


### PR DESCRIPTION
This way, we can depend on the sentry changes elsewhere.