### PR TITLE
chore: fix header generation on macos

### DIFF
--- a/.github/workflows/noosphere_apple_build.yaml
+++ b/.github/workflows/noosphere_apple_build.yaml
@@ -96,13 +96,11 @@ jobs:
           brew: protobuf cmake
       - name: 'Generate the header'
         run: |
-          cd rust/noosphere/include/noosphere
-          cargo run --example generate_header --features headers --locked
-          cd -
+          ./scripts/generate-headers.sh
       - uses: actions/upload-artifact@v3
         with:
           name: include
-          path: rust/noosphere/include
+          path: target/headers/include
 
   # Generate Apple "universal" libraries for Noosphere for supported targets
   noosphere-apple-lipo:

--- a/c/example/Makefile
+++ b/c/example/Makefile
@@ -1,13 +1,22 @@
+UNAME := $(shell uname)
 LIBNOOSPHERE := ../../target/debug/deps/libnoosphere.a
+HEADER := ../../target/headers/include/noosphere/noosphere.h
+INCLUDE_PATH := ../../target/headers/include/noosphere
 
-noosphere.h:
-	cargo run -p noosphere --example generate_header --features headers
+ifeq ($(UNAME), Darwin)
+	LINKER_FLAGS := -framework Security
+else
+	LINKER_FLAGS :=
+endif
+
+$(HEADER):
+	../../scripts/generate-headers.sh
 $(LIBNOOSPHERE):
 	cargo build -p noosphere
-main.o: noosphere.h	
-	$(CC) -c main.c
+main.o: $(HEADER)
+	$(CC) -I$(INCLUDE_PATH) -c main.c
 main.out: main.o $(LIBNOOSPHERE)
-	$(CC) main.o $(LIBNOOSPHERE) -lm -o main.out
+	$(CC) main.o $(LINKER_FLAGS) $(LIBNOOSPHERE) -I$(INCLUDE_PATH) -lm -o main.out
 
 .PHONY: build run clean
 
@@ -16,4 +25,4 @@ build: main.out
 run: main.out
 	./main.out
 clean:
-	rm -rf noosphere.h main.o main.out
+	rm -rf $(HEADER) main.o main.out

--- a/scripts/build-framework.sh
+++ b/scripts/build-framework.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_DIR="$SCRIPT_DIR/../"
+cd $PROJECT_DIR
+
+OUT=""
+LITE=0
+RELEASE_FLAG=""
+PROFILE="debug"
+
+function usage() {
+  echo "build-framework.sh: a utility to build an Apple XCFramework for Noosphere."
+  echo "" 
+  echo "Usage:" 
+  echo "  build-framework.sh [options]" 
+  echo ""
+  echo "Options:"
+  echo "  -l --lite                  Only include x86_64-apple-darwin in framework."
+  echo "  -o <file>, --output <file> Output file."
+  echo "                             [default: \$ROOT/target/framework/{release,debug}/LibNoosphere.xcframework]"
+  echo "  --release                  Build artifacts in release-mode."
+  echo "  -h --help                  Show usage."
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -o|--output)
+      OUT="$2"
+      shift
+      shift
+      ;;
+    -l|--lite)
+      LITE=1
+      shift
+      ;;
+    --release)
+      RELEASE_FLAG="--release"
+      PROFILE="release"
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -n ${OUT} ]]; then
+  OUT="$PROJECT_DIR/target/framework/$PROFILE/LibNoosphere.xcframework"
+fi
+
+rm -rf "$OUT"
+
+$SCRIPT_DIR/generate-headers.sh
+
+TARGETS=("x86_64-apple-darwin")
+if [[ $LITE -eq 0 ]]; then
+  TARGETS+=("aarch64-apple-ios")
+  TARGETS+=("x86_64-apple-ios")
+  TARGETS+=("aarch64-apple-ios-sim")
+  TARGETS+=("aarch64-apple-darwin")
+fi
+
+for TARGET in "${TARGETS[@]}"; do
+  rustup target install $TARGET
+  cargo build --package noosphere $RELEASE_FLAG --target $TARGET --locked
+done
+
+if [[ $LITE -eq 0 ]]; then
+  mkdir -p ./target/{macos-universal,simulator-universal}
+
+  lipo -create \
+    "./target/x86_64-apple-darwin/$PROFILE/libnoosphere.a" \
+    "./target/aarch64-apple-darwin/$PROFILE/libnoosphere.a" \
+    -output "./target/macos-universal/$PROFILE/libnoosphere.a"
+
+  lipo -create \
+    "./target/x86_64-apple-ios/$PROFILE/libnoosphere.a" \
+    "./target/aarch64-apple-ios-sim/$PROFILE/libnoosphere.a" \
+    -output "./target/simulator-universal/$PROFILE/libnoosphere.a"
+
+  xcodebuild -create-xcframework \
+    -library "./target/macos-universal/$PROFILE/libnoosphere.a" \
+    -headers ./target/headers/include/ \
+    -library "./target/simulator-universal/$PROFILE/libnoosphere.a" \
+    -headers ./target/headers/include/ \
+    -library "./target/aarch64-apple-ios/$PROFILE/libnoosphere.a" \
+    -headers ./target/headers/include/ \
+    -output "$OUT"
+else
+  xcodebuild -create-xcframework \
+    -library "./target/x86_64-apple-darwin/$PROFILE/libnoosphere.a" \
+    -headers ./target/headers/include/ \
+    -output "$OUT"
+fi

--- a/scripts/generate-headers.sh
+++ b/scripts/generate-headers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PROJECT_DIR="$SCRIPT_DIR/../"
+cd $PROJECT_DIR
+
+DEFAULT_OUT="$PROJECT_DIR/target/headers"
+OUT="$DEFAULT_OUT"
+
+function usage() {
+  echo "generate-headers.sh: a utility to generate Noosphere's headers."
+  echo "" 
+  echo "Usage:" 
+  echo "  generate-headers.sh [options]" 
+  echo ""
+  echo "Options:"
+  echo "  -o <file>, --output <file> Output directory."
+  echo "                             [default: \$ROOT/target/headers]"
+  echo "  -h --help                  Show usage."
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -o|--output)
+      OUT="$2"
+      shift
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -f "$OUT" ]]; then
+  echo "Output directory must be non-existant or a directory: $OUT"
+  exit 1
+fi
+
+mkdir -p "$OUT"
+cp -r ./rust/noosphere/include "$OUT"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macos linker fails to generate all exports without this flag
+  # https://github.com/subconsciousnetwork/noosphere/issues/473
+  CARGO_PROFILE_DEV_CODEGEN_UNITS=1 cargo run --verbose --package noosphere --example generate_header --features headers --locked
+else
+  cargo run --verbose --package noosphere --example generate_header --features headers --locked
+fi
+
+mv ./noosphere.h "$OUT/include/noosphere/noosphere.h"

--- a/scripts/swift-test.sh
+++ b/scripts/swift-test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+PROJECT_DIR="$SCRIPT_DIR/../"
+cd $PROJECT_DIR
+
+PLACEHOLDER=./_Package.swift
+PROFILE="debug"
+SANITIZE=""
+
+function usage() {
+  echo "swift-test.sh: a utility to run the Swift Noosphere module tests locally."
+  echo "" 
+  echo "Usage:" 
+  echo "  swift-test.sh [options]" 
+  echo ""
+  echo "Options:"
+  echo "  --release                   Use release build."
+  echo "  --sanitize {address,thread} Test with a sanitizer."
+  echo "  -h --help                   Show usage."
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --sanitize)
+      SANITIZE="$2"
+      shift
+      shift
+      ;;
+    --release)
+      PROFILE="release"
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+trap "mv $PLACEHOLDER Package.swift" EXIT
+
+cp Package.swift $PLACEHOLDER
+
+FRAMEWORK_PATH="./target/framework/$PROFILE/LibNoosphere.xcframework"
+sed -i '' -e "s#url: \"[^\"]*\",#path: \"$FRAMEWORK_PATH\"),#" ./Package.swift
+sed -i '' -e "s#checksum: \"[^\"]*\"),##" ./Package.swift
+
+# Enable malloc debugging features
+# https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/MallocDebug.html
+if [[ ! -n ${SANITIZE} ]]; then
+  swift test -c $PROFILE
+else
+  MallocPreScribble=1 MallocScribble=1 swift test -c $PROFILE --sanitize=$SANITIZE
+fi
+exit $?


### PR DESCRIPTION
Provide a script to generate headers that uses codegen_units=1 when building on macos to circumvent a header generation issue. Update CI and C makefile to use this script. Fixes #473.
Also fixes a linker issue on macos for the C example. Fixes #476.