### PR TITLE
fix: Better handling of removed content in `orb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
  "multihash 0.18.1",
  "serde",
  "serde_bytes",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2016,7 +2016,7 @@ dependencies = [
  "indexmap 1.9.3",
  "slab",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2441,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "ipfs-api-prelude"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf47fa129710ae041d5844a15b1365bdad8551673aee237449ba9dec6bcadc"
+checksum = "9b74065805db266ba2c6edbd670b23c4714824a955628472b2e46cc9f3a869cb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2452,14 +2452,14 @@ dependencies = [
  "dirs",
  "futures",
  "http",
+ "multiaddr",
  "multibase",
- "parity-multiaddr",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util 0.6.10",
+ "tokio-util",
  "tracing",
  "walkdir",
 ]
@@ -2482,7 +2482,7 @@ dependencies = [
  "libipld",
  "thiserror",
  "tokio",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2735,7 +2735,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
 ]
 
@@ -2781,7 +2781,7 @@ dependencies = [
  "sha2 0.10.7",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
@@ -2852,7 +2852,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "uint",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "void",
 ]
 
@@ -3029,7 +3029,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util",
  "webrtc",
 ]
 
@@ -3240,7 +3240,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "url",
 ]
 
@@ -3257,28 +3257,17 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
-dependencies = [
- "generic-array",
- "multihash-derive 0.7.2",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "multihash"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.1",
+ "multihash-derive",
  "serde",
  "serde-big-array",
  "sha2 0.10.7",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3292,26 +3281,12 @@ dependencies = [
  "blake3",
  "core2",
  "digest 0.10.7",
- "multihash-derive 0.8.1",
+ "multihash-derive",
  "serde",
  "serde-big-array",
  "sha2 0.10.7",
  "sha3",
- "unsigned-varint 0.7.1",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
-dependencies = [
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3339,7 +3314,7 @@ dependencies = [
  "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3472,7 +3447,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tracing",
  "ucan",
  "ucan-key-support",
@@ -3501,7 +3476,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tracing",
  "ucan",
  "ucan-key-support",
@@ -3576,7 +3551,7 @@ dependencies = [
  "sha2 0.10.7",
  "tokio",
  "tokio-stream",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "wasm-bindgen-test",
 ]
 
@@ -3683,7 +3658,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tower-http",
  "tracing",
  "ucan",
@@ -3775,7 +3750,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tracing",
  "ucan",
  "ucan-key-support",
@@ -3993,24 +3968,6 @@ checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm 0.1.4",
-]
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58341485071825827b7f03cf7efd1cb21e6a709bea778fb50227fd45d2f361b4"
-dependencies = [
- "arrayref",
- "bs58 0.4.0",
- "byteorder",
- "data-encoding",
- "multihash 0.13.2",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.1",
- "url",
 ]
 
 [[package]]
@@ -4382,7 +4339,7 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -4617,7 +4574,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5667,20 +5624,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
@@ -5772,7 +5715,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5977,7 +5920,7 @@ dependencies = [
  "serde_json",
  "strum 0.24.1",
  "strum_macros",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
  "url",
 ]
 
@@ -6085,12 +6028,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "unsigned-varint"

--- a/rust/noosphere-cli/src/native/commands/sphere/history.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere/history.rs
@@ -47,14 +47,29 @@ Author: {author}"#
 
             if !content_changes.is_empty() {
                 let mut removed = Vec::new();
+                let mut any_content_added = false;
+
                 for change in content_changes {
                     match change {
-                        MapOperation::Add { key, .. } => info!("{: >12}  /{key}", "Modified"),
+                        MapOperation::Add { key, .. } => {
+                            any_content_added = true;
+                            info!("{: >12}  /{key}", "Modified")
+                        }
                         MapOperation::Remove { key } => removed.push(key),
                     }
                 }
 
-                info!("")
+                if any_content_added {
+                    info!("");
+                }
+
+                for slug in &removed {
+                    info!("{: >12}  /{slug}", "Removed");
+                }
+
+                if !removed.is_empty() {
+                    info!("")
+                }
             }
 
             let petname_changes = mutation.identities().changes();

--- a/rust/noosphere-cli/src/native/render/writer.rs
+++ b/rust/noosphere-cli/src/native/render/writer.rs
@@ -120,6 +120,14 @@ impl SphereWriter {
     pub async fn remove_content(&self, slug: &str) -> Result<()> {
         if self.is_root_writer() {
             let slug_path = self.paths.slug(slug)?;
+
+            if !slug_path.exists() {
+                trace!(
+                    "No slug link found at '{}', skipping removal of '{slug}'...",
+                    slug_path.display()
+                );
+            }
+
             let file_path = tokio::fs::read_link(&slug_path).await?;
 
             let _ = remove_symlink_file(slug_path);

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -45,7 +45,7 @@ ucan = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = { version = "^0.14.27", features = ["full"] }
 hyper-multipart-rfc7578 = "~0.8"
-ipfs-api-prelude = "~0.5"
+ipfs-api-prelude = "0.6"
 
 [dev-dependencies]
 


### PR DESCRIPTION
This fixes a bug that I encountered when adding-then-removing a note in Subconscious, and later syncing via `orb`. `orb` would attempt to look up the rendered file path for a file that was never rendered (because of how we buffer/flatten the effect multiple new versions of history), and then abort because it couldn't find an expected path.