### PR TITLE
chore: Clean up redundant dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,17 +315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-compat"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,35 +325,6 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -414,32 +374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,12 +394,6 @@ dependencies = [
  "quote",
  "syn 2.0.28",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
@@ -740,21 +668,6 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "blocking"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
- "futures-lite",
- "log",
-]
 
 [[package]]
 name = "bs58"
@@ -2318,23 +2231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
-dependencies = [
- "globset",
- "lazy_static",
- "log",
- "memchr",
- "regex",
- "same-file",
- "thread_local",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,15 +2423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -3079,9 +2966,6 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -3520,8 +3404,6 @@ dependencies = [
  "clap",
  "directories",
  "globset",
- "home",
- "ignore",
  "iroh-car",
  "libipld-cbor",
  "libipld-core",
@@ -3551,7 +3433,6 @@ dependencies = [
  "ucan-key-support",
  "url",
  "wasm-bindgen",
- "whoami",
  "witty-phrase-generator",
 ]
 
@@ -3562,7 +3443,6 @@ dependencies = [
  "anyhow",
  "async-once-cell",
  "async-recursion",
- "async-std",
  "async-stream",
  "byteorder",
  "cid",
@@ -3587,7 +3467,6 @@ dependencies = [
  "anyhow",
  "async-once-cell",
  "async-recursion",
- "async-std",
  "async-stream",
  "async-trait",
  "base64 0.21.2",
@@ -3790,7 +3669,6 @@ name = "noosphere-storage"
 version = "0.8.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-stream",
  "async-trait",
  "base64 0.21.2",
@@ -6155,12 +6033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6582,16 +6454,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "winapi",
-]
-
-[[package]]
-name = "whoami"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = { version = "1" }
+async-stream = { version = "0.3" }
 axum = { version = "^0.6.18" }
 cid = { version = "0.10" }
 directories = { version = "5" }
@@ -39,6 +40,8 @@ subtext = { version = "0.3.4" }
 symlink = { version = "0.1" }
 tempfile = { version = "^3" }
 thiserror = { version = "1" }
+tokio = { version = "^1" }
+tokio-stream = { version = "~0.1" }
 tower = { version = "^0.4.13" }
 tower-http = { version = "^0.4.3" }
 tracing = { version = "0.1" }

--- a/rust/noosphere-api/Cargo.toml
+++ b/rust/noosphere-api/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 
 
 [dependencies]
-anyhow = "^1"
+anyhow = { workspace = true }
 thiserror = { workspace = true }
 cid = { workspace = true }
 url = { workspace = true }
@@ -30,7 +30,7 @@ noosphere-core = { version = "0.15.1", path = "../noosphere-core" }
 noosphere-storage = { version = "0.8.1", path = "../noosphere-storage" }
 iroh-car = { workspace = true }
 reqwest = { version = "0.11.15", default-features = false, features = ["json", "rustls-tls", "stream"] }
-tokio-stream = "~0.1"
+tokio-stream = { workspace = true }
 tokio-util = "0.7.7"
 
 ucan = { workspace = true }
@@ -40,7 +40,7 @@ libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { workspace = true }

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -29,10 +29,10 @@ noosphere-ns = { version = "0.10.1", path = "../noosphere-ns" }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tempfile = { workspace = true }
 clap = { version = "^4.3", features = ["derive", "cargo"] }
-anyhow = "^1"
+anyhow = { workspace = true }
 
-tokio = { version = "^1", features = ["full"] }
-tokio-stream = "~0.1"
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "trace"] }
 async-trait = "~0.1"
@@ -40,9 +40,7 @@ tracing = { workspace = true }
 iroh-car = { workspace = true }
 
 url = { workspace = true, features = ["serde"] }
-whoami = "^1"
 directories = { workspace = true }
-home = "~0.5"
 mime_guess = "^2"
 witty-phrase-generator = "~0.2"
 globset = "~0.4"
@@ -59,7 +57,6 @@ ucan-key-support = { workspace = true }
 cid = { workspace = true }
 symlink = { workspace = true }
 pathdiff = { workspace = true }
-ignore = { workspace = true }
 subtext = "0.3.2"
 
 serde = { workspace = true }

--- a/rust/noosphere-collections/Cargo.toml
+++ b/rust/noosphere-collections/Cargo.toml
@@ -17,13 +17,12 @@ homepage = "https://github.com/subconsciousnetwork/noosphere"
 readme = "README.md"
 
 [dependencies]
-anyhow = "^1"
+anyhow = { workspace = true }
 sha2 = "0.10"
 cid = { workspace = true }
 forest_hash_utils = "0.1.0"
 serde = { workspace = true }
 serde_bytes = "0.11"
-serde_ipld_dagcbor = "0.4"
 byteorder = "^1.4"
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage
 async-once-cell = "0.4"
@@ -31,17 +30,17 @@ async-recursion = "^1"
 libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }
 noosphere-storage = { version = "0.8.1", path = "../noosphere-storage" }
+tokio = { workspace = true, features = ["sync", "io-util"] }
 
-tokio = { version = "^1", features = ["sync", "io-util"] }
-tokio-stream = "~0.1"
-async-stream = "~0.3"
+tokio-stream = { workspace = true }
+async-stream = { workspace = true }
 
 [dev-dependencies]
-async-std = "^1"
 unsigned-varint = "0.7"
+serde_ipld_dagcbor = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/rust/noosphere-collections/src/hamt/hamt_implementation.rs
+++ b/rust/noosphere-collections/src/hamt/hamt_implementation.rs
@@ -46,8 +46,10 @@ pub type HamtStream<'a, K, V> = Pin<Box<dyn Stream<Item = Result<(&'a K, &'a V)>
 /// ```
 /// use noosphere_collections::hamt::Hamt;
 /// use noosphere_storage::MemoryStore;
+/// use tokio;
 ///
-/// async_std::task::block_on(async {
+/// #[tokio::main(flavor = "multi_thread")]
+/// async fn main() {
 ///     let store = MemoryStore::default();
 ///
 ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
@@ -56,7 +58,7 @@ pub type HamtStream<'a, K, V> = Pin<Box<dyn Stream<Item = Result<(&'a K, &'a V)>
 ///     assert_eq!(map.delete(&1).await.unwrap(), Some((1, "a".to_string())));
 ///     assert_eq!(map.get::<_>(&1).await.unwrap(), None);
 ///     let cid = map.flush().await.unwrap();
-/// });
+/// }
 /// ```
 #[derive(Debug)]
 pub struct Hamt<BS, V, K = BytesKey, H = Sha256>
@@ -158,8 +160,10 @@ where
     /// ```
     /// use noosphere_collections::hamt::Hamt;
     /// use noosphere_storage::MemoryStore;
+    /// use tokio;
     ///
-    /// async_std::task::block_on(async {
+    /// #[tokio::main(flavor = "multi_thread")]
+    /// async fn main() {
     ///     let store = MemoryStore::default();
     ///
     ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
@@ -168,7 +172,7 @@ where
     ///
     ///     map.set(37, "b".to_string()).await.unwrap();
     ///     map.set(37, "c".to_string()).await.unwrap();
-    /// })
+    /// }
     /// ```
     pub async fn set(&mut self, key: K, value: V) -> Result<Option<V>> {
         self.root
@@ -188,8 +192,10 @@ where
     /// ```
     /// use noosphere_collections::hamt::Hamt;
     /// use noosphere_storage::MemoryStore;
+    /// use tokio;
     ///
-    /// async_std::task::block_on(async {
+    /// #[tokio::main(flavor = "multi_thread")]
+    /// async fn main() {
     ///     let store = MemoryStore::default();
     ///
     ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
@@ -203,7 +209,7 @@ where
     ///
     ///     let c = map.set_if_absent(30, "c".to_string()).await.unwrap();
     ///     assert_eq!(c, true);
-    /// });
+    /// }
     /// ```
     pub async fn set_if_absent(&mut self, key: K, value: V) -> Result<bool>
     where
@@ -226,15 +232,17 @@ where
     /// ```
     /// use noosphere_collections::hamt::Hamt;
     /// use noosphere_storage::MemoryStore;
+    /// use tokio;
     ///
-    /// async_std::task::block_on(async {
+    /// #[tokio::main(flavor = "multi_thread")]
+    /// async fn main() {
     ///     let store = MemoryStore::default();
     ///
     ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
     ///     map.set(1, "a".to_string()).await.unwrap();
     ///     assert_eq!(map.get(&1).await.unwrap(), Some(&"a".to_string()));
     ///     assert_eq!(map.get(&2).await.unwrap(), None);
-    /// })
+    /// }
     /// ```
     #[inline]
     pub async fn get<Q: ?Sized>(&self, k: &Q) -> Result<Option<&V>>
@@ -260,15 +268,17 @@ where
     /// ```
     /// use noosphere_collections::hamt::Hamt;
     /// use noosphere_storage::MemoryStore;
+    /// use tokio;
     ///
-    /// async_std::task::block_on(async {
+    /// #[tokio::main(flavor = "multi_thread")]
+    /// async fn main() {
     ///     let store = MemoryStore::default();
     ///
     ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
     ///     map.set(1, "a".to_string()).await.unwrap();
     ///     assert_eq!(map.contains_key(&1).await.unwrap(), true);
     ///     assert_eq!(map.contains_key(&2).await.unwrap(), false);
-    /// });
+    /// }
     /// ```
     #[inline]
     pub async fn contains_key<Q: ?Sized>(&self, k: &Q) -> Result<bool>
@@ -295,15 +305,17 @@ where
     /// ```
     /// use noosphere_collections::hamt::Hamt;
     /// use noosphere_storage::MemoryStore;
+    /// use tokio;
     ///
-    /// async_std::task::block_on(async {
+    /// #[tokio::main(flavor = "multi_thread")]
+    /// async fn main() {
     ///     let store = MemoryStore::default();
     ///
     ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
     ///     map.set(1, "a".to_string()).await.unwrap();
     ///     assert_eq!(map.delete(&1).await.unwrap(), Some((1, "a".to_string())));
     ///     assert_eq!(map.delete(&1).await.unwrap(), None);
-    /// });
+    /// }
     /// ```
     pub async fn delete<Q: ?Sized>(&mut self, k: &Q) -> Result<Option<(K, V)>>
     where
@@ -333,8 +345,10 @@ where
     /// ```
     /// use noosphere_collections::hamt::Hamt;
     /// use noosphere_storage::MemoryStore;
+    /// use tokio;
     ///
-    /// async_std::task::block_on(async {
+    /// #[tokio::main(flavor = "multi_thread")]
+    /// async fn main() {
     ///     let store = MemoryStore::default();
     ///
     ///     let mut map: Hamt<_, _, usize> = Hamt::new(store);
@@ -347,7 +361,7 @@ where
     ///         Ok(())
     ///     }).await.unwrap();
     ///     assert_eq!(total, 3);
-    /// });
+    /// }
     /// ```
     #[inline]
     pub async fn for_each<F>(&self, mut f: F) -> Result<()>

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -28,12 +28,11 @@ cid = { workspace = true }
 url = { workspace = true }
 async-trait = "~0.1"
 async-recursion = "^1"
-async-std = "^1"
-async-stream = "~0.3"
+async-stream = { workspace = true }
 
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage
 async-once-cell = "~0.4"
-anyhow = "^1"
+anyhow = { workspace = true }
 thiserror = { workspace = true }
 fastcdc = { workspace = true }
 futures = "~0.3"
@@ -45,7 +44,7 @@ ed25519-zebra = "^3"
 rand = "~0.8"
 once_cell = "^1"
 tiny-bip39 = "^1"
-tokio-stream = "~0.1"
+tokio-stream = { workspace = true }
 libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }
 strum = { workspace = true }
@@ -63,12 +62,12 @@ wasm-bindgen-test = { workspace = true }
 serde_bytes = "~0.11"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: This is needed so that rand can be included in WASM builds
 getrandom = { version = "~0.2", features = ["js"] }
-tokio = { version = "^1", features = ["sync", "macros"] }
+tokio = { workspace = true, features = ["sync", "macros"] }
 console_error_panic_hook = "0.1"
 tracing-wasm = "~0.2"

--- a/rust/noosphere-gateway/Cargo.toml
+++ b/rust/noosphere-gateway/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 reqwest = { version = "~0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-anyhow = "^1"
+anyhow = { workspace = true }
 axum = { workspace = true, features = ["headers", "macros"] }
 iroh-car = { workspace = true }
 thiserror = { workspace = true }
@@ -27,12 +27,12 @@ strum = "0.25"
 strum_macros = "0.25"
 bytes = "^1"
 
-tokio = { version = "^1", features = ["full"] }
-tokio-stream = "~0.1"
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "trace"] }
 async-trait = "~0.1"
-async-stream = "~0.3"
+async-stream = { workspace = true }
 tracing = { workspace = true }
 wnfs-namefilter = { version = "0.1.21" }
 

--- a/rust/noosphere-into/Cargo.toml
+++ b/rust/noosphere-into/Cargo.toml
@@ -24,7 +24,6 @@ subtext = { version = "0.3.2", features = ["stream"] }
 async-trait = "~0.1"
 url = { workspace = true }
 tracing = { workspace = true }
-
 anyhow = { workspace = true }
 
 horrorshow = "~0.8"
@@ -32,11 +31,11 @@ cid = { workspace = true }
 libipld-cbor = { workspace = true }
 
 bytes = "^1"
-tokio-stream = "~0.1"
 tokio-util = "~0.7"
-tokio = { version = "^1", features = ["io-util", "macros", "test-util"] }
+tokio-stream = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "test-util"] }
 
-async-stream = { version = "~0.3" }
+async-stream = { workspace = true }
 futures = { version = "~0.3" }
 async-compat = { version = "~0.2" }
 async-utf8-decoder = { version = "~0.3" }
@@ -52,5 +51,5 @@ wasm-bindgen-test = { workspace = true }
 # Mostly these dependencies are used in the examples
 axum = { workspace = true }
 tempfile = { workspace = true }
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tower-http = { workspace = true, features = ["fs", "trace"] }

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -25,18 +25,18 @@ storage = ["ucan"]
 test_kubo = []
 
 [dependencies]
-anyhow = "^1"
+anyhow = { workspace = true }
 async-compat = { version = "~0.2" }
 async-trait = "~0.1"
-tokio-stream = "~0.1"
-async-stream = "~0.3"
+async-stream = { workspace = true }
 libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }
 cid = { workspace = true }
 reqwest = { version = "~0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "^1", features = ["io-util"] }
+tokio = { workspace = true, features = ["io-util"] }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, features = [ "serde" ] }
 noosphere-storage = { version = "0.8.1", path = "../noosphere-storage" }
@@ -53,5 +53,4 @@ ipfs-api-prelude = "~0.5"
 rand = "~0.8"
 iroh-car = { workspace = true }
 libipld-cbor = { workspace = true }
-noosphere-storage = { version = "0.8.1", path = "../noosphere-storage" }
 noosphere-core = { version = "0.15.1", path = "../noosphere-core" }

--- a/rust/noosphere-ns/Cargo.toml
+++ b/rust/noosphere-ns/Cargo.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 [dependencies]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-anyhow = "^1"
+anyhow = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 lazy_static = "^1"
@@ -35,7 +35,7 @@ futures = "^0.3.26"
 async-trait = "~0.1"
 ucan = { workspace = true }
 ucan-key-support = { workspace = true }
-tokio = { version = "1.29", features = ["io-util", "io-std", "sync", "macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "io-std", "sync", "macros", "rt", "rt-multi-thread"] }
 noosphere-storage = { version = "0.8.1", path = "../noosphere-storage" }
 noosphere-core = { version = "0.15.1", path = "../noosphere-core" }
 libp2p = { version = "0.51.3", default-features = false, features = [ "ed25519", "identify", "dns", "kad", "macros", "noise", "serde", "tcp", "tokio", "yamux" ] }

--- a/rust/noosphere-sphere/Cargo.toml
+++ b/rust/noosphere-sphere/Cargo.toml
@@ -31,8 +31,8 @@ ucan = { workspace = true }
 ucan-key-support = { workspace = true }
 
 async-trait = "~0.1"
-tokio-stream = "~0.1"
-async-stream = "~0.3"
+tokio-stream = { workspace = true }
+async-stream = { workspace = true }
 tokio-util = { version = "0.7.7", features = ["io"] }
 futures-util = "0.3.27"
 libipld-core = { workspace = true }
@@ -48,12 +48,12 @@ noosphere-core = { version = "0.15.1", path = "../noosphere-core", features = ["
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: We should eventually support gateway storage as a specialty target only,
 # as it is a specialty use-case
-tokio = { version = "^1", features = ["sync", "macros"] }
+tokio = { workspace = true, features = ["sync", "macros"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = "0.4.37"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/rust/noosphere-storage/Cargo.toml
+++ b/rust/noosphere-storage/Cargo.toml
@@ -21,10 +21,9 @@ readme = "README.md"
 
 [dependencies]
 anyhow = { workspace = true }
-async-std = "^1"
 async-trait = "~0.1"
-async-stream = "~0.3"
-tokio-stream = "~0.1"
+async-stream = { workspace = true }
+tokio-stream = { workspace = true }
 cid = { workspace = true }
 tracing = "~0.1"
 ucan = { workspace = true }
@@ -40,10 +39,10 @@ wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sled = "~0.34"
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "^1", features = ["sync", "macros"] }
+tokio = { workspace = true, features = ["sync", "macros"] }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }
 rexie = { version = "~0.4" }

--- a/rust/noosphere-storage/src/implementation/memory.rs
+++ b/rust/noosphere-storage/src/implementation/memory.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Result};
-use async_std::sync::Mutex;
 use async_trait::async_trait;
 use cid::Cid;
 use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
 
 use crate::storage::Storage;
 use crate::store::Store;

--- a/rust/noosphere-storage/src/implementation/tracking.rs
+++ b/rust/noosphere-storage/src/implementation/tracking.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use async_std::sync::Mutex;
 use async_trait::async_trait;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use crate::{store::Store, MemoryStorage, MemoryStore, Storage};
 

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -21,18 +21,18 @@ headers = ["safer-ffi/headers"]
 ipfs-storage = ["noosphere-ipfs"]
 
 [dependencies]
-anyhow = "^1"
+anyhow = { workspace = true }
 pkg-version = "^1.0.0"
 thiserror = { workspace = true }
 lazy_static = "^1"
 cid = { workspace = true }
 async-trait = "~0.1"
-async-stream = "~0.3"
+async-stream = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 subtext = { workspace = true }
 itertools = "0.10.5"
-tokio-stream = "~0.1"
+tokio-stream = { workspace = true }
 tokio-util = { version = "~0.7", features = ["io"] }
 libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }
@@ -52,7 +52,7 @@ libipld-core = { workspace = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: We should eventually support gateway storage as a specialty target only,
 # as it is a specialty use-case
-tokio = { version = "^1", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 rexie = { version = "~0.4" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -67,7 +67,7 @@ features = [
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 safer-ffi = { version = "0.1.2", features = ["proc_macros", "python-headers"] }
-tokio = { version = "^1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
replace lingering async-std usage with tokio, promote tokio/tokio-stream to workspace dependency, remove unused deps, a few anyhows weren't using workspace etc.