### PR TITLE
chore: Genercize storage across gateway and rename "default" storages

### DIFF
--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -3,11 +3,11 @@
 use anyhow::{anyhow, Result};
 use cid::Cid;
 use directories::ProjectDirs;
-use noosphere::sphere::SphereContextBuilder;
+use noosphere::{platform::PlatformStorage, sphere::SphereContextBuilder};
 use noosphere_core::authority::Author;
 use noosphere_core::data::{Did, Link, LinkRecord, MemoIpld};
 use noosphere_sphere::{SphereContentRead, SphereContext, SphereCursor, COUNTERPART, GATEWAY_URL};
-use noosphere_storage::{KeyValueStore, NativeStorage, SphereDb};
+use noosphere_storage::{KeyValueStore, SphereDb};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -24,7 +24,7 @@ use super::paths::SpherePaths;
 use super::render::SphereRenderer;
 
 /// The flavor of [SphereContext] used through the CLI
-pub type CliSphereContext = SphereContext<NativeStorage>;
+pub type CliSphereContext = SphereContext<PlatformStorage>;
 
 /// Metadata about a given sphere, including the sphere ID, a [Link]
 /// to it and a corresponding [LinkRecord] (if one is available).
@@ -68,7 +68,7 @@ impl Workspace {
     /// Get an owned referenced to the [SphereDb] that backs the local sphere.
     /// Note that this will initialize the [SphereContext] if it has not been
     /// already.
-    pub async fn db(&self) -> Result<SphereDb<NativeStorage>> {
+    pub async fn db(&self) -> Result<SphereDb<PlatformStorage>> {
         let context = self.sphere_context().await?;
         let context = context.lock().await;
         Ok(context.db().clone())

--- a/rust/noosphere-cli/tests/helpers/mod.rs
+++ b/rust/noosphere-cli/tests/helpers/mod.rs
@@ -8,19 +8,19 @@ pub use cli::*;
 
 use anyhow::Result;
 use noosphere_ipfs::{IpfsStore, KuboClient};
-use noosphere_storage::{BlockStoreRetry, MemoryStore, NativeStorage, UcanStore};
+use noosphere_storage::{BlockStoreRetry, MemoryStore, UcanStore};
 use std::{net::TcpListener, sync::Arc, time::Duration};
 use tempfile::TempDir;
 
 use noosphere_cli::{
     cli::ConfigSetCommand,
     commands::{key::key_create, sphere::config_set, sphere::sphere_create},
-    workspace::Workspace,
+    workspace::{CliSphereContext, Workspace},
 };
 use noosphere_core::data::Did;
 use noosphere_gateway::{start_gateway, GatewayScope};
 use noosphere_ns::{helpers::NameSystemNetwork, server::start_name_system_api_server};
-use noosphere_sphere::{HasSphereContext, SphereContext};
+use noosphere_sphere::HasSphereContext;
 use tokio::{sync::Mutex, task::JoinHandle};
 use url::Url;
 
@@ -222,14 +222,14 @@ impl SpherePair {
     }
 
     /// Returns a [SphereContext] for the client sphere.
-    pub async fn sphere_context(&self) -> Result<Arc<Mutex<SphereContext<NativeStorage>>>> {
+    pub async fn sphere_context(&self) -> Result<Arc<Mutex<CliSphereContext>>> {
         self.client.workspace.sphere_context().await
     }
 
     pub async fn spawn<T, F, Fut>(&self, f: F) -> Result<T>
     where
         T: Send + 'static,
-        F: FnOnce(Arc<Mutex<SphereContext<NativeStorage>>>) -> Fut + Send + 'static,
+        F: FnOnce(Arc<Mutex<CliSphereContext>>) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<T>> + Send + 'static,
     {
         let context = self.sphere_context().await?;

--- a/rust/noosphere-gateway/src/route/fetch.rs
+++ b/rust/noosphere-gateway/src/route/fetch.rs
@@ -19,7 +19,7 @@ use crate::{authority::GatewayAuthority, GatewayScope};
 
 #[instrument(level = "debug", skip(authority, scope, sphere_context, ipfs_client))]
 pub async fn fetch_route<C, S>(
-    authority: GatewayAuthority,
+    authority: GatewayAuthority<S>,
     Query(FetchParameters { since }): Query<FetchParameters>,
     Extension(scope): Extension<GatewayScope>,
     Extension(ipfs_client): Extension<KuboClient>,

--- a/rust/noosphere-gateway/src/route/identify.rs
+++ b/rust/noosphere-gateway/src/route/identify.rs
@@ -8,11 +8,11 @@ use noosphere_storage::Storage;
 pub async fn identify_route<C, S>(
     Extension(scope): Extension<GatewayScope>,
     Extension(sphere_context): Extension<C>,
-    authority: GatewayAuthority,
+    authority: GatewayAuthority<S>,
 ) -> Result<impl IntoResponse, StatusCode>
 where
     C: HasSphereContext<S>,
-    S: Storage,
+    S: Storage + 'static,
 {
     debug!("Invoking identify route...");
 

--- a/rust/noosphere-gateway/src/route/push.rs
+++ b/rust/noosphere-gateway/src/route/push.rs
@@ -35,7 +35,7 @@ use crate::{
     )
 )]
 pub async fn push_route<C, S>(
-    authority: GatewayAuthority,
+    authority: GatewayAuthority<S>,
     Extension(sphere_context): Extension<C>,
     Extension(gateway_scope): Extension<GatewayScope>,
     Extension(syndication_tx): Extension<UnboundedSender<SyndicationJob<C>>>,

--- a/rust/noosphere-gateway/src/route/replicate.rs
+++ b/rust/noosphere-gateway/src/route/replicate.rs
@@ -35,7 +35,7 @@ pub type ReplicationCarStreamBody =
 /// fetch from the gateway.
 #[instrument(level = "debug", skip(authority, scope, sphere_context,))]
 pub async fn replicate_route<C, S>(
-    authority: GatewayAuthority,
+    authority: GatewayAuthority<S>,
     // NOTE: Cannot go from string to CID via serde
     Path(memo_version): Path<String>,
     Query(ReplicateParameters { since }): Query<ReplicateParameters>,

--- a/rust/noosphere-storage/src/helpers.rs
+++ b/rust/noosphere-storage/src/helpers.rs
@@ -2,10 +2,10 @@ use crate::Storage;
 use anyhow::Result;
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::{NativeStorage, NativeStorageInit, NativeStore};
+use crate::{SledStorage, SledStorageInit, SledStore};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn make_disposable_store() -> Result<NativeStore> {
+pub async fn make_disposable_store() -> Result<SledStore> {
     let temp_dir = std::env::temp_dir();
     let temp_name: String = witty_phrase_generator::WPGen::new()
         .with_words(3)
@@ -13,16 +13,15 @@ pub async fn make_disposable_store() -> Result<NativeStore> {
         .into_iter()
         .map(String::from)
         .collect();
-    let db = sled::open(temp_dir.join(temp_name)).unwrap();
-    let provider = NativeStorage::new(NativeStorageInit::Db(db))?;
+    let provider = SledStorage::new(SledStorageInit::Path(temp_dir.join(temp_name)))?;
     provider.get_block_store("foo").await
 }
 
 #[cfg(target_arch = "wasm32")]
-use crate::{WebStorage, WebStore};
+use crate::{IndexedDbStorage, IndexedDbStore};
 
 #[cfg(target_arch = "wasm32")]
-pub async fn make_disposable_store() -> Result<WebStore> {
+pub async fn make_disposable_store() -> Result<IndexedDbStore> {
     let temp_name: String = witty_phrase_generator::WPGen::new()
         .with_words(3)
         .unwrap()
@@ -30,6 +29,6 @@ pub async fn make_disposable_store() -> Result<WebStore> {
         .map(|word| String::from(word))
         .collect();
 
-    let provider = WebStorage::new(&temp_name).await?;
+    let provider = IndexedDbStorage::new(&temp_name).await?;
     provider.get_block_store(crate::db::BLOCK_STORE).await
 }

--- a/rust/noosphere-storage/src/implementation/mod.rs
+++ b/rust/noosphere-storage/src/implementation/mod.rs
@@ -5,13 +5,13 @@ pub use memory::*;
 pub use tracking::*;
 
 #[cfg(not(target_arch = "wasm32"))]
-mod native;
+mod sled;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use native::*;
+pub use self::sled::*;
 
 #[cfg(target_arch = "wasm32")]
-mod web;
+mod indexed_db;
 
 #[cfg(target_arch = "wasm32")]
-pub use web::*;
+pub use indexed_db::*;

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -8,7 +8,7 @@
     target_vendor = "apple"
 ))]
 mod inner {
-    use noosphere_storage::NativeStorage;
+    use noosphere_storage::SledStorage;
     use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
     use crate::key::InsecureKeyStorage;
@@ -19,13 +19,13 @@ mod inner {
     pub type PlatformKeyStorage = InsecureKeyStorage;
 
     #[cfg(not(feature = "ipfs-storage"))]
-    pub type PlatformStorage = NativeStorage;
+    pub type PlatformStorage = SledStorage;
 
     #[cfg(feature = "ipfs-storage")]
     use noosphere_ipfs::{IpfsStorage, KuboClient};
 
     #[cfg(feature = "ipfs-storage")]
-    pub type PlatformStorage = IpfsStorage<NativeStorage, KuboClient>;
+    pub type PlatformStorage = IpfsStorage<SledStorage, KuboClient>;
 
     #[cfg(test)]
     use anyhow::Result;
@@ -59,14 +59,14 @@ mod inner {
     pub type PlatformKeyMaterial = Arc<WebCryptoRsaKeyMaterial>;
     pub type PlatformKeyStorage = WebCryptoKeyStorage;
 
-    use noosphere_storage::WebStorage;
+    use noosphere_storage::IndexedDbStorage;
 
     #[cfg(feature = "ipfs-storage")]
     pub type PlatformStorage =
-        noosphere_ipfs::IpfsStorage<WebStorage, noosphere_ipfs::GatewayClient>;
+        noosphere_ipfs::IpfsStorage<IndexedDbStorage, noosphere_ipfs::GatewayClient>;
 
     #[cfg(not(feature = "ipfs-storage"))]
-    pub type PlatformStorage = WebStorage;
+    pub type PlatformStorage = IndexedDbStorage;
 
     #[cfg(test)]
     use anyhow::Result;
@@ -104,7 +104,7 @@ mod inner {
     ))
 ))]
 mod inner {
-    use noosphere_storage::NativeStorage;
+    use noosphere_storage::SledStorage;
     use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
     use crate::key::InsecureKeyStorage;
@@ -113,13 +113,13 @@ mod inner {
     pub type PlatformKeyStorage = InsecureKeyStorage;
 
     #[cfg(not(feature = "ipfs-storage"))]
-    pub type PlatformStorage = NativeStorage;
+    pub type PlatformStorage = SledStorage;
 
     #[cfg(feature = "ipfs-storage")]
     use noosphere_ipfs::{IpfsStorage, KuboClient};
 
     #[cfg(feature = "ipfs-storage")]
-    pub type PlatformStorage = IpfsStorage<NativeStorage, KuboClient>;
+    pub type PlatformStorage = IpfsStorage<SledStorage, KuboClient>;
 
     #[cfg(test)]
     use anyhow::Result;

--- a/rust/noosphere/src/storage.rs
+++ b/rust/noosphere/src/storage.rs
@@ -42,22 +42,22 @@ impl From<StorageLayout> for PathBuf {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-use noosphere_storage::{NativeStorage, NativeStorageInit};
+use noosphere_storage::{SledStorage, SledStorageInit};
 
 #[cfg(not(target_arch = "wasm32"))]
 impl StorageLayout {
-    pub async fn to_storage(&self) -> Result<NativeStorage> {
-        NativeStorage::new(NativeStorageInit::Path(PathBuf::from(self)))
+    pub async fn to_storage(&self) -> Result<SledStorage> {
+        SledStorage::new(SledStorageInit::Path(PathBuf::from(self)))
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-use noosphere_storage::WebStorage;
+use noosphere_storage::IndexedDbStorage;
 
 #[cfg(target_arch = "wasm32")]
 impl StorageLayout {
-    pub async fn to_storage(&self) -> Result<WebStorage> {
-        WebStorage::new(&self.to_string()).await
+    pub async fn to_storage(&self) -> Result<IndexedDbStorage> {
+        IndexedDbStorage::new(&self.to_string()).await
     }
 }
 


### PR DESCRIPTION
chore: Rename NativeStorage -> SledStorage, WebStorage -> IndexedDbStorage. Make storage generic over gateway. In preparation for exploring pluggable backends in #607 