### PR TITLE
feat: History compaction for spheres and gateways

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,6 @@
   },
   "rust-analyzer.cargo.features": [
     "test-kubo",
-    "helpers",
-    "performance"
+    "helpers"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3635,6 +3635,7 @@ dependencies = [
  "libipld-cbor",
  "libipld-core",
  "mime_guess",
+ "noosphere-common",
  "noosphere-core",
  "noosphere-ipfs",
  "noosphere-ns",

--- a/rust/noosphere-core/src/view/mutation.rs
+++ b/rust/noosphere-core/src/view/mutation.rs
@@ -194,32 +194,14 @@ impl SphereMutation {
 
     /// Consume a [SphereMutation], appending its changes to this one
     pub fn append(&mut self, other: SphereMutation) {
-        self.content.changes = append_changes(
-            std::mem::take(&mut self.content.changes),
-            other.content.changes,
-        );
-
-        self.identities.changes = append_changes(
-            std::mem::take(&mut self.identities.changes),
-            other.identities.changes,
-        );
-
-        self.delegations.changes = append_changes(
-            std::mem::take(&mut self.delegations.changes),
-            other.delegations.changes,
-        );
-
-        self.revocations.changes = append_changes(
-            std::mem::take(&mut self.revocations.changes),
-            other.revocations.changes,
-        );
+        append_changes(&mut self.content.changes, other.content.changes);
+        append_changes(&mut self.identities.changes, other.identities.changes);
+        append_changes(&mut self.delegations.changes, other.delegations.changes);
+        append_changes(&mut self.revocations.changes, other.revocations.changes);
     }
 }
 
-fn append_changes<K, V>(
-    mut destination: Vec<MapOperation<K, V>>,
-    source: Vec<MapOperation<K, V>>,
-) -> Vec<MapOperation<K, V>>
+fn append_changes<K, V>(destination: &mut Vec<MapOperation<K, V>>, source: Vec<MapOperation<K, V>>)
 where
     K: VersionedMapKey,
     V: VersionedMapValue,
@@ -241,8 +223,6 @@ where
 
         destination.push(change);
     }
-
-    destination
 }
 
 /// A generalized expression of a mutation to a [VersionedMapIpld]

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -1556,15 +1556,11 @@ mod tests {
         authorization: &Authorization,
         store: &mut Storage,
         (change_key, change_memo): (&str, &MemoIpld),
-    ) -> anyhow::Result<Link<MemoIpld>> {
+    ) -> Result<Link<MemoIpld>> {
         let mut mutation = SphereMutation::new(author_did);
         mutation.content_mut().set(
             &change_key.into(),
-            &store
-                .save::<DagCborCodec, _>(change_memo)
-                .await
-                .unwrap()
-                .into(),
+            &store.save::<DagCborCodec, _>(change_memo).await?.into(),
         );
 
         let mut base_revision = Sphere::apply_mutation_with_cid(base_cid, &mutation, store).await?;

--- a/rust/noosphere-core/src/view/sphere.rs
+++ b/rust/noosphere-core/src/view/sphere.rs
@@ -17,7 +17,7 @@ use ucan::{
 use crate::{
     authority::{
         ed25519_key_to_mnemonic, generate_capability, generate_ed25519_key, restore_ed25519_key,
-        Authorization, SphereAbility, SPHERE_SEMANTICS, SUPPORTED_KEYS,
+        Author, Authorization, SphereAbility, SPHERE_SEMANTICS, SUPPORTED_KEYS,
     },
     data::{
         Bundle, ChangelogIpld, ContentType, DelegationIpld, Did, Header, IdentityIpld, Link,
@@ -534,7 +534,7 @@ impl<S: BlockStore> Sphere<S> {
     pub async fn hydrate_timeslice<'a>(timeslice: &Timeslice<'a, S>) -> Result<()> {
         let items = timeslice.to_chronological().await?;
 
-        for (cid, _) in items {
+        for cid in items {
             Sphere::at(&cid, timeslice.timeline.store).hydrate().await?;
         }
 
@@ -580,6 +580,47 @@ impl<S: BlockStore> Sphere<S> {
         Ok(())
     }
 
+    /// Compact sphere history through a given version, producing a single
+    /// combined history that reflects all of the changes of the intermediate
+    /// versions. The given history version must have a parent version to base
+    /// the compacted history on top of. The new compacted history will be
+    /// signed by the given author (authorship of the intermediate versions will
+    /// be lost).
+    pub async fn compact<K>(
+        &self,
+        until: &Link<MemoIpld>,
+        author: &Author<K>,
+    ) -> Result<Link<MemoIpld>>
+    where
+        K: KeyMaterial + Clone + 'static,
+    {
+        let parent_sphere =
+            if let Some(parent_sphere) = Sphere::at(until, &self.store).get_parent().await? {
+                parent_sphere
+            } else {
+                return Err(anyhow!(
+                    "Cannot compact history; compound history must must have ancestral base"
+                ));
+            };
+
+        let timeline = Timeline::new(&self.store);
+        let timeslice = timeline.slice(&self.cid, Some(until)).include_past();
+
+        let history_to_compact = timeslice.to_chronological().await?;
+        let mut compact_mutation = SphereMutation::new(&author.did().await?);
+
+        for link in history_to_compact {
+            let mutation = Sphere::at(&link, &self.store).derive_mutation().await?;
+            compact_mutation.append(mutation);
+        }
+
+        let mut revision = parent_sphere.apply_mutation(&compact_mutation).await?;
+
+        revision
+            .sign(&author.key, author.authorization.as_ref())
+            .await
+    }
+
     /// Attempt to linearize the canonical history of the sphere by re-basing
     /// the history onto a branch with an implicitly common lineage.
     pub async fn rebase<Credential: KeyMaterial>(
@@ -600,7 +641,7 @@ impl<S: BlockStore> Sphere<S> {
 
         let mut next_base = new_base.clone();
 
-        for (cid, _) in rebase_revisions.iter() {
+        for cid in rebase_revisions.iter() {
             let mut revision = Sphere::rebase_version(cid, &next_base, &mut store).await?;
             next_base = revision.sign(credential, authorization).await?;
         }
@@ -1025,6 +1066,8 @@ mod tests {
     use crate::{
         authority::{generate_ed25519_key, Authorization, SphereAbility},
         data::{Bundle, DelegationIpld, IdentityIpld, Link, MemoIpld, RevocationIpld},
+        helpers::make_valid_link_record,
+        tracing::initialize_tracing,
         view::{Sphere, SphereMutation, Timeline, SPHERE_LIFETIME},
     };
     use noosphere_storage::{BlockStore, MemoryStore, Store, UcanStore};
@@ -1394,7 +1437,7 @@ mod tests {
         let timeslice = timeline.slice(sphere.cid(), None);
         let items = timeslice.to_chronological().await.unwrap();
 
-        for (cid, _) in items {
+        for cid in items {
             Sphere::at(&cid, &other_store).hydrate().await.unwrap();
         }
 
@@ -1433,7 +1476,7 @@ mod tests {
         let timeslice = timeline.slice(sphere.cid(), None);
         let items = timeslice.to_chronological().await.unwrap();
 
-        for (cid, _) in items {
+        for cid in items {
             Sphere::at(&cid, &other_store).hydrate().await.unwrap();
         }
 
@@ -1499,11 +1542,34 @@ mod tests {
         let timeslice = timeline.slice(sphere.cid(), None);
         let items = timeslice.to_chronological().await.unwrap();
 
-        for (cid, _) in items {
+        for cid in items {
             Sphere::at(&cid, &other_store).hydrate().await.unwrap();
         }
 
         store.expect_replica_in(&other_store).await.unwrap();
+    }
+
+    async fn make_content_revision<Credential: KeyMaterial, Storage: Store>(
+        base_cid: &Link<MemoIpld>,
+        author_did: &str,
+        credential: &Credential,
+        authorization: &Authorization,
+        store: &mut Storage,
+        (change_key, change_memo): (&str, &MemoIpld),
+    ) -> anyhow::Result<Link<MemoIpld>> {
+        let mut mutation = SphereMutation::new(author_did);
+        mutation.content_mut().set(
+            &change_key.into(),
+            &store
+                .save::<DagCborCodec, _>(change_memo)
+                .await
+                .unwrap()
+                .into(),
+        );
+
+        let mut base_revision = Sphere::apply_mutation_with_cid(base_cid, &mutation, store).await?;
+
+        base_revision.sign(credential, Some(authorization)).await
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -1513,30 +1579,6 @@ mod tests {
         let owner_key = generate_ed25519_key();
         let owner_did = owner_key.get_did().await.unwrap();
 
-        async fn make_revision<Credential: KeyMaterial, Storage: Store>(
-            base_cid: &Link<MemoIpld>,
-            author_did: &str,
-            credential: &Credential,
-            authorization: &Authorization,
-            store: &mut Storage,
-            (change_key, change_memo): (&str, &MemoIpld),
-        ) -> anyhow::Result<Link<MemoIpld>> {
-            let mut mutation = SphereMutation::new(author_did);
-            mutation.content_mut().set(
-                &change_key.into(),
-                &store
-                    .save::<DagCborCodec, _>(change_memo)
-                    .await
-                    .unwrap()
-                    .into(),
-            );
-
-            let mut base_revision =
-                Sphere::apply_mutation_with_cid(base_cid, &mutation, store).await?;
-
-            base_revision.sign(credential, Some(authorization)).await
-        }
-
         let foo_memo = MemoIpld::for_body(&mut store, b"foo").await.unwrap();
         let bar_memo = MemoIpld::for_body(&mut store, b"bar").await.unwrap();
         let baz_memo = MemoIpld::for_body(&mut store, b"baz").await.unwrap();
@@ -1545,7 +1587,7 @@ mod tests {
 
         let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut store).await.unwrap();
 
-        let base_cid = make_revision(
+        let base_cid = make_content_revision(
             sphere.cid(),
             &owner_did,
             &owner_key,
@@ -1558,7 +1600,7 @@ mod tests {
 
         let mut external_store = store.fork().await;
 
-        let external_cid_a = make_revision(
+        let external_cid_a = make_content_revision(
             &base_cid,
             &owner_did,
             &owner_key,
@@ -1569,7 +1611,7 @@ mod tests {
         .await
         .unwrap();
 
-        let external_cid_b = make_revision(
+        let external_cid_b = make_content_revision(
             &external_cid_a,
             &owner_did,
             &owner_key,
@@ -1587,7 +1629,7 @@ mod tests {
         .await
         .unwrap();
 
-        let local_cid_a = make_revision(
+        let local_cid_a = make_content_revision(
             &base_cid,
             &owner_did,
             &owner_key,
@@ -1598,7 +1640,7 @@ mod tests {
         .await
         .unwrap();
 
-        let local_cid_b = make_revision(
+        let local_cid_b = make_content_revision(
             &local_cid_a,
             &owner_did,
             &owner_key,
@@ -1617,5 +1659,217 @@ mod tests {
             .rebase(&base_cid, &external_cid_b, &owner_key, Some(&authorization))
             .await
             .unwrap();
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_compacts_basic_history_into_a_single_revision() -> Result<()> {
+        let mut store = MemoryStore::default();
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await?;
+
+        let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut store).await?;
+
+        let base = sphere.cid().clone();
+        let mut long_history_version = base.clone();
+
+        for content in ["foo", "bar", "baz"] {
+            let memo = MemoIpld::for_body(&mut store, content.as_bytes()).await?;
+            long_history_version = make_content_revision(
+                &long_history_version,
+                &owner_did,
+                &owner_key,
+                &authorization,
+                &mut store,
+                (content, &memo),
+            )
+            .await?;
+        }
+
+        let long_history_sphere = Sphere::at(&long_history_version, &store);
+        let mut until_sphere = long_history_sphere.clone();
+
+        for _ in 0..2 {
+            until_sphere = until_sphere.get_parent().await?.unwrap();
+        }
+
+        let author = Author {
+            key: owner_key,
+            authorization: Some(authorization),
+        };
+
+        let compacted_history_version = long_history_sphere
+            .compact(until_sphere.cid(), &author)
+            .await?;
+
+        let compacted_history_sphere = Sphere::at(&compacted_history_version, &store);
+
+        let mutation = compacted_history_sphere.derive_mutation().await?;
+
+        assert_eq!(
+            mutation
+                .content()
+                .changes()
+                .iter()
+                .map(|op| match op {
+                    MapOperation::Add { key, .. } => key.as_str(),
+                    MapOperation::Remove { key } => key.as_str(),
+                })
+                .collect::<Vec<&str>>(),
+            vec!["foo", "bar", "baz"]
+        );
+
+        assert_eq!(
+            compacted_history_sphere.get_parent().await?.unwrap().cid(),
+            &base
+        );
+
+        for content in ["foo", "bar", "baz"] {
+            let compacted_content = compacted_history_sphere.get_content().await?;
+            let long_history_content = long_history_sphere.get_content().await?;
+            assert_eq!(
+                compacted_content
+                    .get_as_cid::<DagCborCodec>(&content.into())
+                    .await?,
+                long_history_content
+                    .get_as_cid::<DagCborCodec>(&content.into())
+                    .await?
+            );
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_compacts_nontrivial_history_into_a_single_revision() -> Result<()> {
+        initialize_tracing(None);
+
+        let mut store = MemoryStore::default();
+        let owner_key = generate_ed25519_key();
+        let owner_did = owner_key.get_did().await?;
+
+        let (sphere, authorization, _) = Sphere::generate(&owner_did, &mut store).await?;
+
+        let base = sphere.cid().clone();
+        let mut long_history_version = base.clone();
+
+        for i in 0..100 {
+            let petname_id = (i / 6 - 1) * 6;
+            let petname_change = i % 6 == 0;
+            let additive_change = i == 0 || i % 15 != 0;
+
+            let mut mutation = SphereMutation::new(&owner_did);
+
+            let memo = MemoIpld::for_body(&mut store, format!("content{i}")).await?;
+            let link = store.save::<DagCborCodec, _>(memo).await?;
+
+            mutation
+                .content_mut()
+                .set(&format!("slug{i}"), &link.into());
+
+            if additive_change {
+                mutation
+                    .content_mut()
+                    .set(&format!("slug{i}"), &link.into());
+            } else {
+                mutation.content_mut().remove(&format!("slug{}", i - 1));
+            }
+
+            if petname_change {
+                if additive_change {
+                    let (did, _, link) =
+                        make_valid_link_record(&mut UcanStore(store.clone())).await?;
+                    let identity = IdentityIpld {
+                        did,
+                        link_record: Some(link),
+                    };
+                    mutation
+                        .identities_mut()
+                        .set(&format!("petname{i}"), &identity);
+                } else {
+                    mutation
+                        .identities_mut()
+                        .remove(&format!("petname{}", petname_id));
+                }
+            }
+
+            let mut revision = Sphere::at(&long_history_version, &store)
+                .apply_mutation(&mutation)
+                .await?;
+
+            long_history_version = revision.sign(&owner_key, Some(&authorization)).await?;
+        }
+
+        let long_history_sphere = Sphere::at(&long_history_version, &store);
+        let mut until_sphere = long_history_sphere.clone();
+
+        for _ in 0..99 {
+            until_sphere = until_sphere.get_parent().await?.unwrap();
+        }
+
+        let author = Author {
+            key: owner_key,
+            authorization: Some(authorization),
+        };
+
+        let compacted_history_version = long_history_sphere
+            .compact(until_sphere.cid(), &author)
+            .await?;
+
+        let compacted_history_sphere = Sphere::at(&compacted_history_version, &store);
+
+        let mutation = compacted_history_sphere.derive_mutation().await?;
+
+        assert_eq!(mutation.identities().changes().len(), 14);
+        assert_eq!(mutation.content().changes().len(), 100);
+
+        let content = compacted_history_sphere.get_content().await?;
+        let identities = compacted_history_sphere
+            .get_address_book()
+            .await?
+            .get_identities()
+            .await?;
+
+        debug!("{:#?}", mutation.identities().changes());
+
+        for i in 0..99 {
+            let petname_change = i % 6 == 0;
+            let removed_petname_change = (i + 6) % 15 == 0;
+            let removed_content_change = (i + 1) % 15 == 0;
+            let added_change = i == 0 || i % 15 != 0;
+            let added_content_change = !removed_content_change && added_change;
+            let added_petname_change = !removed_petname_change && added_change;
+
+            debug!("i: {i}, added content: {added_content_change}, removed content: {removed_content_change}, added petname: {added_petname_change}, removed petname: {removed_petname_change}");
+
+            if added_content_change {
+                assert!(content
+                    .get_as_cid::<DagCborCodec>(&format!("slug{}", i))
+                    .await?
+                    .is_some());
+            } else if removed_content_change {
+                assert!(content
+                    .get_as_cid::<DagCborCodec>(&format!("slug{}", i))
+                    .await?
+                    .is_none());
+            }
+
+            if petname_change {
+                if added_petname_change {
+                    assert!(identities
+                        .get_as_cid::<DagCborCodec>(&format!("petname{}", i))
+                        .await?
+                        .is_some());
+                } else if removed_petname_change {
+                    assert!(identities
+                        .get_as_cid::<DagCborCodec>(&format!("petname{}", i))
+                        .await?
+                        .is_none());
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/rust/noosphere-core/src/view/timeline.rs
+++ b/rust/noosphere-core/src/view/timeline.rs
@@ -127,12 +127,12 @@ impl<'a, S: BlockStore> Timeslice<'a, S> {
     /// note that this can be quite memory costly (depending on how much history
     /// is being aggregated), so it is better to stream in reverse-chronological
     /// order if possible.
-    pub async fn to_chronological(&self) -> Result<Vec<(Link<MemoIpld>, MemoIpld)>> {
+    pub async fn to_chronological(&self) -> Result<Vec<Link<MemoIpld>>> {
         let mut chronological = VecDeque::new();
         let mut stream = Box::pin(self.stream());
 
         while let Some(result) = stream.next().await {
-            chronological.push_front(result?);
+            chronological.push_front(result?.0);
         }
 
         Ok(chronological.into())
@@ -198,12 +198,7 @@ mod tests {
         let timeline = Timeline::new(&store);
         let timeslice = timeline.slice(&future, Some(&past));
 
-        let items: Vec<Link<MemoIpld>> = timeslice
-            .to_chronological()
-            .await?
-            .into_iter()
-            .map(|(cid, _)| cid)
-            .collect();
+        let items: Vec<Link<MemoIpld>> = timeslice.to_chronological().await?;
 
         assert_eq!(items.len(), 1);
 
@@ -242,12 +237,7 @@ mod tests {
         let timeline = Timeline::new(&store);
         let timeslice = timeline.slice(&future, Some(&past));
 
-        let items: Vec<Link<MemoIpld>> = timeslice
-            .to_chronological()
-            .await?
-            .into_iter()
-            .map(|(cid, _)| cid)
-            .collect();
+        let items: Vec<Link<MemoIpld>> = timeslice.to_chronological().await?;
 
         assert_eq!(items.len(), 3);
 

--- a/rust/noosphere-gateway/Cargo.toml
+++ b/rust/noosphere-gateway/Cargo.toml
@@ -20,6 +20,8 @@ tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 reqwest = { workspace = true }
+noosphere-common = { version = "0.1.0", path = "../noosphere-common", features = ["helpers"] }
+noosphere-core = { version = "0.16.0", path = "../noosphere-core", features = ["helpers"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = { workspace = true }

--- a/rust/noosphere-gateway/src/lib.rs
+++ b/rust/noosphere-gateway/src/lib.rs
@@ -1,4 +1,9 @@
+//! This crate contains substantially all of the implementation of the Noosphere Gateway
+//! and provides it as a re-usable library. It is the same implementation of the gateway
+//! that is used by the Noosphere CLI.
+
 #![cfg(not(target_arch = "wasm32"))]
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate tracing;

--- a/rust/noosphere-gateway/src/worker/cleanup.rs
+++ b/rust/noosphere-gateway/src/worker/cleanup.rs
@@ -1,0 +1,297 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use noosphere_core::{
+    context::{HasMutableSphereContext, HasSphereContext, SphereCursor, COUNTERPART},
+    data::Did,
+};
+use noosphere_storage::{KeyValueStore, Storage};
+use strum_macros::Display as EnumDisplay;
+use tokio::{
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    task::JoinHandle,
+};
+use tokio_stream::StreamExt;
+
+// Once an hour
+const PERIODIC_CLEANUP_INTERVAL_SECONDS: u64 = 60 * 60;
+
+#[derive(EnumDisplay)]
+pub enum CleanupJob<C> {
+    CompactHistory(C),
+}
+
+pub fn start_cleanup<C, S>(
+    gateway_sphere: C,
+) -> (UnboundedSender<CleanupJob<C>>, JoinHandle<Result<()>>)
+where
+    C: HasMutableSphereContext<S> + 'static,
+    S: Storage + 'static,
+{
+    let (tx, rx) = unbounded_channel();
+
+    (tx.clone(), {
+        tokio::task::spawn(async move {
+            let _ = tokio::join!(
+                cleanup_task(rx),
+                periodic_compaction_task(tx, gateway_sphere),
+            );
+            Ok(())
+        })
+    })
+}
+
+async fn cleanup_task<C, S>(mut receiver: UnboundedReceiver<CleanupJob<C>>) -> Result<()>
+where
+    C: HasMutableSphereContext<S>,
+    S: Storage + 'static,
+{
+    debug!("Cleanup worker started");
+
+    while let Some(job) = receiver.recv().await {
+        if let Err(error) = process_job(job).await {
+            warn!("Error processing cleanup job: {}", error);
+        }
+    }
+
+    Ok(())
+}
+
+async fn periodic_compaction_task<C, S>(tx: UnboundedSender<CleanupJob<C>>, gateway_sphere: C)
+where
+    C: HasMutableSphereContext<S>,
+    S: Storage + 'static,
+{
+    loop {
+        if let Err(error) = tx.send(CleanupJob::CompactHistory(gateway_sphere.clone())) {
+            error!("Periodic compaction failed: {}", error);
+        }
+
+        tokio::time::sleep(Duration::from_secs(PERIODIC_CLEANUP_INTERVAL_SECONDS)).await;
+    }
+}
+
+async fn process_job<C, S>(job: CleanupJob<C>) -> Result<()>
+where
+    C: HasMutableSphereContext<S>,
+    S: Storage + 'static,
+{
+    debug!("Running {}", job);
+
+    match job {
+        CleanupJob::CompactHistory(context) => {
+            let mut cursor = SphereCursor::latest(context);
+            let author = cursor.sphere_context().await?.author().clone();
+            let sphere_identity = cursor.identity().await?;
+
+            debug!(
+                "Attempting history compaction for local sphere {}",
+                sphere_identity
+            );
+
+            let counterpart: Did = cursor
+                .sphere_context()
+                .await?
+                .db()
+                .require_key(COUNTERPART)
+                .await?;
+
+            // Look at the parent of the oldest gateway sphere version we have
+            // checked so far; if that parent has a content changelog that
+            // contains a change to the counterpart sphere root, that's the new
+            // base, aka the intended parent version of the compact change we
+            // are about to produce.
+            let (compact_until, version_count) = {
+                let mut version_count = 0usize;
+
+                let sphere = cursor.to_sphere().await?;
+                let stream = sphere.into_history_stream(None);
+
+                tokio::pin!(stream);
+
+                let mut compact_until = None;
+
+                while let Some((cid, sphere)) = stream.try_next().await? {
+                    let counterpart_changed = sphere
+                        .get_content()
+                        .await?
+                        .get_changelog()
+                        .await?
+                        .changes
+                        .iter()
+                        .filter(|op| {
+                            let key = match op {
+                                noosphere_core::data::MapOperation::Add { key, .. } => key,
+                                noosphere_core::data::MapOperation::Remove { key } => key,
+                            };
+                            key == &counterpart
+                        })
+                        .count()
+                        > 0;
+
+                    if counterpart_changed {
+                        break;
+                    }
+
+                    compact_until = Some(cid);
+                    version_count += 1;
+                }
+
+                (compact_until, version_count)
+            };
+
+            // Here we perform the actual compaction, so we take a mutable lock
+            // on the sphere context until we are done
+            if let Some(compact_until) = compact_until {
+                debug!("Compacting {version_count} versions (through {compact_until})",);
+
+                let cursor_version = cursor.version().await?;
+                let mut context = cursor.sphere_context_mut().await?;
+                let latest_version = context.version().await?;
+
+                if cursor_version != latest_version {
+                    return Err(anyhow!(
+                        "Could not compact history; history advanced since job began"
+                    ));
+                }
+
+                let sphere = context.sphere().await?;
+                let new_tip = sphere.compact(&compact_until, &author).await?;
+                context
+                    .db_mut()
+                    .set_version(&sphere_identity, &new_tip)
+                    .await?;
+
+                debug!("Finished compacting {version_count} versions; new tip is {new_tip}");
+            }
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use noosphere_common::helpers::wait;
+    use noosphere_core::{
+        authority::Access,
+        context::{
+            HasMutableSphereContext, HasSphereContext, SphereContentWrite, SphereCursor,
+            COUNTERPART,
+        },
+        data::ContentType,
+        helpers::{make_valid_link_record, simulated_sphere_context},
+        tracing::initialize_tracing,
+        view::Timeline,
+    };
+    use noosphere_storage::KeyValueStore;
+
+    use crate::worker::{start_cleanup, CleanupJob};
+
+    #[tokio::test]
+    async fn it_compacts_excess_name_record_changes_in_a_gateway_sphere() -> Result<()> {
+        initialize_tracing(None);
+
+        let (mut gateway_sphere_context, _) =
+            simulated_sphere_context(Access::ReadWrite, None).await?;
+        let mut gateway_db = gateway_sphere_context
+            .sphere_context()
+            .await?
+            .db_mut()
+            .clone();
+        let (user_sphere_context, _) =
+            simulated_sphere_context(Access::ReadWrite, Some(gateway_db.clone())).await?;
+        let user_sphere_identity = user_sphere_context.identity().await?;
+        let user_sphere_version = user_sphere_context.version().await?;
+
+        gateway_db
+            .set_key(COUNTERPART, &user_sphere_identity)
+            .await?;
+        gateway_sphere_context
+            .link_raw(&format!("{user_sphere_identity}"), &user_sphere_version)
+            .await?;
+        let base_version = gateway_sphere_context.save(None).await?;
+
+        debug!("Base version: {}", base_version);
+
+        let tl = Timeline::new(&gateway_db);
+        let ts = tl.slice(&base_version, None);
+        let versions = ts.to_chronological().await?;
+
+        debug!(
+            "Before task: {:#?}",
+            versions
+                .iter()
+                .map(|cid| cid.to_string())
+                .collect::<Vec<String>>()
+        );
+
+        let (tx, cleanup_worker) = start_cleanup(gateway_sphere_context.clone());
+
+        wait(1).await;
+
+        let mut latest_version = base_version.clone();
+
+        for _ in 0..10 {
+            let (_, link_record, _) = make_valid_link_record(&mut gateway_db.clone()).await?;
+            gateway_sphere_context
+                .write(
+                    &format!("link_record/{user_sphere_identity}"),
+                    &ContentType::Text,
+                    link_record.encode()?.as_bytes(),
+                    None,
+                )
+                .await?;
+            latest_version = gateway_sphere_context.save(None).await?;
+        }
+
+        let ts = tl.slice(&latest_version, None);
+        let versions = ts.to_chronological().await?;
+
+        debug!(
+            "Before compaction: {:#?}",
+            versions
+                .iter()
+                .map(|cid| cid.to_string())
+                .collect::<Vec<String>>()
+        );
+
+        assert_eq!(13, versions.len());
+
+        tx.send(CleanupJob::CompactHistory(gateway_sphere_context.clone()))?;
+
+        wait(1).await;
+
+        debug!("Test proceeding");
+
+        let cursor = SphereCursor::latest(gateway_sphere_context);
+        let new_latest_version = cursor.version().await?;
+
+        debug!("New latest version: {}", new_latest_version);
+
+        assert_ne!(new_latest_version, latest_version);
+
+        let ts = tl.slice(&new_latest_version, None);
+        let versions = ts.to_chronological().await?;
+
+        debug!(
+            "After compaction: {:#?}",
+            versions
+                .iter()
+                .map(|cid| cid.to_string())
+                .collect::<Vec<String>>()
+        );
+
+        assert_eq!(4, versions.len());
+
+        assert_eq!(
+            cursor.to_sphere().await?.get_parent().await?.unwrap().cid(),
+            &base_version
+        );
+
+        cleanup_worker.abort();
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-gateway/src/worker/mod.rs
+++ b/rust/noosphere-gateway/src/worker/mod.rs
@@ -1,5 +1,7 @@
+mod cleanup;
 mod name_system;
 mod syndication;
 
+pub use cleanup::*;
 pub use name_system::*;
 pub use syndication::*;

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -517,6 +517,7 @@ where
 mod tests {
     use noosphere_core::{
         authority::{generate_capability, Access, SphereAbility},
+        context::HasSphereContext,
         data::LINK_RECORD_FACT_NAME,
         helpers::simulated_sphere_context,
     };
@@ -597,6 +598,8 @@ mod tests {
         .await
         .is_err());
 
+        let expected_sphere_version = sphere.version().await?;
+
         // Republished records however can be published if expired.
         assert!(process_job(
             NameSystemJob::Publish {
@@ -609,6 +612,11 @@ mod tests {
         )
         .await
         .is_ok());
+
+        let final_sphere_version = sphere.version().await?;
+
+        // Republishing a link record should not create new sphere history
+        assert_eq!(expected_sphere_version, final_sphere_version);
 
         Ok(())
     }

--- a/rust/noosphere-gateway/src/worker/name_system.rs
+++ b/rust/noosphere-gateway/src/worker/name_system.rs
@@ -232,8 +232,13 @@ where
                 context,
                 republish,
             } => {
-                if let Err(error) = set_counterpart_record(context, &record).await {
-                    warn!("Could not set counterpart record on sphere: {error}");
+                // NOTE: Very important not to update this record on every
+                // re-publish, otherwise we will generate a new sphere revision
+                // on an on-going basis indefinitely
+                if !republish {
+                    if let Err(error) = set_counterpart_record(context, &record).await {
+                        warn!("Could not set counterpart record on sphere: {error}");
+                    }
                 }
                 if republish || record.has_publishable_timeframe() {
                     client.publish(record).await?;

--- a/rust/noosphere-gateway/src/worker/syndication.rs
+++ b/rust/noosphere-gateway/src/worker/syndication.rs
@@ -150,7 +150,7 @@ where
     // For all CIDs since the last historical checkpoint, syndicate a CAR
     // of blocks that are unique to that revision to the backing IPFS
     // implementation
-    for (cid, _) in timeline {
+    for cid in timeline {
         // TODO(#175): At each increment, if there are sub-graphs of a
         // sphere that should *not* be syndicated (e.g., other spheres
         // referenced by this sphere that are probably syndicated


### PR DESCRIPTION
This change proposes a form of incremental history compaction, the core of which is implemented in `Sphere`. Its only use at this time will be in the Noosphere Gateway, where it will be used to ensure that side-effects that cause history to accrue for the gateway's sphere do not result in unbounded version growth. As of this change, the gateway will attempt to compact its history once an hour. The compaction flattens all history since the last user sync point.