### PR TITLE
feat: Update to rs-ucan 0.4.0, implementing Ucan 0.10ish.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,7 +2780,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e2d584751cecb2aabaa56106be6be91338a60a0f4e420cf2af639204f596fc1"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "ed25519-dalek",
  "log",
  "multiaddr",
@@ -3584,7 +3593,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "strum",
- "strum_macros",
+ "strum_macros 0.24.3",
  "tiny-bip39",
  "tokio",
  "tokio-stream",
@@ -3621,7 +3630,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
+ "strum_macros 0.24.3",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3961,7 +3970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
 dependencies = [
  "arrayref",
- "bs58",
+ "bs58 0.4.0",
  "byteorder",
  "data-encoding",
  "multihash 0.13.2",
@@ -4114,14 +4123,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
+ "der 0.7.6",
+ "pkcs8 0.10.2",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -4614,20 +4622,22 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
 dependencies = [
  "byteorder",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.9.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature 2.1.0",
+ "spki 0.7.2",
  "subtle",
  "zeroize",
 ]
@@ -5241,6 +5251,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "stun"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5778,15 +5801,15 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucan"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d1efb030f1b24acd7f6a84ef7346d4b6f390000c5304f1d4db11428b9ac5bb"
+checksum = "b3722c8cba706d28123758300ca0738852b5132b37a7c656f59b9484ac8f2435"
 dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
  "base64 0.21.0",
- "bs58",
+ "bs58 0.5.0",
  "cid 0.10.1",
  "futures",
  "getrandom 0.2.9",
@@ -5798,20 +5821,20 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
+ "strum_macros 0.25.0",
  "unsigned-varint 0.7.1",
  "url",
 ]
 
 [[package]]
 name = "ucan-key-support"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c8af03a21853cc6e1edf43a28aa2d6712b5d1692c75777896cd9bf09d56d9c"
+checksum = "204146152a164519150c4e9c27f9a728c04d50b7f8a4668c33e5f84d2e536226"
 dependencies = [
  "anyhow",
  "async-trait",
- "bs58",
+ "bs58 0.5.0",
  "ed25519-zebra",
  "js-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "~0.3.16", features = ["env-filter", "tracing-log"] }
 thiserror = { version = "1" }
 gloo-timers = { version = "0.2", features = ["futures"] }
-ucan = { version = "0.3.2" }
-ucan-key-support = { version = "0.1.6" }
+ucan = { version = "0.4.0" }
+ucan-key-support = { version = "0.1.7" }
 libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }

--- a/c/example/main.c
+++ b/c/example/main.c
@@ -95,6 +95,7 @@ void test_errors() {
   assert(error_message != NULL);
   assert(ns_error_code_get(error) == NS_ERROR_CODE_OTHER);
 
+  ns_error_free(error);
   ns_string_free(error_message);
   ns_free(noosphere);
 }

--- a/rust/noosphere-api/src/data.rs
+++ b/rust/noosphere-api/src/data.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, str::FromStr};
 use anyhow::{anyhow, Result};
 use cid::Cid;
 use noosphere_core::{
-    authority::{SphereAction, SphereReference, SPHERE_SEMANTICS},
+    authority::{generate_capability, SphereAbility, SPHERE_SEMANTICS},
     data::{Bundle, Did, Jwt, Link, MemoIpld},
 };
 use noosphere_storage::{base64_decode, base64_encode};
@@ -11,7 +11,6 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 use ucan::{
-    capability::{Capability, Resource, With},
     chain::ProofChain,
     crypto::{did::DidParser, KeyMaterial},
     store::UcanStore,
@@ -227,15 +226,7 @@ impl IdentifyResponse {
             return Err(anyhow!("Wrong audience!"));
         }
 
-        let capability = Capability {
-            with: With::Resource {
-                kind: Resource::Scoped(SphereReference {
-                    did: self.sphere_identity.to_string(),
-                }),
-            },
-            can: SphereAction::Push,
-        };
-
+        let capability = generate_capability(&self.sphere_identity, SphereAbility::Push);
         let capability_infos = proof.reduce_capabilities(&SPHERE_SEMANTICS);
 
         for capability_info in capability_infos {

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "^1"
 fastcdc = "3"
 futures = "~0.3"
 serde = { workspace = true }
+serde_json = { workspace = true }
 byteorder = "^1.4"
 base64 = "0.21"
 ed25519-zebra = "^3"
@@ -58,7 +59,6 @@ sentry-tracing = { workspace = true, optional = true }
 [dev-dependencies]
 wasm-bindgen-test = { workspace = true }
 serde_bytes = "~0.11"
-serde_json = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "^1", features = ["full"] }

--- a/rust/noosphere-core/src/authority/author.rs
+++ b/rust/noosphere-core/src/authority/author.rs
@@ -1,18 +1,18 @@
 use crate::{
     authority::{
-        generate_ed25519_key, Authorization, SphereAction, SphereReference, SPHERE_SEMANTICS,
-        SUPPORTED_KEYS,
+        generate_ed25519_key, Authorization, SphereAbility, SPHERE_SEMANTICS, SUPPORTED_KEYS,
     },
     data::Did,
 };
 use anyhow::{anyhow, Result};
 use noosphere_storage::{SphereDb, Storage};
 use ucan::{
-    capability::{Capability, Resource, With},
     chain::ProofChain,
     crypto::{did::DidParser, KeyMaterial},
 };
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
+
+use super::generate_capability;
 
 /// The level of access that a given user has to a related resource. Broadly,
 /// a user will always have either read/write access (to their own sphere) or
@@ -79,14 +79,7 @@ where
                 return Ok(Access::ReadOnly);
             }
 
-            let read_write_capability = Capability {
-                with: With::Resource {
-                    kind: Resource::Scoped(SphereReference {
-                        did: sphere_identity.to_string(),
-                    }),
-                },
-                can: SphereAction::Push,
-            };
+            let read_write_capability = generate_capability(sphere_identity, SphereAbility::Push);
             let mut did_parser = DidParser::new(SUPPORTED_KEYS);
             let proof_chain = ProofChain::from_ucan(ucan, None, &mut did_parser, db).await?;
 

--- a/rust/noosphere-core/src/data/sphere.rs
+++ b/rust/noosphere-core/src/data/sphere.rs
@@ -60,18 +60,13 @@ mod tests {
     use anyhow::Result;
     use ed25519_zebra::{SigningKey as Ed25519PrivateKey, VerificationKey as Ed25519PublicKey};
     use libipld_cbor::DagCborCodec;
-    use ucan::{
-        builder::UcanBuilder,
-        capability::{Capability, Resource, With},
-        crypto::KeyMaterial,
-        store::UcanJwtStore,
-    };
+    use ucan::{builder::UcanBuilder, crypto::KeyMaterial, store::UcanJwtStore};
     use ucan_key_support::ed25519::Ed25519KeyMaterial;
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use crate::{
-        authority::{SphereAction, SphereReference},
+        authority::{generate_capability, SphereAbility},
         data::{ContentType, Did, Header, MemoIpld, SphereIpld},
         view::Sphere,
     };
@@ -105,14 +100,7 @@ mod tests {
             body: sphere_cid,
         };
 
-        let capability: Capability<SphereReference, SphereAction> = Capability {
-            with: With::Resource {
-                kind: Resource::Scoped(SphereReference {
-                    did: identity.to_string(),
-                }),
-            },
-            can: SphereAction::Authorize,
-        };
+        let capability = generate_capability(&identity, SphereAbility::Authorize);
 
         let authorization = UcanBuilder::default()
             .issued_by(&identity_credential)
@@ -161,15 +149,7 @@ mod tests {
             body: sphere_cid,
         };
 
-        let capability: Capability<SphereReference, SphereAction> = Capability {
-            with: With::Resource {
-                kind: Resource::Scoped(SphereReference {
-                    did: identity.to_string(),
-                }),
-            },
-            can: SphereAction::Authorize,
-        };
-
+        let capability = generate_capability(&identity, SphereAbility::Authorize);
         let authorization = UcanBuilder::default()
             .issued_by(&identity_credential)
             .for_audience(&authorized)

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -3,7 +3,7 @@ use libipld_cbor::DagCborCodec;
 use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
 
 use crate::{
-    authority::{generate_capability, Authorization, SphereAction},
+    authority::{generate_capability, Authorization, SphereAbility},
     data::{
         ChangelogIpld, DelegationIpld, Did, IdentityIpld, Jwt, Link, MapOperation, MemoIpld,
         RevocationIpld, VersionedMapKey, VersionedMapValue,
@@ -49,10 +49,10 @@ impl<S: BlockStore> SphereRevision<S> {
                         .issued_by(credential)
                         .for_audience(&self.sphere_identity)
                         .with_lifetime(120)
-                        .witnessed_by(&witness_ucan)
+                        .witnessed_by(&witness_ucan, None)
                         .claiming_capability(&generate_capability(
                             &self.sphere_identity,
-                            SphereAction::Publish,
+                            SphereAbility::Publish,
                         ))
                         .with_nonce()
                         .build()?

--- a/rust/noosphere-gateway/src/authority.rs
+++ b/rust/noosphere-gateway/src/authority.rs
@@ -9,12 +9,14 @@ use axum::{
     TypedHeader,
 };
 use libipld_core::cid::Cid;
-use noosphere_core::authority::{SphereAction, SphereReference, SPHERE_SEMANTICS};
+use noosphere_core::authority::{SphereAbility, SphereReference, SPHERE_SEMANTICS};
 use noosphere_sphere::SphereContext;
 use noosphere_storage::NativeStorage;
 
 use tokio::sync::Mutex;
-use ucan::{capability::Capability, chain::ProofChain, crypto::KeyMaterial, store::UcanJwtStore};
+use ucan::{
+    capability::CapabilityView, chain::ProofChain, crypto::KeyMaterial, store::UcanJwtStore,
+};
 
 use super::GatewayScope;
 
@@ -38,7 +40,7 @@ where
 {
     pub fn try_authorize(
         &self,
-        capability: &Capability<SphereReference, SphereAction>,
+        capability: &CapabilityView<SphereReference, SphereAbility>,
     ) -> Result<(), StatusCode> {
         let capability_infos = self.proof.reduce_capabilities(&SPHERE_SEMANTICS);
 

--- a/rust/noosphere-gateway/src/route/identify.rs
+++ b/rust/noosphere-gateway/src/route/identify.rs
@@ -1,7 +1,7 @@
 use crate::{authority::GatewayAuthority, GatewayScope};
 use axum::{http::StatusCode, response::IntoResponse, Extension, Json};
 use noosphere_api::data::IdentifyResponse;
-use noosphere_core::authority::{generate_capability, SphereAction};
+use noosphere_core::authority::{generate_capability, SphereAbility};
 use noosphere_sphere::HasSphereContext;
 use noosphere_storage::Storage;
 use ucan::crypto::KeyMaterial;
@@ -20,7 +20,7 @@ where
 
     authority.try_authorize(&generate_capability(
         &scope.counterpart,
-        SphereAction::Fetch,
+        SphereAbility::Fetch,
     ))?;
 
     let sphere_context = sphere_context

--- a/rust/noosphere-gateway/src/route/push.rs
+++ b/rust/noosphere-gateway/src/route/push.rs
@@ -6,7 +6,7 @@ use axum::{http::StatusCode, Extension};
 
 use noosphere_api::data::{PushBody, PushError, PushResponse};
 use noosphere_core::{
-    authority::{SphereAction, SphereReference},
+    authority::{generate_capability, SphereAbility},
     data::{Bundle, Link, LinkRecord, MapOperation, MemoIpld},
     view::Sphere,
 };
@@ -14,7 +14,6 @@ use noosphere_sphere::{HasMutableSphereContext, SphereContentWrite, SphereCursor
 use noosphere_storage::Storage;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::StreamExt;
-use ucan::capability::{Capability, Resource, With};
 use ucan::crypto::KeyMaterial;
 
 use crate::{
@@ -57,14 +56,10 @@ where
         return Err(StatusCode::FORBIDDEN);
     }
 
-    authority.try_authorize(&Capability {
-        with: With::Resource {
-            kind: Resource::Scoped(SphereReference {
-                did: gateway_scope.counterpart.to_string(),
-            }),
-        },
-        can: SphereAction::Push,
-    })?;
+    authority.try_authorize(&generate_capability(
+        &gateway_scope.counterpart,
+        SphereAbility::Push,
+    ))?;
 
     let gateway_push_routine = GatewayPushRoutine {
         sphere_context,

--- a/rust/noosphere-gateway/src/route/replicate.rs
+++ b/rust/noosphere-gateway/src/route/replicate.rs
@@ -12,7 +12,7 @@ use cid::Cid;
 use libipld_cbor::DagCborCodec;
 use noosphere_api::data::ReplicateParameters;
 use noosphere_core::{
-    authority::{generate_capability, SphereAction},
+    authority::{generate_capability, SphereAbility},
     data::{ContentType, MemoIpld},
 };
 use noosphere_ipfs::{IpfsStore, KuboClient};
@@ -58,7 +58,7 @@ where
 
     authority.try_authorize(&generate_capability(
         &scope.counterpart,
-        SphereAction::Fetch,
+        SphereAbility::Fetch,
     ))?;
 
     let db = sphere_context
@@ -167,7 +167,7 @@ mod tests {
     use anyhow::Result;
     use noosphere_core::{
         authority::{
-            generate_capability, generate_ed25519_key, Author, Authorization, SphereAction,
+            generate_capability, generate_ed25519_key, Author, Authorization, SphereAbility,
         },
         data::{DelegationIpld, RevocationIpld},
     };
@@ -288,9 +288,9 @@ mod tests {
             .for_audience(&to_be_revoked_did)
             .claiming_capability(&generate_capability(
                 &sphere_context.identity().await?,
-                SphereAction::Publish,
+                SphereAbility::Publish,
             ))
-            .witnessed_by(&author_ucan)
+            .witnessed_by(&author_ucan, None)
             .with_lifetime(6000)
             .with_nonce()
             .build()?

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -499,10 +499,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use noosphere_core::authority::{generate_capability, SphereAction};
+    use noosphere_core::{
+        authority::{generate_capability, SphereAbility},
+        data::LINK_RECORD_FACT_NAME,
+    };
     use noosphere_ns::helpers::KeyValueNameResolver;
     use noosphere_sphere::helpers::{simulated_sphere_context, SimulationAccess};
-    use serde_json::json;
     use ucan::builder::UcanBuilder;
 
     use super::*;
@@ -517,10 +519,11 @@ mod tests {
             UcanBuilder::default()
                 .issued_by(&context.author().key)
                 .for_audience(identity)
-                .claiming_capability(&generate_capability(identity, SphereAction::Publish))
+                .claiming_capability(&generate_capability(identity, SphereAbility::Publish))
                 .with_lifetime(1000)
                 .with_fact(
-                    json!({ "link": "bafyr4iagi6t6khdrtbhmyjpjgvdlwv6pzylxhuhstxhkdp52rju7er325i" }),
+                    LINK_RECORD_FACT_NAME,
+                    "bafyr4iagi6t6khdrtbhmyjpjgvdlwv6pzylxhuhstxhkdp52rju7er325i".to_owned(),
                 )
                 .build()
                 .unwrap()
@@ -536,10 +539,11 @@ mod tests {
             UcanBuilder::default()
                 .issued_by(&context.author().key)
                 .for_audience(identity)
-                .claiming_capability(&generate_capability(identity, SphereAction::Publish))
+                .claiming_capability(&generate_capability(identity, SphereAbility::Publish))
                 .with_expiration(ucan::time::now() - 1000)
                 .with_fact(
-                    json!({ "link": "bafyr4iagi6t6khdrtbhmyjpjgvdlwv6pzylxhuhstxhkdp52rju7er325i" }),
+                    LINK_RECORD_FACT_NAME,
+                    "bafyr4iagi6t6khdrtbhmyjpjgvdlwv6pzylxhuhstxhkdp52rju7er325i".to_owned(),
                 )
                 .build()
                 .unwrap()

--- a/rust/noosphere-ns/src/bin/orb-ns/cli/mod.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/cli/mod.rs
@@ -12,12 +12,11 @@ mod test {
     use anyhow::Result;
     use cid::Cid;
     use noosphere::key::{InsecureKeyStorage, KeyStorage};
-    use noosphere_core::authority::{generate_capability, SphereAction};
-    use noosphere_core::data::{Did, LinkRecord};
+    use noosphere_core::authority::{generate_capability, SphereAbility};
+    use noosphere_core::data::{Did, LinkRecord, LINK_RECORD_FACT_NAME};
     use noosphere_core::view::SPHERE_LIFETIME;
     use noosphere_ns::{Multiaddr, PeerId};
     use serde::Deserialize;
-    use serde_json::json;
     use tokio;
     use tokio::sync::oneshot;
     use ucan::builder::UcanBuilder;
@@ -126,8 +125,8 @@ mod test {
         let ucan = UcanBuilder::default()
             .issued_by(&key_b)
             .for_audience(&id_b)
-            .claiming_capability(&generate_capability(&id_b, SphereAction::Publish))
-            .with_fact(json!({ "link": cid_link.to_string() }))
+            .claiming_capability(&generate_capability(&id_b, SphereAbility::Publish))
+            .with_fact(LINK_RECORD_FACT_NAME, cid_link.to_string())
             .with_lifetime(SPHERE_LIFETIME)
             .build()?
             .sign()

--- a/rust/noosphere-ns/src/dht_client.rs
+++ b/rust/noosphere-ns/src/dht_client.rs
@@ -97,13 +97,12 @@ pub mod test {
     use cid::Cid;
     use libp2p::multiaddr::Protocol;
     use noosphere_core::{
-        authority::{generate_capability, generate_ed25519_key, SphereAction},
-        data::Did,
+        authority::{generate_capability, generate_ed25519_key, SphereAbility},
+        data::{Did, LINK_RECORD_FACT_NAME},
         tracing::initialize_tracing,
         view::SPHERE_LIFETIME,
     };
     use noosphere_storage::{MemoryStorage, SphereDb};
-    use serde_json::json;
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
@@ -179,9 +178,9 @@ pub mod test {
             .for_audience(&sphere_identity)
             .claiming_capability(&generate_capability(
                 &sphere_identity,
-                SphereAction::Publish,
+                SphereAbility::Publish,
             ))
-            .with_fact(json!({ "link": link.to_string() }))
+            .with_fact(LINK_RECORD_FACT_NAME, link.to_string())
             .with_lifetime(SPHERE_LIFETIME)
             .build()?
             .sign()

--- a/rust/noosphere-ns/src/name_resolver.rs
+++ b/rust/noosphere-ns/src/name_resolver.rs
@@ -43,12 +43,11 @@ pub mod test {
     use super::*;
     use cid::Cid;
     use noosphere_core::{
-        authority::{generate_capability, generate_ed25519_key, SphereAction},
-        data::Did,
+        authority::{generate_capability, generate_ed25519_key, SphereAbility},
+        data::{Did, LINK_RECORD_FACT_NAME},
         tracing::initialize_tracing,
         view::SPHERE_LIFETIME,
     };
-    use serde_json::json;
     use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
 
     pub async fn test_name_resolver_simple<N: NameResolver>(resolver: N) -> Result<()> {
@@ -63,9 +62,9 @@ pub mod test {
             .for_audience(&sphere_identity)
             .claiming_capability(&generate_capability(
                 &sphere_identity,
-                SphereAction::Publish,
+                SphereAbility::Publish,
             ))
-            .with_fact(json!({ "link": link.to_string() }))
+            .with_fact(LINK_RECORD_FACT_NAME, link.to_string())
             .with_lifetime(SPHERE_LIFETIME)
             .build()?
             .sign()

--- a/rust/noosphere-sphere/src/context.rs
+++ b/rust/noosphere-sphere/src/context.rs
@@ -237,8 +237,8 @@ mod tests {
     use anyhow::Result;
 
     use noosphere_core::{
-        authority::{generate_capability, SphereAction},
-        data::{ContentType, LinkRecord},
+        authority::{generate_capability, SphereAbility},
+        data::{ContentType, LinkRecord, LINK_RECORD_FACT_NAME},
         tracing::initialize_tracing,
     };
 
@@ -250,7 +250,6 @@ mod tests {
         helpers::{make_valid_link_record, simulated_sphere_context, SimulationAccess},
         HasMutableSphereContext, HasSphereContext, SphereContentWrite, SpherePetnameWrite,
     };
-    use serde_json::json;
 
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -344,15 +343,14 @@ mod tests {
                             .unwrap()
                             .resolve_ucan(&db)
                             .await?,
+                        None,
                     )
                     .claiming_capability(&generate_capability(
                         &sphere_identity,
-                        SphereAction::Publish,
+                        SphereAbility::Publish,
                     ))
                     .with_lifetime(120)
-                    .with_fact(json!({
-                    "link": version.to_string()
-                    }))
+                    .with_fact(LINK_RECORD_FACT_NAME, version.to_string())
                     .build()?
                     .sign()
                     .await?,


### PR DESCRIPTION
Building off of https://github.com/ucan-wg/rs-ucan/pull/105, temporarily targeting the GitHub branch.

Changes:
* Provide `None` hasher to `witnessed_by`
* Expiration can now be empty, handle
* Use `generate_capability()` where appropriate
* Facts are now always maps, key the link value under `LINK_RECORD_FACT_NAME` as `"link"` -- open to suggestions here, probably should be less generic than "link", though not completely noosphere-specific as these could be shared outside the nooverse

Rename: 
* `Capability` => `CapabilityView`
* `With` => `Resource`
* `Action` => `Ability`
* `Resource` => `ResourceUri`
* `SphereAction` => `SphereAbility`
