### PR TITLE
feat: add Content-Length headers when writing to a sphere.

### DIFF
--- a/rust/noosphere-core/src/context/content/write.rs
+++ b/rust/noosphere-core/src/context/content/write.rs
@@ -158,7 +158,18 @@ where
         let body_cid =
             BodyChunkIpld::store_bytes(&bytes, self.sphere_context_mut().await?.db_mut()).await?;
 
-        self.link(slug, content_type, &body_cid, additional_headers)
+        let header = (
+            Header::ContentLength.to_string(),
+            format!("{}", bytes.len()),
+        );
+        let additional_headers = if let Some(mut headers) = additional_headers {
+            headers.push(header);
+            headers
+        } else {
+            vec![header]
+        };
+
+        self.link(slug, content_type, &body_cid, Some(additional_headers))
             .await
     }
 

--- a/rust/noosphere-core/src/data/headers/header.rs
+++ b/rust/noosphere-core/src/data/headers/header.rs
@@ -2,6 +2,8 @@ use std::{convert::Infallible, fmt::Display, ops::Deref, str::FromStr};
 
 /// Well-known headers in the Noosphere
 pub enum Header {
+    /// The content length (in bytes) of associated binary data
+    ContentLength,
     /// Content-type, for mimes
     ContentType,
     /// A proof, typically a UCAN JWT
@@ -34,6 +36,7 @@ impl FromStr for Header {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().as_str() {
+            "content-length" => Header::ContentLength,
             "content-type" => Header::ContentType,
             "file-extension" => Header::FileExtension,
             "proof" => Header::Proof,
@@ -52,6 +55,7 @@ impl Deref for Header {
 
     fn deref(&self) -> &Self::Target {
         match self {
+            Header::ContentLength => "Content-Length",
             Header::ContentType => "Content-Type",
             Header::Proof => "Proof",
             Header::Author => "Author",

--- a/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
+++ b/swift/Tests/SwiftNoosphereTests/NoosphereTests.swift
@@ -188,11 +188,12 @@ final class NoosphereTests: XCTestCase {
         var pointer = file_header_names.ptr!;
         
         // NOTE: "hello" is only given once even though there are two headers with that name
-        assert(name_count == 3)
+        assert(name_count == 4)
         
         let expected_headers = [
             ["foo", "bar"],
             ["hello", "world"],
+            ["Content-Length", String(file_bytes.count)],
             ["Content-Type", "text/subtext"]
         ]
         


### PR DESCRIPTION
First pass on this; we could also add length when `link`ing, either the size of the pointer or `0`