### PR TITLE
chore: use tokio::sync::OnceCell instead of async_once_cell::OnceCell.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,7 +3571,6 @@ name = "noosphere-collections"
 version = "0.6.3"
 dependencies = [
  "anyhow",
- "async-once-cell",
  "async-recursion",
  "async-stream",
  "byteorder",

--- a/rust/noosphere-collections/Cargo.toml
+++ b/rust/noosphere-collections/Cargo.toml
@@ -24,8 +24,6 @@ forest_hash_utils = "0.1.0"
 serde = { workspace = true }
 serde_bytes = "0.11"
 byteorder = "^1.4"
-# NOTE: async-once-cell 0.4.0 shipped unstable feature usage
-async-once-cell = "0.4"
 async-recursion = "^1"
 libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }

--- a/rust/noosphere-collections/src/hamt/pointer.rs
+++ b/rust/noosphere-collections/src/hamt/pointer.rs
@@ -7,11 +7,11 @@ use anyhow::{anyhow, Result};
 use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
 
-use async_once_cell::OnceCell;
 use cid::Cid;
 use libipld_core::ipld::Ipld;
 use serde::de::{self, DeserializeOwned};
 use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
+use tokio::sync::OnceCell;
 
 use forest_hash_utils::Hash;
 


### PR DESCRIPTION
Replaces/Fixes #593