### PR TITLE
chore: mark noosphere-car's version as 0.3.0+deprecated

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,9 @@
   "last-release-sha": "39d0260c3fd2e4deb155f7eb60d460c0d76dae4f",
   "packages": {
     "rust/noosphere-api": {},
-    "rust/noosphere-car": {},
+    "rust/noosphere-car": {
+      "release-as": "0.3.0+deprecated" 
+    },
     "rust/noosphere-cli": {
       "draft": true
     },

--- a/rust/noosphere-car/src/header.rs
+++ b/rust/noosphere-car/src/header.rs
@@ -7,6 +7,7 @@ use crate::error::Error;
 /// A car header.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
+#[deprecated(note = "`noosphere-car` is deprecated. Please use `iroh-car`.")]
 pub enum CarHeader {
     V1(CarHeaderV1),
 }

--- a/rust/noosphere-car/src/lib.rs
+++ b/rust/noosphere-car/src/lib.rs
@@ -3,6 +3,8 @@
 //!
 //! Implementation of the [car](https://ipld.io/specs/transport/car/) format.
 
+#![allow(deprecated)]
+
 mod error;
 mod header;
 mod reader;

--- a/rust/noosphere-car/src/reader.rs
+++ b/rust/noosphere-car/src/reader.rs
@@ -22,6 +22,7 @@ impl<S> CarReaderSend for S {}
 
 /// Reads CAR files that are in a BufReader
 #[derive(Debug)]
+#[deprecated(note = "`noosphere-car` is deprecated. Please use `iroh-car`.")]
 pub struct CarReader<R> {
     reader: R,
     header: CarHeader,

--- a/rust/noosphere-car/src/writer.rs
+++ b/rust/noosphere-car/src/writer.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 use crate::{error::Error, header::CarHeader};
 
 #[derive(Debug)]
+#[deprecated(note = "`noosphere-car` is deprecated. Please use `iroh-car`.")]
 pub struct CarWriter<W> {
     header: CarHeader,
     writer: W,

--- a/rust/noosphere-car/tests/car_file_test.rs
+++ b/rust/noosphere-car/tests/car_file_test.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use futures::TryStreamExt;
 use noosphere_car::*;
 use tokio::io::BufReader;


### PR DESCRIPTION
* Structs needed to be marked as deprecated in order to float the deprecation to the docs landing page (the export was insufficient)
* Should be sure that the release process doesn't increment or change the version on publish (though if it bumps to `0.3.1+deprecated`, oh well)
* FWIW `0.3.0` < `0.3.0+deprecated`