### PR TITLE
chore: additionally publish images to ghcr.io

### DIFF
--- a/.github/workflows/container_images.yaml
+++ b/.github/workflows/container_images.yaml
@@ -125,3 +125,19 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           tags: 'us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/subconscious/${{ matrix.image.name }}:${{matrix.tag}}'
+
+      - name: 'Log Docker in to GitHub Container Registry'
+        uses: 'docker/login-action@v2.1.0'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push container images
+        uses: docker/build-push-action@v4
+        with:
+          file: ${{ matrix.image.file }}
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: 'ghcr.io/${{ env.REPO_OWNER }}/${{ matrix.image.name }}:${{matrix.tag}}'


### PR DESCRIPTION
This should allow folks to use the images as well, and doesn't require us to have a magic google project id we have to remember.