### PR TITLE
fix: Disallow Dependabot from building containers again

### DIFF
--- a/.github/workflows/container_images.yaml
+++ b/.github/workflows/container_images.yaml
@@ -17,6 +17,7 @@ name: 'Container images'
 jobs:
   build-and-push:
     name: 'Build and push'
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     # It would be ideal to run container build jobs sequentially, but the
     # current behavior of Github Workflow "concurrency" prevents this from


### PR DESCRIPTION
This fix was already implemented in https://github.com/subconsciousnetwork/noosphere/commit/29472323c8ff5797ac7d3713fb1109e2235f6505 but was accidentally reverted in https://github.com/subconsciousnetwork/noosphere/commit/4940c331ed6fa0295b3ed93ec2f39133b3f973d2