### PR TITLE
fix: Increase allowed request body payload size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "noosphere-sphere",
  "noosphere-storage",
  "pathdiff",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }
 pathdiff = { version = "0.2.1" }
+rand = { version = "0.8" }
 sentry-tracing = { version = "0.31.5" }
 serde = { version = "^1" }
 serde_json = { version = "^1" }

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -58,6 +58,7 @@ cid = { workspace = true }
 symlink = { workspace = true }
 pathdiff = { workspace = true }
 subtext = "0.3.2"
+rand = {workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/noosphere-cli/tests/helpers/mod.rs
+++ b/rust/noosphere-cli/tests/helpers/mod.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
 mod cli;
+mod random;
 
+pub use crate::helpers::random::*;
 pub use cli::*;
 
 use anyhow::Result;

--- a/rust/noosphere-cli/tests/helpers/random.rs
+++ b/rust/noosphere-cli/tests/helpers/random.rs
@@ -1,0 +1,35 @@
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// A helper to support consistent use of seeded randomness in tests.
+/// Its primary purpose is to retain and report the seed in use for a
+/// random number generator that can be shared across threads in tests.
+/// This is probably not suitable for use outside of tests.
+pub struct TestEntropy {
+    seed: [u8; 32],
+    rng: Arc<Mutex<StdRng>>,
+}
+
+impl Default for TestEntropy {
+    fn default() -> Self {
+        Self::from_seed(rand::thread_rng().gen::<[u8; 32]>())
+    }
+}
+
+impl TestEntropy {
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        tracing::info!(?seed, "Initializing test entropy...");
+
+        let rng = Arc::new(Mutex::new(SeedableRng::from_seed(seed.clone())));
+        Self { seed, rng }
+    }
+
+    pub fn to_rng(&self) -> Arc<Mutex<StdRng>> {
+        self.rng.clone()
+    }
+
+    pub fn seed(&self) -> &[u8] {
+        &self.seed
+    }
+}

--- a/rust/noosphere-gateway/src/gateway.rs
+++ b/rust/noosphere-gateway/src/gateway.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderValue, Method};
 use axum::routing::{get, put};
 use axum::{Extension, Router, Server};
@@ -22,6 +23,8 @@ use crate::{
 };
 
 use noosphere_core::tracing::initialize_tracing;
+
+pub const DEFAULT_BODY_LENGTH_LIMIT: usize = 100 /* MB */ * 1000 * 1000;
 
 #[derive(Clone, Debug)]
 pub struct GatewayScope {
@@ -99,6 +102,7 @@ where
         .layer(Extension(gateway_key_did))
         .layer(Extension(syndication_tx))
         .layer(Extension(name_system_tx))
+        .layer(DefaultBodyLimit::max(DEFAULT_BODY_LENGTH_LIMIT))
         .layer(cors)
         .layer(TraceLayer::new_for_http());
 

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -50,7 +50,7 @@ ipfs-api-prelude = "0.6"
 [dev-dependencies]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-rand = "~0.8"
+rand = { workspace = true }
 iroh-car = { workspace = true }
 libipld-cbor = { workspace = true }
 noosphere-core = { version = "0.15.1", path = "../noosphere-core" }

--- a/rust/noosphere-ns/Cargo.toml
+++ b/rust/noosphere-ns/Cargo.toml
@@ -57,7 +57,7 @@ url = { version = "^2", features = [ "serde" ], optional = true }
 [dev-dependencies]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-rand = { version = "0.8.5" }
+rand = { workspace = true }
 libipld-cbor = { workspace = true }
 tempfile = { workspace = true }
 

--- a/rust/noosphere-sphere/src/sync/strategy.rs
+++ b/rust/noosphere-sphere/src/sync/strategy.rs
@@ -359,6 +359,13 @@ where
             .bundle_until_ancestor(local_sphere_base.as_ref())
             .await?;
 
+        let mut byte_count = 0;
+        for bytes in bundle.map().values() {
+            byte_count += bytes.len();
+        }
+
+        trace!("Total bytes in bundle to be pushed: {}", byte_count);
+
         let client = context.client().await?;
 
         let local_sphere_identity = context.identity();

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,3 +1,6 @@
+// TODO(getditto/safer_ffi#181): Re-enable this lint
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
+
 mod authority;
 mod context;
 mod error;


### PR DESCRIPTION
This change increases our allowed body payload size to ~100MB. This is a stop-gap until such time as we update to streaming pushes (which can perhaps be treated in a special way). We also need to investigate:

- #606 
- #612
- #613