### PR TITLE
chore: Replace noosphere-car with iroh-car throughout the noosphere crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "iroh-car"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a291220adb48738bdea587156c5f44ca5ec4ad31fdeb8fb88fda1dcd7886a24"
+dependencies = [
+ "anyhow",
+ "cid 0.10.1",
+ "futures",
+ "libipld",
+ "thiserror",
+ "tokio",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,9 +3476,9 @@ version = "0.9.1"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
+ "iroh-car",
  "libipld-cbor",
  "libipld-core",
- "noosphere-car",
  "noosphere-core",
  "noosphere-storage",
  "reqwest",
@@ -3507,12 +3522,12 @@ dependencies = [
  "clap",
  "globset",
  "home",
+ "iroh-car",
  "libipld-cbor",
  "libipld-core",
  "mime_guess",
  "noosphere",
  "noosphere-api",
- "noosphere-car",
  "noosphere-core",
  "noosphere-gateway",
  "noosphere-ipfs",
@@ -3616,11 +3631,11 @@ dependencies = [
  "axum 0.6.18",
  "bytes",
  "cid 0.10.1",
+ "iroh-car",
  "libipld-cbor",
  "libipld-core",
  "mime_guess",
  "noosphere-api",
- "noosphere-car",
  "noosphere-core",
  "noosphere-ipfs",
  "noosphere-ns",
@@ -3687,9 +3702,9 @@ dependencies = [
  "hyper",
  "hyper-multipart-rfc7578",
  "ipfs-api-prelude",
+ "iroh-car",
  "libipld-cbor",
  "libipld-core",
- "noosphere-car",
  "noosphere-core",
  "noosphere-storage",
  "rand 0.8.5",
@@ -3747,10 +3762,10 @@ dependencies = [
  "bytes",
  "cid 0.10.1",
  "futures-util",
+ "iroh-car",
  "libipld-cbor",
  "libipld-core",
  "noosphere-api",
- "noosphere-car",
  "noosphere-core",
  "noosphere-storage",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,26 +19,27 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = { version = "1" }
-subtext = { version = "0.3.4" }
-tempfile = { version = "^3" }
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "~0.3.16", features = ["env-filter", "tracing-log", "json"] }
-thiserror = { version = "1" }
+cid = { version = "0.10" }
 gloo-timers = { version = "0.2", features = ["futures"] }
-ucan = { version = "0.4.0" }
-ucan-key-support = { version = "0.1.7" }
+iroh-car = { version = "^0.3.0" }
 libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }
-cid = { version = "0.10" }
 multihash = { version = "0.18" }
-void = { version = "1" }
-wnfs-namefilter = { version = "0.1.21" }
 strum = { version = "0.24" }
 strum_macros = { version = "0.24" }
 serde = { version = "^1" }
 serde_json = { version = "^1" }
 sentry-tracing = { version = "0.31.5" }
+subtext = { version = "0.3.4" }
+tempfile = { version = "^3" }
+thiserror = { version = "1" }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "~0.3.16", features = ["env-filter", "tracing-log", "json"] }
+ucan = { version = "0.4.0" }
+ucan-key-support = { version = "0.1.7" }
+void = { version = "1" }
+wnfs-namefilter = { version = "0.1.21" }
 
 js-sys = { version = "^0.3" }
 wasm-bindgen = { version = "^0.2" }

--- a/rust/noosphere-api/Cargo.toml
+++ b/rust/noosphere-api/Cargo.toml
@@ -28,7 +28,7 @@ serde_urlencoded = "~0.7"
 tracing = { workspace = true }
 noosphere-core = { version = "0.13.1", path = "../noosphere-core" }
 noosphere-storage = { version = "0.7.1", path = "../noosphere-storage" }
-noosphere-car = { version = "0.2.0", path = "../noosphere-car" }
+iroh-car = { workspace = true }
 reqwest = { version = "0.11.15", default-features = false, features = ["json", "rustls-tls", "stream"] }
 tokio-stream = "~0.1"
 tokio-util = "0.7.7"

--- a/rust/noosphere-api/src/client.rs
+++ b/rust/noosphere-api/src/client.rs
@@ -9,8 +9,8 @@ use crate::{
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
+use iroh_car::CarReader;
 use libipld_cbor::DagCborCodec;
-use noosphere_car::CarReader;
 
 use noosphere_core::{
     authority::{generate_capability, Author, SphereAbility, SphereReference},

--- a/rust/noosphere-car/README.md
+++ b/rust/noosphere-car/README.md
@@ -1,6 +1,9 @@
-![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Alpha-red)
+![API Stability: Alpha](https://img.shields.io/badge/API%20Stability-Deprecated-red)
 
 # Noosphere CAR
+
+:warning: **noosphere-car** is **deprecated**. :warning:
+Please use [iroh-car](https://github.com/n0-computer/iroh-car).
 
 [CAR file](https://ipld.io/specs/transport/car/) support for Noosphere. "CAR" stands
 for Content Addressable aRchives. A CAR file typically contains a serialized

--- a/rust/noosphere-car/src/lib.rs
+++ b/rust/noosphere-car/src/lib.rs
@@ -1,3 +1,6 @@
+//! :warning: `noosphere-car` is deprecated.
+//! Please use [iroh-car](https://docs.rs/iroh-car).
+//!
 //! Implementation of the [car](https://ipld.io/specs/transport/car/) format.
 
 mod error;
@@ -7,6 +10,9 @@ mod util;
 mod varint;
 mod writer;
 
+#[deprecated(note = "`noosphere-car` is deprecated. Please use `iroh-car`.")]
 pub use crate::header::CarHeader;
+#[deprecated(note = "`noosphere-car` is deprecated. Please use `iroh-car`.")]
 pub use crate::reader::CarReader;
+#[deprecated(note = "`noosphere-car` is deprecated. Please use `iroh-car`.")]
 pub use crate::writer::CarWriter;

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -36,7 +36,7 @@ tower = "~0.4"
 tower-http = { version = "~0.3", features = ["cors", "trace"] }
 async-trait = "~0.1"
 tracing = { workspace = true }
-noosphere-car = { version = "0.2.0", path = "../noosphere-car" }
+iroh-car = { workspace = true }
 
 url = { version = "^2", features = [ "serde" ] }
 whoami = "^1"

--- a/rust/noosphere-gateway/Cargo.toml
+++ b/rust/noosphere-gateway/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "~0.11", default-features = false, features = ["json", "ru
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "^1"
+iroh-car = { workspace = true }
 thiserror = { workspace = true }
 strum = "0.24"
 strum_macros = "0.24"
@@ -38,7 +39,6 @@ wnfs-namefilter = { version = "0.1.21" }
 url = { version = "^2", features = [ "serde" ] }
 mime_guess = "^2"
 
-noosphere-car = { version = "0.2.0", path = "../noosphere-car" }
 noosphere-ipfs = { version = "0.6.1", path = "../noosphere-ipfs" }
 noosphere-core = { version = "0.13.1", path = "../noosphere-core" }
 noosphere-ns = { version = "0.9.1", path = "../noosphere-ns" }

--- a/rust/noosphere-gateway/src/worker/syndication.rs
+++ b/rust/noosphere-gateway/src/worker/syndication.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tokio_stream::StreamExt;
 use url::Url;
 
-use noosphere_car::{CarHeader, CarWriter};
+use iroh_car::{CarHeader, CarWriter};
 use wnfs_namefilter::BloomFilter;
 
 /// A [SyndicationJob] is a request to syndicate the blocks of a _counterpart_

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -51,7 +51,7 @@ ipfs-api-prelude = "~0.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 rand = "~0.8"
+iroh-car = { workspace = true }
 libipld-cbor = { workspace = true }
 noosphere-storage = { version = "0.7.1", path = "../noosphere-storage" }
-noosphere-car = { version = "0.2.0", path = "../noosphere-car" }
 noosphere-core = { version = "0.13.1", path = "../noosphere-core" }

--- a/rust/noosphere-ipfs/src/client/kubo.rs
+++ b/rust/noosphere-ipfs/src/client/kubo.rs
@@ -155,8 +155,8 @@ mod tests {
 
     use super::{IpfsClient, KuboClient};
     use cid::Cid;
+    use iroh_car::{CarHeader, CarWriter};
     use libipld_cbor::DagCborCodec;
-    use noosphere_car::{CarHeader, CarWriter};
     use noosphere_core::tracing::initialize_tracing;
     use noosphere_storage::{block_deserialize, block_serialize};
     use rand::prelude::*;

--- a/rust/noosphere-sphere/Cargo.toml
+++ b/rust/noosphere-sphere/Cargo.toml
@@ -19,13 +19,13 @@ helpers = []
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
+iroh-car = { workspace = true }
 url = { version = "^2", features = ["serde"] }
 tracing = { workspace = true }
 
 noosphere-core = { version = "0.13.1", path = "../noosphere-core" }
 noosphere-storage = { version = "0.7.1", path = "../noosphere-storage" }
 noosphere-api = { version = "0.9.1", path = "../noosphere-api" }
-noosphere-car = { version = "0.2.0", path = "../noosphere-car" }
 
 ucan = { workspace = true }
 ucan-key-support = { workspace = true }

--- a/rust/noosphere-sphere/src/replication/car.rs
+++ b/rust/noosphere-sphere/src/replication/car.rs
@@ -3,7 +3,7 @@ use async_stream::try_stream;
 use bytes::Bytes;
 use cid::Cid;
 use futures_util::sink::SinkExt;
-use noosphere_car::{CarHeader, CarWriter};
+use iroh_car::{CarHeader, CarWriter};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use tokio::sync::mpsc::channel;
 use tokio_stream::Stream;

--- a/rust/noosphere-sphere/src/replication/stream.rs
+++ b/rust/noosphere-sphere/src/replication/stream.rs
@@ -232,8 +232,8 @@ mod tests {
     use anyhow::Result;
     use std::collections::BTreeSet;
 
+    use iroh_car::CarReader;
     use libipld_cbor::DagCborCodec;
-    use noosphere_car::CarReader;
     use noosphere_core::{
         data::{BodyChunkIpld, ContentType, MemoIpld},
         tracing::initialize_tracing,


### PR DESCRIPTION
Fixes #446

TBD what we have to do to mark noosphere-car as deprecated -- will need to remove the code and workspace/release-it entries