### PR TITLE
feat: C FFI to verify authorizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros 0.24.3",
+ "thiserror",
  "tiny-bip39",
  "tokio",
  "tokio-stream",

--- a/rust/noosphere-api/src/data.rs
+++ b/rust/noosphere-api/src/data.rs
@@ -5,6 +5,7 @@ use cid::Cid;
 use noosphere_core::{
     authority::{generate_capability, SphereAbility, SPHERE_SEMANTICS},
     data::{Bundle, Did, Jwt, Link, MemoIpld},
+    error::NoosphereError,
 };
 use noosphere_storage::{base64_decode, base64_encode};
 use reqwest::StatusCode;
@@ -137,6 +138,12 @@ pub enum PushError {
     UpToDate,
     #[error("Internal error")]
     Internal(anyhow::Error),
+}
+
+impl From<NoosphereError> for PushError {
+    fn from(error: NoosphereError) -> Self {
+        error.into()
+    }
 }
 
 impl From<anyhow::Error> for PushError {

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -33,6 +33,7 @@ async-stream = "~0.3"
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage
 async-once-cell = "~0.3"
 anyhow = "^1"
+thiserror = { workspace = true }
 fastcdc = "3"
 futures = "~0.3"
 serde = { workspace = true }

--- a/rust/noosphere-core/src/error.rs
+++ b/rust/noosphere-core/src/error.rs
@@ -1,4 +1,4 @@
-use noosphere_api::data::PushError;
+use crate::authority::Authorization;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -14,16 +14,13 @@ pub enum NoosphereError {
 
     #[error("Missing configuration: {0}")]
     MissingConfiguration(&'static str),
+
+    #[error("The provided authorization {0} is invalid: {1}")]
+    InvalidAuthorization(Authorization, String),
 }
 
 impl From<anyhow::Error> for NoosphereError {
     fn from(error: anyhow::Error) -> Self {
         NoosphereError::Other(error)
-    }
-}
-
-impl From<NoosphereError> for PushError {
-    fn from(error: NoosphereError) -> Self {
-        error.into()
     }
 }

--- a/rust/noosphere-core/src/lib.rs
+++ b/rust/noosphere-core/src/lib.rs
@@ -5,4 +5,5 @@ pub mod authority;
 pub mod data;
 pub mod view;
 
+pub mod error;
 pub mod tracing;

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -805,13 +805,13 @@ impl<S: BlockStore> Sphere<S> {
                 ));
             }
 
+            let ucan_issuer = chain_link.ucan().issuer();
+
             if let Some(revocation) = revocations.get(&link).await? {
-                // NOTE: The implication here is that only the sphere itself can
-                // issue revocations The follow-on implicationis that a user
-                // must provide the sphere mnemonic in order to issue a
-                // revocation
-                if revocation.iss != sphere_identity {
-                    warn!("Revocation for {} had an invalid issuer; expected {}, but found {}; skipping...", link, sphere_identity, revocation.iss);
+                // NOTE: The implication here is that only the sphere itself or
+                // the direct issuer may issue revocations
+                if revocation.iss != sphere_identity || revocation.iss != ucan_issuer {
+                    warn!("Revocation for {} had an invalid issuer; expected {} or {}, but found {}; skipping...", link, ucan_issuer, sphere_identity, revocation.iss);
                     continue;
                 }
 

--- a/rust/noosphere-sphere/src/authority/read.rs
+++ b/rust/noosphere-sphere/src/authority/read.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use noosphere_core::{
     authority::{Author, Authorization},
     data::{Did, Link, Mnemonic},
+    error::NoosphereError,
 };
 use noosphere_storage::Storage;
 
@@ -24,7 +25,10 @@ where
 {
     /// For a given [Authorization], checks that the authorization and all of its
     /// ancester proofs are valid and have not been revoked
-    async fn verify_authorization(&self, authorization: &Authorization) -> Result<()>;
+    async fn verify_authorization(
+        &self,
+        authorization: &Authorization,
+    ) -> Result<(), NoosphereError>;
 
     /// Look up an authorization by a [Did].
     async fn get_authorization(&self, did: &Did) -> Result<Option<Authorization>>;
@@ -42,7 +46,10 @@ where
     C: HasSphereContext<S>,
     S: Storage + 'static,
 {
-    async fn verify_authorization(&self, authorization: &Authorization) -> Result<()> {
+    async fn verify_authorization(
+        &self,
+        authorization: &Authorization,
+    ) -> Result<(), NoosphereError> {
         self.to_sphere()
             .await?
             .verify_authorization(authorization)

--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -11,7 +11,6 @@ use subtext::{Peer, Slashlink};
 use tokio::{io::AsyncReadExt, sync::Mutex};
 
 use crate::{
-    error::NoosphereError,
     ffi::{NsError, NsHeaders, NsNoosphere, TryOrInitialize},
     platform::{PlatformSphereChannel, PlatformStorage},
 };
@@ -174,9 +173,8 @@ pub fn ns_sphere_traverse_by_petname(
             Ok(maybe_sphere) => {
                 async_runtime.spawn_blocking(move || callback(context, None, maybe_sphere))
             }
-            Err(error) => async_runtime.spawn_blocking(move || {
-                callback(context, Some(NoosphereError::from(error).into()), None)
-            }),
+            Err(error) => async_runtime
+                .spawn_blocking(move || callback(context, Some(NsError::from(error).into()), None)),
         };
     });
 }
@@ -299,9 +297,8 @@ pub fn ns_sphere_content_read(
             Ok(maybe_file) => {
                 async_runtime.spawn_blocking(move || callback(context, None, maybe_file))
             }
-            Err(error) => async_runtime.spawn_blocking(move || {
-                callback(context, Some(NoosphereError::from(error).into()), None)
-            }),
+            Err(error) => async_runtime
+                .spawn_blocking(move || callback(context, Some(NsError::from(error).into()), None)),
         };
     });
 }
@@ -604,9 +601,8 @@ pub fn ns_sphere_file_contents_read(
             Ok(maybe_bytes) => {
                 async_runtime.spawn_blocking(move || callback(context, None, Some(maybe_bytes)))
             }
-            Err(error) => async_runtime.spawn_blocking(move || {
-                callback(context, Some(NoosphereError::from(error).into()), None)
-            }),
+            Err(error) => async_runtime
+                .spawn_blocking(move || callback(context, Some(NsError::from(error).into()), None)),
         };
     });
 }

--- a/rust/noosphere/src/ffi/petname.rs
+++ b/rust/noosphere/src/ffi/petname.rs
@@ -9,10 +9,7 @@ use noosphere_core::data::Did;
 use noosphere_sphere::{SpherePetnameRead, SpherePetnameWrite, SphereWalker};
 use safer_ffi::{char_p::InvalidNulTerminator, prelude::*};
 
-use crate::{
-    error::NoosphereError,
-    ffi::{NsError, TryOrInitialize},
-};
+use crate::ffi::{NsError, TryOrInitialize};
 
 use super::{NsNoosphere, NsSphere};
 
@@ -124,9 +121,8 @@ pub fn ns_sphere_petnames_assigned_get(
             Ok(petnames) => {
                 async_runtime.spawn_blocking(move || callback(context, None, Some(petnames)))
             }
-            Err(error) => async_runtime.spawn_blocking(move || {
-                callback(context, Some(NoosphereError::from(error).into()), None)
-            }),
+            Err(error) => async_runtime
+                .spawn_blocking(move || callback(context, Some(NsError::from(error).into()), None)),
         };
     });
 }
@@ -189,7 +185,7 @@ pub fn ns_sphere_petname_resolve(
             .block_on(async { sphere.inner().resolve_petname(petname.to_str()).await })?;
         if let Some(version) = version {
             let version_str = version.to_string().try_into().map_err(
-                |error: InvalidNulTerminator<String>| -> NoosphereError { anyhow!(error).into() },
+                |error: InvalidNulTerminator<String>| -> NsError { anyhow!(error).into() },
             )?;
             Ok(Some(version_str))
         } else {

--- a/rust/noosphere/src/ffi/sphere.rs
+++ b/rust/noosphere/src/ffi/sphere.rs
@@ -7,7 +7,6 @@ use noosphere_sphere::{HasSphereContext, SphereSync, SyncRecovery};
 use safer_ffi::char_p::InvalidNulTerminator;
 use safer_ffi::prelude::*;
 
-use crate::error::NoosphereError;
 use crate::ffi::{NsError, NsNoosphere, NsSphere, TryOrInitialize};
 use crate::sphere::SphereReceipt;
 
@@ -209,9 +208,8 @@ pub fn ns_sphere_sync(
             Ok(cid_string) => {
                 async_runtime.spawn_blocking(move || callback(context, None, Some(cid_string)))
             }
-            Err(error) => async_runtime.spawn_blocking(move || {
-                callback(context, Some(NoosphereError::from(error).into()), None)
-            }),
+            Err(error) => async_runtime
+                .spawn_blocking(move || callback(context, Some(NsError::from(error).into()), None)),
         };
     });
 }

--- a/rust/noosphere/src/lib.rs
+++ b/rust/noosphere/src/lib.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate tracing;
 
-pub mod error;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ffi;
 

--- a/swift/Sources/SwiftNoosphere/Noosphere.swift
+++ b/swift/Sources/SwiftNoosphere/Noosphere.swift
@@ -110,6 +110,25 @@ public func nsSphereSync(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, 
     }
 }
 
+public typealias NsSphereAuthorityAuthorizationVerifyHandler = (OpaquePointer?) -> ()
+
+/// See: ns_sphere_authority_authorization_verify
+public func nsSphereAuthorityAuthorizationVerify(_ noosphere: OpaquePointer!, _ sphere: OpaquePointer!, _ cid: UnsafePointer<CChar>!, handler: @escaping NsSphereAuthorityAuthorizationVerifyHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_authority_authorization_verify(noosphere, sphere, cid, context) {
+        (context, error) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereAuthorityAuthorizationVerifyHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error)
+    }
+}
+
 public typealias NsSphereAuthorityEscalateHandler = (OpaquePointer?, OpaquePointer?) -> ()
 
 /// See: ns_sphere_authority_escalate

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -635,6 +635,8 @@ final class NoosphereTests: XCTestCase {
                                     (error) in
                                     
                                     assert(error != nil)
+                                    let error_code = ns_error_code_get(error)
+                                    assert(error_code == NS_ERROR_CODE_INVALID_AUTHORIZATION.rawValue)
                                     
                                     ns_string_free(authorization_ptr)
                                     ns_sphere_free(root_sphere)


### PR DESCRIPTION
This adds C FFI support for verifying that an authorization is still valid, given its CID. The bulk of the implementation here has already shipped, we just didn't have an FFI wrapper for it.