### PR TITLE
feat!: Disaster recovery via gateway

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -97,6 +97,27 @@ jobs:
           run_daemon: true
       - name: 'Run Rust native target tests'
         run: NOOSPHERE_LOG=deafening cargo test --features test-kubo,headers,performance
+
+  run-test-suite-linux-rocksdb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: 'Setup Rust'
+        run: |
+          curl -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: 'Install environment packages'
+        run: |
+          sudo apt-get update -qqy
+          sudo apt-get install jq protobuf-compiler cmake libclang-dev
+      - name: 'Install IPFS Kubo'
+        uses: ibnesayeed/setup-ipfs@master
+        with:
+          ipfs_version: v0.17.0
+          run_daemon: true
+      - name: 'Run Rust native target tests (RocksDB)'
+        run: NOOSPHERE_LOG=defeaning cargo test -p noosphere -p noosphere-storage --features rocksdb,test-kubo,performance
+
   run-test-suite-linux-c:
     runs-on: ubuntu-latest
     steps:
@@ -115,6 +136,7 @@ jobs:
       - name: 'Run C integration tests'
         run: |
           make run -C ./c/example
+
   run-test-suite-web-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,8 @@
     ]
   },
   "rust-analyzer.cargo.features": [
-    "test-kubo"
+    "test-kubo",
+    "helpers",
+    "performance"
   ]
 }

--- a/rust/noosphere-cli/src/native/commands/sphere/mod.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere/mod.rs
@@ -27,8 +27,11 @@ use noosphere::{
     key::KeyStorage,
     sphere::{SphereContextBuilder, SphereContextBuilderArtifacts},
 };
-use noosphere_core::context::{HasMutableSphereContext, SphereContext, SphereSync, SyncRecovery};
 use noosphere_core::{authority::Authorization, data::Did};
+use noosphere_core::{
+    context::{HasMutableSphereContext, SphereContext, SphereSync},
+    data::Mnemonic,
+};
 
 use tokio::sync::Mutex;
 use ucan::crypto::KeyMaterial;
@@ -36,7 +39,7 @@ use url::Url;
 
 /// Create a sphere, assigning authority to modify it to the given key
 /// (specified by nickname)
-pub async fn sphere_create(owner_key: &str, workspace: &mut Workspace) -> Result<()> {
+pub async fn sphere_create(owner_key: &str, workspace: &mut Workspace) -> Result<(Did, Mnemonic)> {
     workspace.ensure_sphere_uninitialized()?;
 
     let sphere_paths = SpherePaths::intialize(workspace.working_directory()).await?;
@@ -73,7 +76,7 @@ You will be asked to enter them if you ever need to transfer ownership of the sp
 
     workspace.initialize(sphere_paths)?;
 
-    Ok(())
+    Ok((sphere_identity.clone(), mnemonic.into()))
 }
 
 /// Join an existing sphere
@@ -144,7 +147,7 @@ Type or paste the code here and press enter:"#
             .await?
             .configure_gateway_url(Some(gateway_url))
             .await?;
-        sphere_context.sync(SyncRecovery::None).await?;
+        sphere_context.sync().await?;
     }
 
     workspace.initialize(sphere_paths)?;

--- a/rust/noosphere-cli/src/native/commands/sphere/sync.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere/sync.rs
@@ -1,6 +1,6 @@
 use crate::native::{content::Content, workspace::Workspace};
 use anyhow::{anyhow, Result};
-use noosphere_core::context::{SphereSync, SyncRecovery};
+use noosphere_core::context::{SphereSync, SyncExtent, SyncRecovery};
 
 /// Attempt to synchronize the local workspace with a configured gateway,
 /// optionally automatically retrying a fixed number of times in case a rebase
@@ -20,7 +20,9 @@ pub async fn sync(auto_retry: u32, render_depth: Option<u32>, workspace: &Worksp
 
     {
         let mut context = workspace.sphere_context().await?;
-        context.sync(SyncRecovery::Retry(auto_retry)).await?;
+        context
+            .sync_with_options(SyncExtent::FetchAndPush, SyncRecovery::Retry(auto_retry))
+            .await?;
     }
 
     info!("Sync complete, rendering updated workspace...");

--- a/rust/noosphere-cli/src/native/workspace.rs
+++ b/rust/noosphere-cli/src/native/workspace.rs
@@ -67,6 +67,13 @@ impl Workspace {
             .clone())
     }
 
+    /// Release the internally-held [SphereContext] (if any), causing its
+    /// related resources to be dropped (e.g., database locks). Accessing it
+    /// via [Workspace::sphere_context] will initialize it again.
+    pub fn release_sphere_context(&mut self) {
+        self.sphere_context = OnceCell::new();
+    }
+
     /// Get an owned referenced to the [SphereDb] that backs the local sphere.
     /// Note that this will initialize the [SphereContext] if it has not been
     /// already.

--- a/rust/noosphere-gateway/src/lib.rs
+++ b/rust/noosphere-gateway/src/lib.rs
@@ -1,26 +1,14 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 #[macro_use]
 extern crate tracing;
 
-#[cfg(not(target_arch = "wasm32"))]
 mod authority;
-
-#[cfg(not(target_arch = "wasm32"))]
-mod try_or_reset;
-
-#[cfg(not(target_arch = "wasm32"))]
+mod error;
 mod extractor;
-
-#[cfg(not(target_arch = "wasm32"))]
+mod gateway;
+mod handlers;
+mod try_or_reset;
 mod worker;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod handlers;
-
-#[cfg(not(target_arch = "wasm32"))]
-mod error;
-
-#[cfg(not(target_arch = "wasm32"))]
-mod gateway;
-
-#[cfg(not(target_arch = "wasm32"))]
 pub use gateway::*;

--- a/rust/noosphere-storage/src/implementation/indexed_db.rs
+++ b/rust/noosphere-storage/src/implementation/indexed_db.rs
@@ -1,6 +1,6 @@
 use crate::store::Store;
 use crate::{db::SPHERE_DB_STORE_NAMES, storage::Storage};
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use js_sys::Uint8Array;
 use rexie::{
@@ -196,7 +196,7 @@ impl Store for IndexedDbStore {
 }
 
 #[cfg(feature = "performance")]
-struct SpaceUsageError(Error);
+struct SpaceUsageError(anyhow::Error);
 
 #[cfg(feature = "performance")]
 impl From<JsValue> for SpaceUsageError {
@@ -210,7 +210,7 @@ impl From<JsValue> for SpaceUsageError {
 }
 
 #[cfg(feature = "performance")]
-impl From<SpaceUsageError> for Error {
+impl From<SpaceUsageError> for anyhow::Error {
     fn from(value: SpaceUsageError) -> Self {
         value.0
     }

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 subtext = { workspace = true }
 itertools = "0.11.0"
+rand = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { version = "~0.7", features = ["io"] }
 libipld-core = { workspace = true }

--- a/rust/noosphere/src/ffi/context.rs
+++ b/rust/noosphere/src/ffi/context.rs
@@ -26,19 +26,21 @@ use noosphere_core::context::{
 ///
 /// An opaque struct representing a sphere.
 pub struct NsSphere {
-    pub inner: PlatformSphereChannel,
+    pub(crate) inner: PlatformSphereChannel,
 }
 
 impl NsSphere {
-    pub fn inner(&self) -> &SphereCursor<Arc<SphereContext<PlatformStorage>>, PlatformStorage> {
+    pub(crate) fn inner(
+        &self,
+    ) -> &SphereCursor<Arc<SphereContext<PlatformStorage>>, PlatformStorage> {
         self.inner.immutable()
     }
 
-    pub fn inner_mut(&mut self) -> &mut Arc<Mutex<SphereContext<PlatformStorage>>> {
+    pub(crate) fn inner_mut(&mut self) -> &mut Arc<Mutex<SphereContext<PlatformStorage>>> {
         self.inner.mutable()
     }
 
-    pub fn to_channel(&self) -> PlatformSphereChannel {
+    pub(crate) fn to_channel(&self) -> PlatformSphereChannel {
         self.inner.clone()
     }
 }
@@ -56,11 +58,7 @@ pub struct NsSphereFile {
 }
 
 impl NsSphereFile {
-    pub fn inner(&self) -> &SphereFile<Pin<Box<dyn AsyncFileBody>>> {
-        &self.inner
-    }
-
-    pub fn inner_mut(&mut self) -> &mut SphereFile<Pin<Box<dyn AsyncFileBody>>> {
+    pub(crate) fn inner_mut(&mut self) -> &mut SphereFile<Pin<Box<dyn AsyncFileBody>>> {
         &mut self.inner
     }
 }

--- a/rust/noosphere/src/ffi/error.rs
+++ b/rust/noosphere/src/ffi/error.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use noosphere_core::error::NoosphereError;
 use safer_ffi::prelude::*;
 

--- a/rust/noosphere/src/ffi/headers.rs
+++ b/rust/noosphere/src/ffi/headers.rs
@@ -11,12 +11,8 @@ pub struct NsHeaders {
 }
 
 impl NsHeaders {
-    pub fn inner(&self) -> &Vec<(String, String)> {
+    pub(crate) fn inner(&self) -> &Vec<(String, String)> {
         &self.inner
-    }
-
-    pub fn inner_mut(&mut self) -> &mut Vec<(String, String)> {
-        &mut self.inner
     }
 }
 

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,5 +1,8 @@
 // TODO(getditto/safer_ffi#181): Re-enable this lint
-#![allow(clippy::incorrect_clone_impl_on_copy_type)]
+#![allow(clippy::incorrect_clone_impl_on_copy_type, non_snake_case)]
+
+//! This module defins a C FFI for Noosphere, suitable for cross-language
+//! embedding on many different targets
 
 mod authority;
 mod context;
@@ -20,9 +23,6 @@ pub use headers::*;
 pub use key::*;
 pub use petname::*;
 pub use sphere::*;
-
-///! This module contains FFI implementation for all C ABI-speaking language
-///! integrations.
 
 #[cfg(feature = "headers")]
 pub fn generate_headers() -> std::io::Result<()> {

--- a/rust/noosphere/src/ffi/noosphere.rs
+++ b/rust/noosphere/src/ffi/noosphere.rs
@@ -36,7 +36,7 @@ pub struct NsNoosphere {
 }
 
 impl NsNoosphere {
-    pub fn new(
+    pub(crate) fn new(
         global_storage_path: &str,
         sphere_storage_path: &str,
         gateway_api: Option<&Url>,
@@ -58,18 +58,14 @@ impl NsNoosphere {
         })
     }
 
-    pub fn async_runtime(&self) -> &TokioRuntime {
+    pub(crate) fn async_runtime(&self) -> &TokioRuntime {
         // NOTE: Unwrap is safe because we don't allow initializing
         // [NsNoosphere] with an empty [OnceCell]
         self.async_runtime.get().unwrap()
     }
 
-    pub fn inner(&self) -> &NoosphereContext {
+    pub(crate) fn inner(&self) -> &NoosphereContext {
         &self.inner
-    }
-
-    pub fn inner_mut(&mut self) -> &mut NoosphereContext {
-        &mut self.inner
     }
 }
 

--- a/rust/noosphere/src/ffi/tracing.rs
+++ b/rust/noosphere/src/ffi/tracing.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use noosphere_core::tracing::{initialize_tracing, NoosphereLog};
 use safer_ffi::prelude::*;
 
@@ -11,7 +13,7 @@ use safer_ffi::prelude::*;
 // representation that will be used via a specialty [`NS_ENUM`][3] macro.
 // However, this macro is built-for-purpose by Apple and Safer FFI has no
 // knowledge of it. So, using it would require specialized header generation
-// behavior for the Apple case, and that creates a lot of complexity and room
+// behaSyncRecoveryvior for the Apple case, and that creates a lot of complexity and room
 // for error on our part.
 //
 // TODO(#345): Add support for `NS_ENUM` and use a more compact representation

--- a/rust/noosphere/src/key/insecure.rs
+++ b/rust/noosphere/src/key/insecure.rs
@@ -35,6 +35,8 @@ pub struct InsecureKeyStorage {
 }
 
 impl InsecureKeyStorage {
+    /// Initialize a new [InsecureKeyStorage] at the provided path. Keys will be
+    /// stored in the clear on disk at the configured path.
     pub fn new(global_storage_path: &Path) -> Result<Self> {
         let storage_path = global_storage_path.join("keys");
 

--- a/rust/noosphere/src/key/web.rs
+++ b/rust/noosphere/src/key/web.rs
@@ -23,6 +23,10 @@ pub const INDEXEDDB_STORAGE_VERSION: u32 = 1;
 pub const STORE_NAME: &str = "keys";
 
 impl WebCryptoKeyStorage {
+    /// Initialize a new [WebCryptoKeyStorage] using the given name. This name
+    /// will correspond to an underlying IndexedDB database name, so
+    /// initializing the storage again using the same name will typically enable
+    /// cross-session persistance.
     pub async fn new(db_name: &str) -> Result<Self> {
         Self::configure(INDEXEDDB_STORAGE_VERSION, db_name, &[STORE_NAME]).await
     }

--- a/rust/noosphere/src/lib.rs
+++ b/rust/noosphere/src/lib.rs
@@ -1,3 +1,57 @@
+#![warn(missing_docs)]
+
+//! This crate is a high-level entrypoint for embedders of the Noosphere
+//! protocol. Embedders may use [NoosphereContext] to initialize a singleton
+//! that enables manaing spheres, including creating new ones and joining
+//! existing ones.
+//!
+//! ```rust,no_run
+//! # use noosphere::{
+//! #     NoosphereStorage, NoosphereSecurity, NoosphereNetwork, NoosphereContextConfiguration, NoosphereContext, sphere::SphereReceipt
+//! # };
+//! # use noosphere_core::{
+//! #     context::{
+//! #         HasMutableSphereContext, SphereContentWrite, SphereSync
+//! #     },
+//! #     data::ContentType
+//! # };
+//! # use url::Url;
+//! # use anyhow::Result;
+//! #
+//! # #[tokio::main]
+//! # pub async fn main() -> Result<()> {
+//! let noosphere = NoosphereContext::new(NoosphereContextConfiguration {
+//!     storage: NoosphereStorage::Scoped {
+//!         path: "/path/to/block/storage".into(),
+//!     },
+//!     security: NoosphereSecurity::Insecure {
+//!         path: "/path/to/key/storage".into(),
+//!     },
+//!     network: NoosphereNetwork::Http {
+//!         gateway_api: Some(Url::parse("http://example.com")?),
+//!         ipfs_gateway_url: None,
+//!     },
+//! })?;
+//!
+//! noosphere.create_key("my-key").await?;
+//!
+//! let SphereReceipt { identity, mnemonic } = noosphere.create_sphere("my-key").await?;
+//!     
+//! // identity is the sphere's DID
+//! // mnemonic is a recovery phrase that must be stored securely by the user
+//!
+//! let mut sphere_channel = noosphere.get_sphere_channel(&identity).await?;
+//! let sphere = sphere_channel.mutable();
+//!
+//! // Write something to the sphere's content space
+//! sphere.write("foo", &ContentType::Text, "bar".as_bytes(), None).await?;
+//! sphere.save(None).await?;
+//! // Sync the sphere with the network via a Noosphere gateway
+//! sphere.sync().await?;
+//! #    Ok(())
+//! # }
+//! ```
+
 #[macro_use]
 extern crate tracing;
 

--- a/rust/noosphere/src/platform.rs
+++ b/rust/noosphere/src/platform.rs
@@ -1,10 +1,12 @@
-///! Platform-specific types and bindings
-///! Platforms will vary in capabilities for things like block storage and
-///! secure key management. This module lays out the concrete strategies we will
-///! use on a per-platform basis.
+//! Platform-specific types and bindings
+//! Platforms will vary in capabilities for things like block storage and
+//! secure key management. This module lays out the concrete strategies we will
+//! use on a per-platform basis.
 
 #[cfg(apple)]
 mod inner {
+    #![allow(missing_docs)]
+
     use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
     use crate::key::InsecureKeyStorage;
@@ -49,6 +51,8 @@ mod inner {
 
 #[cfg(wasm)]
 mod inner {
+    #![allow(missing_docs)]
+
     use crate::key::WebCryptoKeyStorage;
 
     use std::sync::Arc;
@@ -101,7 +105,10 @@ mod inner {
     use crate::key::InsecureKeyStorage;
     use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
+    /// The default key type produced by the [crate::key::KeyStorage]
+    /// implementation in use for this platform
     pub type PlatformKeyMaterial = Ed25519KeyMaterial;
+    /// The default [crate::key::KeyStorage] in use for this platform
     pub type PlatformKeyStorage = InsecureKeyStorage;
 
     #[cfg(sled)]
@@ -109,6 +116,8 @@ mod inner {
     #[cfg(rocksdb)]
     pub(crate) type PrimitiveStorage = noosphere_storage::RocksDbStorage;
 
+    /// The default backing [noosphere_storage::Storage] in use for this
+    /// platform
     #[cfg(not(ipfs_storage))]
     pub type PlatformStorage = PrimitiveStorage;
     #[cfg(ipfs_storage)]
@@ -148,8 +157,14 @@ use crate::sphere::SphereChannel;
 // NOTE: We may someday define the 3rd and 4th terms of this type differently on
 // web, where `Arc` and `Mutex` are currently overkill for our needs and may be
 // substituted for `Rc` and `RwLock`, respectively.
-pub type PlatformSphereContext = SphereCursor<Arc<SphereContext<PlatformStorage>>, PlatformStorage>;
-pub type PlatformMutableSphereContext = Arc<Mutex<SphereContext<PlatformStorage>>>;
 
+/// A type alias for the kind of [noosphere_core::context::HasSphereContext] in use
+/// by the Noosphere implementation on the current platform
+pub type PlatformSphereContext = SphereCursor<Arc<SphereContext<PlatformStorage>>, PlatformStorage>;
+/// A type alias for the kind of [noosphere_core::context::HasMutableSphereContext] in use
+/// by the Noosphere implementation on the current platform
+pub type PlatformMutableSphereContext = Arc<Mutex<SphereContext<PlatformStorage>>>;
+/// A type alias for the kind of [SphereChannel] in use by the Noosphere
+/// implementation on the current platform
 pub type PlatformSphereChannel =
     SphereChannel<PlatformStorage, PlatformSphereContext, PlatformMutableSphereContext>;

--- a/rust/noosphere/src/sphere/builder/create.rs
+++ b/rust/noosphere/src/sphere/builder/create.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use crate::{
+    key::KeyStorage,
+    sphere::{generate_db, SphereContextBuilder, SphereContextBuilderArtifacts},
+};
+use anyhow::{anyhow, Result};
+use cid::Cid;
+use noosphere_core::{
+    authority::Author,
+    context::{SphereContext, SphereContextKey, AUTHORIZATION, IDENTITY, USER_KEY_NAME},
+    view::Sphere,
+};
+use noosphere_storage::{KeyValueStore, MemoryStore};
+
+pub async fn create_a_sphere(
+    builder: SphereContextBuilder,
+) -> Result<SphereContextBuilderArtifacts> {
+    let storage_path = builder.require_storage_path()?.to_owned();
+    let key_storage = builder
+        .key_storage
+        .as_ref()
+        .ok_or_else(|| anyhow!("No key storage configured!"))?;
+    let key_name = builder
+        .key_name
+        .as_ref()
+        .ok_or_else(|| anyhow!("No key name configured!"))?;
+    if builder.authorization.is_some() {
+        warn!("Creating a new sphere; the configured authorization will be ignored!");
+    }
+
+    let owner_key: SphereContextKey = Arc::new(Box::new(key_storage.require_key(key_name).await?));
+    let owner_did = owner_key.get_did().await?;
+
+    // NOTE: We generate the sphere in-memory because we don't know where to
+    // store it on disk until we have its ID
+    let mut memory_store = MemoryStore::default();
+    let (sphere, authorization, mnemonic) = Sphere::generate(&owner_did, &mut memory_store)
+        .await
+        .unwrap();
+
+    let sphere_did = sphere.get_identity().await.unwrap();
+    let mut db = generate_db(
+        storage_path,
+        builder.scoped_storage_layout,
+        Some(sphere_did.clone()),
+        builder.ipfs_gateway_url,
+    )
+    .await?;
+
+    db.persist(&memory_store).await?;
+
+    db.set_version(&sphere_did, sphere.cid()).await?;
+
+    db.set_key(IDENTITY, &sphere_did).await?;
+    db.set_key(USER_KEY_NAME, key_name.to_owned()).await?;
+    db.set_key(AUTHORIZATION, Cid::try_from(&authorization)?)
+        .await?;
+
+    let mut context = SphereContext::new(
+        sphere_did,
+        Author {
+            key: owner_key,
+            authorization: Some(authorization),
+        },
+        db,
+        None,
+    )
+    .await?;
+
+    if builder.gateway_api.is_some() {
+        context
+            .configure_gateway_url(builder.gateway_api.as_ref())
+            .await?;
+    }
+
+    Ok(SphereContextBuilderArtifacts::SphereCreated { context, mnemonic })
+}

--- a/rust/noosphere/src/sphere/builder/join.rs
+++ b/rust/noosphere/src/sphere/builder/join.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use cid::Cid;
+use noosphere_core::{
+    authority::Author,
+    context::{SphereContext, SphereContextKey, AUTHORIZATION, IDENTITY, USER_KEY_NAME},
+    data::Did,
+};
+use noosphere_storage::KeyValueStore;
+
+use crate::{
+    key::KeyStorage,
+    sphere::{generate_db, SphereContextBuilder, SphereContextBuilderArtifacts},
+};
+
+pub async fn join_a_sphere(
+    builder: SphereContextBuilder,
+    sphere_identity: Did,
+) -> Result<SphereContextBuilderArtifacts> {
+    let key_storage = builder
+        .key_storage
+        .as_ref()
+        .ok_or_else(|| anyhow!("No key storage configured!"))?;
+    let key_name = builder
+        .key_name
+        .as_ref()
+        .ok_or_else(|| anyhow!("No key name configured!"))?;
+    let storage_path = builder.require_storage_path()?.to_owned();
+
+    let user_key: SphereContextKey = Arc::new(Box::new(key_storage.require_key(key_name).await?));
+
+    let mut db = generate_db(
+        storage_path,
+        builder.scoped_storage_layout,
+        Some(sphere_identity.clone()),
+        builder.ipfs_gateway_url.clone(),
+    )
+    .await?;
+
+    db.set_key(IDENTITY, &sphere_identity).await?;
+    db.set_key(USER_KEY_NAME, key_name.to_owned()).await?;
+
+    if let Some(authorization) = &builder.authorization {
+        db.set_key(AUTHORIZATION, Cid::try_from(authorization)?)
+            .await?;
+    }
+
+    debug!("Initializing context...");
+
+    let mut context = SphereContext::new(
+        sphere_identity,
+        Author {
+            key: user_key,
+            authorization: builder.authorization.clone(),
+        },
+        db,
+        None,
+    )
+    .await?;
+
+    debug!("Configuring gateway URL...");
+
+    if builder.gateway_api.is_some() {
+        context
+            .configure_gateway_url(builder.gateway_api.as_ref())
+            .await?;
+    }
+
+    Ok(SphereContextBuilderArtifacts::SphereOpened(context))
+}

--- a/rust/noosphere/src/sphere/builder/open.rs
+++ b/rust/noosphere/src/sphere/builder/open.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use noosphere_core::{
+    authority::{Author, Authorization},
+    context::{SphereContext, SphereContextKey, AUTHORIZATION, IDENTITY, USER_KEY_NAME},
+    data::Did,
+};
+use noosphere_storage::KeyValueStore;
+
+use crate::{
+    key::KeyStorage,
+    sphere::{generate_db, SphereContextBuilder, SphereContextBuilderArtifacts},
+};
+
+pub async fn open_a_sphere(
+    builder: SphereContextBuilder,
+    sphere_identity: Option<Did>,
+) -> Result<SphereContextBuilderArtifacts> {
+    let storage_path = builder.require_storage_path()?.to_owned();
+    let db = generate_db(
+        storage_path,
+        builder.scoped_storage_layout,
+        sphere_identity,
+        builder.ipfs_gateway_url,
+    )
+    .await?;
+
+    let user_key_name: String = db.require_key(USER_KEY_NAME).await?;
+    let authorization = db.get_key(AUTHORIZATION).await?.map(Authorization::Cid);
+
+    let author = match builder.key_storage {
+        Some(key_storage) => {
+            let key: SphereContextKey =
+                Arc::new(Box::new(key_storage.require_key(&user_key_name).await?));
+
+            Author { key, authorization }
+        }
+        _ => return Err(anyhow!("Unable to resolve sphere author")),
+    };
+
+    let sphere_identity = db.require_key(IDENTITY).await?;
+    let mut context = SphereContext::new(sphere_identity, author, db, None).await?;
+
+    if builder.gateway_api.is_some() {
+        context
+            .configure_gateway_url(builder.gateway_api.as_ref())
+            .await?;
+    }
+
+    Ok(SphereContextBuilderArtifacts::SphereOpened(context))
+}

--- a/rust/noosphere/src/sphere/builder/recover.rs
+++ b/rust/noosphere/src/sphere/builder/recover.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use cid::Cid;
+use noosphere_core::{
+    authority::{generate_capability, generate_ed25519_key, Author, Authorization, SphereAbility},
+    context::{
+        SphereAuthorityRead, SphereContext, SphereSync, SyncExtent, SyncRecovery, AUTHORIZATION,
+        GATEWAY_URL, IDENTITY, USER_KEY_NAME,
+    },
+    data::Did,
+};
+use noosphere_storage::KeyValueStore;
+use tokio::sync::Mutex;
+use ucan::{builder::UcanBuilder, crypto::KeyMaterial};
+
+use crate::{
+    key::KeyStorage,
+    sphere::{generate_db, SphereContextBuilder, SphereContextBuilderArtifacts},
+};
+
+pub async fn recover_a_sphere(
+    builder: SphereContextBuilder,
+    sphere_identity: Did,
+) -> Result<SphereContextBuilderArtifacts> {
+    // 1. Check to make sure the local key is available
+
+    let key_storage = builder.require_key_storage()?;
+    let local_key_name = builder.require_key_name()?.to_owned();
+    let local_key_did = Did(key_storage
+        .require_key(&local_key_name)
+        .await?
+        .get_did()
+        .await?);
+
+    // 2. Backup existing database, moving it to a new location
+    // NOTE: Database backups not available on wasm targets
+
+    let storage_path = builder.require_storage_path()?.to_owned();
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use crate::storage::StorageLayout;
+        use rand::Rng;
+        use std::path::PathBuf;
+
+        let storage_layout: StorageLayout = (
+            storage_path.clone(),
+            builder.scoped_storage_layout,
+            Some(sphere_identity.clone()),
+        )
+            .try_into()?;
+
+        let database_root: PathBuf = storage_layout.into();
+
+        debug!(?database_root);
+
+        if database_root.exists() {
+            let timestamp = std::time::SystemTime::UNIX_EPOCH.elapsed()?;
+            let nonce = rand::thread_rng().gen::<u32>();
+            let backup_id = format!("backup.{}-{}", timestamp.as_nanos(), nonce);
+
+            let mut backup_root = database_root.clone();
+            backup_root.set_extension(backup_id);
+
+            info!("Backing up existing database...");
+
+            tokio::fs::rename(database_root, backup_root).await?;
+        }
+    }
+
+    // 3. Generate a new, one-time authorization with the mnemonic
+
+    let one_time_key: Arc<Box<dyn KeyMaterial>> = Arc::new(Box::new(generate_ed25519_key()));
+    let one_time_key_identity = one_time_key.get_did().await?;
+    let root_key = builder.require_mnemonic()?.to_credential()?;
+
+    let authorization = Authorization::Ucan(
+        UcanBuilder::default()
+            .issued_by(&root_key)
+            .for_audience(&one_time_key_identity)
+            .claiming_capability(&generate_capability(&sphere_identity, SphereAbility::Fetch))
+            .with_lifetime(60 * 60)
+            .with_nonce()
+            .build()?
+            .sign()
+            .await?,
+    );
+
+    // 4. Generate a new DB for the sphere
+
+    let mut db = generate_db(
+        storage_path,
+        builder.scoped_storage_layout,
+        Some(sphere_identity.clone()),
+        builder.ipfs_gateway_url.clone(),
+    )
+    .await?;
+
+    // 5. Attempt to sync (fetch-only) from the gateway
+
+    db.set_key(IDENTITY, &sphere_identity).await?;
+    db.set_key(GATEWAY_URL, builder.require_gateway_api()?)
+        .await?;
+
+    let author = Author {
+        key: one_time_key,
+        authorization: Some(authorization),
+    };
+
+    let mut context = Arc::new(Mutex::new(
+        SphereContext::new(sphere_identity.clone(), author, db.clone(), None).await?,
+    ));
+    context
+        .sync_with_options(SyncExtent::FetchOnly, SyncRecovery::None)
+        .await?;
+
+    // TODO: Should probably revoke the authorization of the one-time
+    // key at the end for good measure.
+
+    // 6. Recover the original authorization
+
+    let authorization = context
+        .get_authorization(&local_key_did)
+        .await?
+        .ok_or_else(|| anyhow!("No authorization for key '{}' found!", local_key_name))?;
+
+    db.set_key(USER_KEY_NAME, local_key_name.to_owned()).await?;
+    db.set_key(AUTHORIZATION, Cid::try_from(&authorization)?)
+        .await?;
+
+    // 7. Initialize the recovered sphere using the intended author
+
+    let local_key: Arc<Box<dyn KeyMaterial>> =
+        Arc::new(Box::new(key_storage.require_key(&local_key_name).await?));
+    let author = Author {
+        key: local_key,
+        authorization: Some(authorization),
+    };
+
+    let context = SphereContext::new(sphere_identity, author, db, None).await?;
+
+    Ok(SphereContextBuilderArtifacts::SphereOpened(context))
+}

--- a/rust/noosphere/src/sphere/channel.rs
+++ b/rust/noosphere/src/sphere/channel.rs
@@ -31,6 +31,8 @@ where
     Ci: HasSphereContext<S>,
     Cm: HasMutableSphereContext<S>,
 {
+    /// Initialize a new [SphereChannel] by providing it with a
+    /// [HasSphereContext] and [HasMutableSphereContext] over the same sphere.
     pub fn new(immutable: Ci, mutable: Cm) -> Self {
         Self {
             immutable,

--- a/rust/noosphere/src/sphere/mod.rs
+++ b/rust/noosphere/src/sphere/mod.rs
@@ -1,3 +1,6 @@
+//! Constructs that describe high-level operations related to spheres, such
+//! as creation, joining and recovery.
+
 mod builder;
 mod channel;
 mod receipt;

--- a/rust/noosphere/src/sphere/receipt.rs
+++ b/rust/noosphere/src/sphere/receipt.rs
@@ -1,6 +1,12 @@
-use noosphere_core::data::Did;
+use noosphere_core::data::{Did, Mnemonic};
 
+/// The result of creating a sphere is a [SphereReceipt], which reports both the
+/// sphere identity (it's [Did]) and a [Mnemonic] which must be saved in some
+/// secure storage medium on the side (it will not be recorded in the user's
+/// sphere data).
 pub struct SphereReceipt {
+    /// The identity of the newly created sphere
     pub identity: Did,
-    pub mnemonic: String,
+    /// The recovery [Mnemonic] of the newly created sphere
+    pub mnemonic: Mnemonic,
 }

--- a/rust/noosphere/src/wasm/mod.rs
+++ b/rust/noosphere/src/wasm/mod.rs
@@ -1,3 +1,8 @@
+#![allow(missing_docs)]
+
+//! This module defines a [wasm-bindgen]-based FFI for `wasm32-unknown-unknown`
+//! targets
+
 mod file;
 mod fs;
 mod noosphere;

--- a/rust/noosphere/src/wasm/noosphere.rs
+++ b/rust/noosphere/src/wasm/noosphere.rs
@@ -125,7 +125,7 @@ impl NoosphereContext {
 
         Ok(SphereReceipt {
             identity: receipt.identity.into(),
-            mnemonic: receipt.mnemonic,
+            mnemonic: receipt.mnemonic.into(),
         })
     }
 

--- a/rust/noosphere/tests/distributed_stress.rs
+++ b/rust/noosphere/tests/distributed_stress.rs
@@ -14,7 +14,7 @@ mod latency {
     use noosphere_core::{
         context::{
             HasMutableSphereContext, SphereContentRead, SphereContentWrite, SpherePetnameWrite,
-            SphereSync, SyncRecovery,
+            SphereSync,
         },
         data::ContentType,
         tracing::initialize_tracing,
@@ -66,7 +66,7 @@ mod latency {
                     ctx.save(None).await?;
                 }
 
-                Ok(ctx.sync(SyncRecovery::Retry(3)).await?)
+                Ok(ctx.sync().await?)
             })
             .await?;
 
@@ -100,20 +100,20 @@ mod latency {
                     ctx.save(None).await?;
                 }
 
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
 
                 ctx.set_petname("peer2", Some(peer_2_identity)).await?;
 
                 ctx.save(None).await?;
 
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
 
                 // TODO(#606): Implement this part of the test when we "fix" latency asymmetry between
                 // name system and syndication workers. We should be able to test traversing to a peer
                 // after a huge update as been added to the name system.
                 // wait(1).await;
 
-                // ctx.sync(SyncRecovery::Retry(3)).await?;
+                // ctx.sync().await?;
 
                 // wait(1).await;
 
@@ -142,7 +142,7 @@ mod multiplayer {
     use noosphere_core::{
         context::{
             HasMutableSphereContext, SphereAuthorityWrite, SphereContentWrite, SpherePetnameWrite,
-            SphereSync, SyncRecovery,
+            SphereSync,
         },
         data::Did,
         tracing::initialize_tracing,
@@ -190,7 +190,7 @@ mod multiplayer {
                 .await?;
 
                 ctx.save(None).await?;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
 
                 Ok(())
             })
@@ -205,9 +205,9 @@ mod multiplayer {
                     ctx.set_petname("peer3-of-peer2", Some(sphere_3_id)).await?;
                     ctx.set_petname("peer4", Some(sphere_4_id)).await?;
                     ctx.save(None).await?;
-                    ctx.sync(SyncRecovery::Retry(3)).await?;
+                    ctx.sync().await?;
                     wait(1).await;
-                    ctx.sync(SyncRecovery::Retry(3)).await?;
+                    ctx.sync().await?;
                     Ok(())
                 })
                 .await?;
@@ -221,9 +221,9 @@ mod multiplayer {
                     ctx.set_petname("peer2", Some(sphere_2_id)).await?;
                     ctx.set_petname("peer3", Some(sphere_3_id)).await?;
                     ctx.save(None).await?;
-                    ctx.sync(SyncRecovery::Retry(3)).await?;
+                    ctx.sync().await?;
                     wait(1).await;
-                    ctx.sync(SyncRecovery::Retry(3)).await?;
+                    ctx.sync().await?;
                     Ok(())
                 })
                 .await?;
@@ -247,7 +247,7 @@ mod multiplayer {
             .spawn(move |mut ctx| async move {
                 let authorization = ctx.authorize("cli", &Did(cli_id)).await?;
                 ctx.save(None).await?;
-                let version = ctx.sync(SyncRecovery::Retry(3)).await?;
+                let version = ctx.sync().await?;
                 wait(1).await;
                 Ok((authorization, version))
             })
@@ -296,10 +296,10 @@ mod multiplayer {
                 .await?;
                 ctx.set_petname("peer5", Some(sphere_5_id)).await?;
                 ctx.save(None).await?;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
                 wait(1).await;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
+                ctx.sync().await?;
 
                 Ok(())
             })
@@ -310,9 +310,9 @@ mod multiplayer {
             .spawn(move |mut ctx| async move {
                 ctx.set_petname("peer4-of-peer3", Some(sphere_4_id)).await?;
                 ctx.save(None).await?;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
                 wait(1).await;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
 
                 Ok(())
             })
@@ -325,9 +325,9 @@ mod multiplayer {
                     .await?;
                 ctx.set_petname("peer4", None).await?;
                 ctx.save(None).await?;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
                 wait(1).await;
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
 
                 Ok(())
             })
@@ -353,9 +353,9 @@ mod multiplayer {
                 ctx.remove("never-seen").await?;
                 ctx.save(None).await?;
 
-                ctx.sync(SyncRecovery::Retry(3)).await?;
+                ctx.sync().await?;
                 wait(2).await;
-                let version = ctx.sync(SyncRecovery::Retry(3)).await?;
+                let version = ctx.sync().await?;
 
                 Ok(version)
             })

--- a/swift/Sources/SwiftNoosphere/Noosphere.swift
+++ b/swift/Sources/SwiftNoosphere/Noosphere.swift
@@ -242,3 +242,23 @@ public func nsSphereAuthorityAuthorizationIdentity(_ noosphere: OpaquePointer!, 
         handler.contents(error, identity)
     }
 }
+
+
+public typealias NsSphereRecoverHandler = (OpaquePointer?) -> ()
+
+/// See: ns_sphere_recover
+public func nsSphereRecover(_ noosphere: OpaquePointer!, _ sphereIdentity: UnsafePointer<CChar>!, _ localKeyName: UnsafePointer<CChar>!, _ mnemonic: UnsafePointer<CChar>!, handler: @escaping NsSphereRecoverHandler) {
+    let context = Unmanaged.passRetained(Box(contents: handler)).toOpaque()
+
+    ns_sphere_recover(noosphere, sphereIdentity, localKeyName, mnemonic, context) {
+        (context, error) in
+
+        guard let context = context else {
+            return
+        }
+
+        let handler = Unmanaged<Box<NsSphereRecoverHandler>>.fromOpaque(context).takeRetainedValue()
+
+        handler.contents(error)
+    }
+}


### PR DESCRIPTION
This change proposes a disaster recovery mechanism where an embedding Noosphere client may take advantage of an existing gateway to restore a user's local sphere data.

In order to recover data from a gateway, the following information is needed:
- URL of the gateway
- The DID of the user's sphere
- The name of an authorized device key
- The user's recovery mnemonic

The Noosphere library then generates an ephemeral, one-time-use authorized credential and uses it to perform the fetch half of a gateway sync. After the sync completes, it ensures that the local storage layer is properly configured to use the original device key.