### PR TITLE
chore: Remove multihash as a dependency and rely on the exports from the cid crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,7 +2014,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util 0.7.8",
@@ -2032,6 +2038,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "headers"
@@ -2322,6 +2334,16 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -3247,7 +3269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "core2",
- "multihash-derive 0.8.1",
+ "multihash-derive 0.8.0",
  "serde",
  "serde-big-array",
  "unsigned-varint 0.7.1",
@@ -3261,7 +3283,7 @@ checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.1",
+ "multihash-derive 0.8.0",
  "serde",
  "serde-big-array",
  "sha2 0.10.7",
@@ -3279,7 +3301,7 @@ dependencies = [
  "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.1",
+ "multihash-derive 0.8.0",
  "serde",
  "serde-big-array",
  "sha2 0.10.7",
@@ -3303,9 +3325,9 @@ dependencies = [
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -3507,7 +3529,6 @@ dependencies = [
  "integer-encoding",
  "libipld",
  "libipld-cbor",
- "multihash 0.18.1",
  "thiserror",
  "tokio",
  "wasm-bindgen-test",
@@ -3568,7 +3589,6 @@ dependencies = [
  "forest_hash_utils",
  "libipld-cbor",
  "libipld-core",
- "multihash 0.18.1",
  "noosphere-storage",
  "serde",
  "serde_bytes",
@@ -4271,12 +4291,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror",
- "toml",
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5637,6 +5657,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6719,6 +6756,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ iroh-car = { version = "^0.3.0" }
 libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }
-multihash = { version = "0.18" }
 strum = { version = "0.24" }
 strum_macros = { version = "0.24" }
 serde = { version = "^1" }

--- a/rust/noosphere-car/Cargo.toml
+++ b/rust/noosphere-car/Cargo.toml
@@ -27,7 +27,6 @@ thiserror = { workspace = true }
 tokio = { version = "^1", features = ["io-util"] }
 
 [dev-dependencies]
-multihash = { workspace = true }
 tokio = { version = "^1", features = ["macros", "sync", "rt", "io-util"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/rust/noosphere-car/src/header.rs
+++ b/rust/noosphere-car/src/header.rs
@@ -80,9 +80,9 @@ impl From<Vec<Cid>> for CarHeaderV1 {
 
 #[cfg(test)]
 mod tests {
+    use cid::multihash::{Code, MultihashDigest};
     use libipld::codec::{Decode, Encode};
     use libipld_cbor::DagCborCodec;
-    use multihash::MultihashDigest;
 
     use super::*;
 
@@ -95,7 +95,7 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn symmetric_header_v1() {
-        let digest = multihash::Code::Blake3_256.digest(b"test");
+        let digest = Code::Blake3_256.digest(b"test");
         let cid = Cid::new_v1(DagCborCodec.into(), digest);
 
         let header = CarHeaderV1::from(vec![cid]);

--- a/rust/noosphere-car/src/reader.rs
+++ b/rust/noosphere-car/src/reader.rs
@@ -74,12 +74,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use cid::Cid;
+    use crate::{header::CarHeaderV1, writer::CarWriter};
+    use cid::{
+        multihash::{Code, MultihashDigest},
+        Cid,
+    };
     use futures::TryStreamExt;
     use libipld_cbor::DagCborCodec;
-    use multihash::MultihashDigest;
-
-    use crate::{header::CarHeaderV1, writer::CarWriter};
 
     use super::*;
 
@@ -92,10 +93,10 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn car_write_read() {
-        let digest_test = multihash::Code::Blake3_256.digest(b"test");
+        let digest_test = Code::Blake3_256.digest(b"test");
         let cid_test = Cid::new_v1(DagCborCodec.into(), digest_test);
 
-        let digest_foo = multihash::Code::Blake3_256.digest(b"foo");
+        let digest_foo = Code::Blake3_256.digest(b"foo");
         let cid_foo = Cid::new_v1(DagCborCodec.into(), digest_foo);
 
         let header = CarHeader::V1(CarHeaderV1::from(vec![cid_foo]));

--- a/rust/noosphere-collections/Cargo.toml
+++ b/rust/noosphere-collections/Cargo.toml
@@ -25,7 +25,6 @@ serde = { workspace = true }
 serde_bytes = "0.11"
 serde_ipld_dagcbor = "0.2"
 byteorder = "^1.4"
-multihash = { workspace = true }
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage
 async-once-cell = "0.3"
 async-recursion = "^1"


### PR DESCRIPTION
Updating `multihash` causes conflicts with `cid`, as `cid` re-exports its own `multihash` and `multibase`.