### PR TITLE
chore: Trick `release-please` into accepting cycle

### DIFF
--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -49,7 +49,8 @@ ucan-key-support = { workspace = true }
 libipld-core = { workspace = true }
 rand = { workspace = true }
 serde_json = { workspace = true }
-noosphere-cli = { version = "0.14.1", path = "../noosphere-cli", features = ["helpers"] }
+# TODO(#629): This is a dependency cycle hack that we need until we can get off of release-please
+noosphere-cli-dev = { path = "../noosphere-cli", features = ["helpers"], package = "noosphere-cli" }
 noosphere-core = { version = "0.15.1", path = "../noosphere-core", features = ["helpers"] }
 noosphere-common = { version = "0.1.0", path = "../noosphere-common", features = ["helpers"] }
 noosphere-gateway = { version = "0.8.1", path = "../noosphere-gateway" }

--- a/rust/noosphere/tests/cli.rs
+++ b/rust/noosphere/tests/cli.rs
@@ -3,9 +3,11 @@
 //! Integration tests to demonstrate that the Noosphere CLI, aka "orb", works
 //! end-to-end in concert with the name system and backing block syndication
 
+// TODO(#629): Remove this when we migrate off of `release-please`
+extern crate noosphere_cli_dev as noosphere_cli;
+
 use anyhow::Result;
-use noosphere_cli::helpers::CliSimulator;
-use noosphere_cli::paths::SPHERE_DIRECTORY;
+use noosphere_cli::{helpers::CliSimulator, paths::SPHERE_DIRECTORY};
 use noosphere_common::helpers::wait;
 use noosphere_core::tracing::initialize_tracing;
 use serde_json::Value;

--- a/rust/noosphere/tests/distributed_basic.rs
+++ b/rust/noosphere/tests/distributed_basic.rs
@@ -4,6 +4,9 @@
 //! name system and block syndication backend (e.g., IPFS Kubo). The tests in this
 //! module represent basic distributed system scenarios.
 
+// TODO(#629): Remove this when we migrate off of `release-please`
+extern crate noosphere_cli_dev as noosphere_cli;
+
 #[macro_use]
 extern crate tracing;
 

--- a/rust/noosphere/tests/distributed_stress.rs
+++ b/rust/noosphere/tests/distributed_stress.rs
@@ -5,6 +5,9 @@
 //! module represent sophisticated, complicated, nuanced or high-latency scenarios.
 
 mod latency {
+    // TODO(#629): Remove this when we migrate off of `release-please`
+    extern crate noosphere_cli_dev as noosphere_cli;
+
     use anyhow::Result;
     use noosphere_cli::helpers::{start_name_system_server, SpherePair};
     use noosphere_common::helpers::TestEntropy;
@@ -130,6 +133,8 @@ mod latency {
 }
 
 mod multiplayer {
+    // TODO(#629): Remove this when we migrate off of `release-please`
+    extern crate noosphere_cli_dev as noosphere_cli;
 
     use anyhow::Result;
     use noosphere_cli::helpers::{start_name_system_server, CliSimulator, SpherePair};

--- a/rust/noosphere/tests/gateway.rs
+++ b/rust/noosphere/tests/gateway.rs
@@ -4,6 +4,9 @@
 //! tests in this module should be able to run without an available backing
 //! IPFS-like block syndication layer.
 
+// TODO(#629): Remove this when we migrate off of `release-please`
+extern crate noosphere_cli_dev as noosphere_cli;
+
 use anyhow::Result;
 use noosphere::key::KeyStorage;
 use noosphere_core::context::{


### PR DESCRIPTION
This is needed because `release-please` doesn't understand that a dependency cycle via `dev-dependencies` is permitted by Cargo. One could reasonably argue that this cycle is bad and should be resolved, but it's only for the sake of sharing test helpers and for now this is the path of least resistance.