### PR TITLE
feat: Improved IPFS Kubo syndication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,19 +584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "serde",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,21 +1308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deterministic-bloom"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a3873e91e360aee2403cbafd2beb42f02ace06da9b053574518f003aa2490d"
-dependencies = [
- "bitvec",
- "miette",
- "rand_core 0.6.4",
- "serde",
- "thiserror",
- "tracing",
- "xxhash-rust",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,12 +1663,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -3183,29 +3149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "miette-derive",
- "once_cell",
- "thiserror",
- "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,7 +3573,6 @@ dependencies = [
  "axum",
  "bytes",
  "cid",
- "deterministic-bloom",
  "iroh-car",
  "libipld-cbor",
  "libipld-core",
@@ -3648,6 +3590,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -3702,6 +3645,8 @@ dependencies = [
  "iroh-car",
  "libipld-cbor",
  "libipld-core",
+ "libipld-json",
+ "multihash 0.18.1",
  "noosphere-common",
  "noosphere-core",
  "noosphere-storage",
@@ -4378,12 +4323,6 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -5442,12 +5381,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -6719,15 +6652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "x25519-dalek"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6786,12 +6710,6 @@ dependencies = [
  "thiserror",
  "time",
 ]
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b"
 
 [[package]]
 name = "yamux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = { version = "1" }
+async-recursion = { version = "1" }
 async-stream = { version = "0.3" }
 axum = { version = "^0.6.18" }
 bytes = { version = "^1" }
@@ -34,6 +35,8 @@ js-sys = { version = "^0.3" }
 libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }
+libipld-json = { version = "0.16" }
+multihash = { version = "0.18" }
 pathdiff = { version = "0.2.1" }
 rand = { version = "0.8" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/rust/noosphere-cli/src/native/commands/sphere/auth.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere/auth.rs
@@ -139,7 +139,7 @@ pub async fn auth_list(tree: bool, as_json: bool, workspace: &Workspace) -> Resu
     while let Some((name, identity, link)) = authorization_stream.try_next().await? {
         let jwt = Jwt(db.require_token(&link).await?);
         max_name_length = max_name_length.max(name.len());
-        authorization_meta.insert(link.clone(), (name, identity, jwt));
+        authorization_meta.insert(link, (name, identity, jwt));
     }
 
     if tree {
@@ -162,13 +162,13 @@ pub async fn auth_list(tree: bool, as_json: bool, workspace: &Workspace) -> Resu
             if *ucan.issuer() == sphere_identity {
                 // TODO(#554): Such an authorization ought not have any topical proofs,
                 // but perhaps we should verify that
-                authorization_roots.push(link.clone())
+                authorization_roots.push(*link)
             } else {
                 for proof in proofs {
                     let items = match authorization_hierarchy.get_mut(&proof) {
                         Some(items) => items,
                         None => {
-                            authorization_hierarchy.insert(proof.clone(), Vec::new());
+                            authorization_hierarchy.insert(proof, Vec::new());
                             authorization_hierarchy.get_mut(&proof).ok_or_else(|| {
                                 anyhow!(
                                     "Could not access list of child authorizations for {}",
@@ -177,7 +177,7 @@ pub async fn auth_list(tree: bool, as_json: bool, workspace: &Workspace) -> Resu
                             })?
                         }
                     };
-                    items.push(link.clone());
+                    items.push(*link);
                 }
             }
         }

--- a/rust/noosphere-cli/src/native/commands/sphere/history.rs
+++ b/rust/noosphere-cli/src/native/commands/sphere/history.rs
@@ -10,7 +10,7 @@ use crate::workspace::Workspace;
 pub async fn history(workspace: &Workspace) -> Result<()> {
     let sphere_context = workspace.sphere_context().await?;
     let sphere = sphere_context.to_sphere().await?;
-    let latest_version = sphere.cid().clone();
+    let latest_version = *sphere.cid();
     let db = sphere.store().clone();
 
     let history_stream = sphere.into_history_stream(None);

--- a/rust/noosphere-cli/src/native/render/job.rs
+++ b/rust/noosphere-cli/src/native/render/job.rs
@@ -212,7 +212,7 @@ where
 
             // Create a symlink to each peer (they will be rendered later, if
             // they haven't been already)
-            petname_change_buffer.add(name.clone(), (did.clone(), cid.clone().into()))?;
+            petname_change_buffer.add(name.clone(), (did.clone(), cid.into()))?;
 
             if petname_change_buffer.is_full() {
                 petname_change_buffer.flush_to_writer(&self.writer).await?;
@@ -278,10 +278,8 @@ where
                     Some(identity) => match cursor.get_petname_record(&petname).await? {
                         Some(link_record) => {
                             if let Some(version) = link_record.get_link() {
-                                petname_change_buffer.add(
-                                    petname.clone(),
-                                    (identity.clone(), Cid::from(version.clone())),
-                                )?;
+                                petname_change_buffer
+                                    .add(petname.clone(), (identity.clone(), Cid::from(version)))?;
 
                                 let mut petname_path = self.petname_path.clone();
                                 petname_path.push(petname);

--- a/rust/noosphere-collections/Cargo.toml
+++ b/rust/noosphere-collections/Cargo.toml
@@ -24,7 +24,7 @@ forest_hash_utils = "0.1.0"
 serde = { workspace = true }
 serde_bytes = "0.11"
 byteorder = "^1.4"
-async-recursion = "^1"
+async-recursion = { workspace = true }
 libipld-core = { workspace = true }
 libipld-cbor = { workspace = true }
 noosphere-storage = { version = "0.9.0", path = "../noosphere-storage" }

--- a/rust/noosphere-common/src/channel.rs
+++ b/rust/noosphere-common/src/channel.rs
@@ -198,10 +198,7 @@ mod tests {
         });
 
         let res = client.send(Request::Ping()).await?;
-        assert!(match res {
-            Ok(Response::Pong()) => true,
-            _ => false,
-        });
+        matches!(res, Ok(Response::Pong()));
 
         for n in 0..10 {
             client.send_oneshot(Request::SetFlag(n))?;

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 cid = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 async-trait = "~0.1"
-async-recursion = "^1"
+async-recursion = { workspace = true }
 async-stream = { workspace = true }
 
 # NOTE: async-once-cell 0.4.0 shipped unstable feature usage

--- a/rust/noosphere-core/src/api/client.rs
+++ b/rust/noosphere-core/src/api/client.rs
@@ -325,7 +325,7 @@ where
         store: S,
         push_body: v0alpha2::PushBody,
     ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + ConditionalSync + 'static {
-        let root = push_body.local_tip.clone().into();
+        let root = push_body.local_tip.into();
         trace!("Creating push stream...");
 
         let block_stream = try_stream! {

--- a/rust/noosphere-core/src/context/content/read.rs
+++ b/rust/noosphere-core/src/context/content/read.rs
@@ -42,7 +42,7 @@ where
         let hamt = links.get_hamt().await?;
 
         Ok(match hamt.get(&slug.to_string()).await? {
-            Some(memo) => Some(self.get_file(&revision, memo.clone()).await?),
+            Some(memo) => Some(self.get_file(&revision, *memo).await?),
             None => None,
         })
     }

--- a/rust/noosphere-core/src/context/cursor.rs
+++ b/rust/noosphere-core/src/context/cursor.rs
@@ -46,7 +46,7 @@ where
         SphereCursor {
             has_sphere_context,
             storage: PhantomData,
-            sphere_version: Some(sphere_version.clone()),
+            sphere_version: Some(*sphere_version),
         }
     }
 
@@ -66,7 +66,7 @@ where
     /// version it is mounted to even when the latest version of the sphere
     /// changes.
     pub async fn mount_at(&mut self, sphere_version: &Link<MemoIpld>) -> Result<&Self> {
-        self.sphere_version = Some(sphere_version.clone());
+        self.sphere_version = Some(*sphere_version);
 
         Ok(self)
     }
@@ -112,7 +112,7 @@ where
 
         match sphere.get_parent().await? {
             Some(parent) => {
-                self.sphere_version = Some(parent.cid().clone());
+                self.sphere_version = Some(*parent.cid());
                 Ok(self.sphere_version.as_ref())
             }
             None => Ok(None),
@@ -140,7 +140,7 @@ where
         let new_version = self.has_sphere_context.save(additional_headers).await?;
 
         if self.sphere_version.is_some() {
-            self.sphere_version = Some(new_version.clone());
+            self.sphere_version = Some(new_version);
         }
 
         Ok(new_version)
@@ -162,7 +162,7 @@ where
 
     async fn version(&self) -> Result<Link<MemoIpld>> {
         match &self.sphere_version {
-            Some(sphere_version) => Ok(sphere_version.clone()),
+            Some(sphere_version) => Ok(*sphere_version),
             None => self.has_sphere_context.version().await,
         }
     }
@@ -191,7 +191,7 @@ where
 
                 async move {
                     let replicate_parameters = since.as_ref().map(|since| ReplicateParameters {
-                        since: Some(since.clone()),
+                        since: Some(*since),
                     });
                     let (db, client) = {
                         let sphere_context = cursor.sphere_context().await?;

--- a/rust/noosphere-core/src/context/sync/strategy.rs
+++ b/rust/noosphere-core/src/context/sync/strategy.rs
@@ -191,9 +191,8 @@ where
                     .into();
                 return Ok((
                     local_sphere_tip,
-                    counterpart_sphere_base
-                        .ok_or_else(|| anyhow!("Counterpart sphere history is missing!"))?
-                        .clone(),
+                    *counterpart_sphere_base
+                        .ok_or_else(|| anyhow!("Counterpart sphere history is missing!"))?,
                     updated_names,
                 ));
             }
@@ -272,12 +271,12 @@ where
                 )
                 .await?;
 
-                new_base.clone()
+                new_base
             }
             // No new history at all
             (Some(current_tip), _, _) => {
                 info!("Nothing to sync!");
-                current_tip.clone()
+                *current_tip
             }
             // We should have local history but we don't!
             _ => {
@@ -409,8 +408,8 @@ where
             .push(&PushBody {
                 sphere: local_sphere_identity.clone(),
                 local_base: local_sphere_base,
-                local_tip: local_sphere_tip.clone(),
-                counterpart_tip: Some(counterpart_sphere_tip.clone()),
+                local_tip: *local_sphere_tip,
+                counterpart_tip: Some(*counterpart_sphere_tip),
                 name_record: Some(name_record),
             })
             .await?;

--- a/rust/noosphere-core/src/data/bundle.rs
+++ b/rust/noosphere-core/src/data/bundle.rs
@@ -699,7 +699,7 @@ mod tests {
 
         let (sphere, ucan, _) = Sphere::generate(&owner_did, &mut store).await.unwrap();
 
-        let original_cid = sphere.cid().clone();
+        let original_cid = *sphere.cid();
 
         let foo_key = String::from("foo");
         let foo_memo = MemoIpld::for_body(&mut store, b"foo").await.unwrap();

--- a/rust/noosphere-core/src/data/link.rs
+++ b/rust/noosphere-core/src/data/link.rs
@@ -39,6 +39,8 @@ where
     linked_type: PhantomData<T>,
 }
 
+impl<T> Copy for Link<T> where T: Clone {}
+
 impl<T> Debug for Link<T>
 where
     T: Clone,

--- a/rust/noosphere-core/src/data/memo.rs
+++ b/rust/noosphere-core/src/data/memo.rs
@@ -120,7 +120,7 @@ impl MemoIpld {
     pub async fn branch_from<S: BlockStore>(cid: &Link<MemoIpld>, store: &S) -> Result<Self> {
         match store.load::<DagCborCodec, MemoIpld>(cid).await {
             Ok(mut memo) => {
-                memo.parent = Some(cid.clone());
+                memo.parent = Some(*cid);
                 memo.remove_header(&Header::Signature);
                 memo.remove_header(&Header::Proof);
 

--- a/rust/noosphere-core/src/helpers/context.rs
+++ b/rust/noosphere-core/src/helpers/context.rs
@@ -21,6 +21,10 @@ use crate::{
     stream::{walk_versioned_map_elements, walk_versioned_map_elements_and},
 };
 
+/// An alias for the [HasMutableSphereContext] type returned by [simulated_sphere_context]
+pub type SimulatedHasMutableSphereContext =
+    Arc<Mutex<SphereContext<TrackingStorage<MemoryStorage>>>>;
+
 /// Create a temporary, non-persisted [SphereContext] that tracks usage
 /// internally. This is intended for use in docs and tests, and should otherwise
 /// be ignored. When creating the simulated [SphereContext], you can pass an
@@ -29,10 +33,7 @@ use crate::{
 pub async fn simulated_sphere_context(
     profile: Access,
     db: Option<SphereDb<TrackingStorage<MemoryStorage>>>,
-) -> Result<(
-    Arc<Mutex<SphereContext<TrackingStorage<MemoryStorage>>>>,
-    Mnemonic,
-)> {
+) -> Result<(SimulatedHasMutableSphereContext, Mnemonic)> {
     let db = match db {
         Some(db) => db,
         None => {

--- a/rust/noosphere-core/src/stream/memo.rs
+++ b/rust/noosphere-core/src/stream/memo.rs
@@ -6,6 +6,7 @@ use crate::{
     view::Sphere,
 };
 use anyhow::{anyhow, Result};
+use async_recursion::async_recursion;
 use async_stream::try_stream;
 use cid::Cid;
 use libipld_cbor::DagCborCodec;
@@ -36,7 +37,7 @@ where
 {
     debug!("Streaming history via memo...");
 
-    let latest = latest.clone();
+    let latest = *latest;
     let since = since.cloned();
 
     try_stream! {
@@ -122,11 +123,10 @@ where
                         if replicate_content {
                             debug!("Replicating content...");
                             let content = sphere.get_content().await?;
-                            let include_content = include_content;
 
                             tasks.spawn(walk_versioned_map_changes_and(content, store.clone(), move |_, link, store| async move {
                                 if include_content {
-                                    walk_memo_body(store, &link).await?;
+                                    walk_memo_body(store, &link, include_content).await?;
                                 } else {
                                     link.load_from(&store).await?;
                                 };
@@ -190,7 +190,8 @@ where
 #[instrument(level = "trace", skip(store))]
 pub fn memo_body_stream<S>(
     store: S,
-    memo_version: &Cid,
+    memo_version: &Link<MemoIpld>,
+    include_content: bool,
 ) -> impl Stream<Item = Result<(Cid, Vec<u8>)>> + ConditionalSend
 where
     S: BlockStore + 'static,
@@ -204,7 +205,7 @@ where
 
         let mut receiver_is_open = true;
         let mut walk_memo_finished = false;
-        let mut walk_memo_finishes = Box::pin(walk_memo_body(store, &memo_version));
+        let mut walk_memo_finishes = Box::pin(walk_memo_body(store, &memo_version, include_content));
 
         while receiver_is_open {
             select! {
@@ -228,7 +229,13 @@ where
 
 #[allow(clippy::let_with_type_underscore)]
 #[instrument(level = "trace", skip(store))]
-async fn walk_memo_body<S>(store: S, memo_version: &Cid) -> Result<()>
+#[cfg_attr(target_arch="wasm32", async_recursion(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
+async fn walk_memo_body<S>(
+    store: S,
+    memo_version: &Link<MemoIpld>,
+    include_content: bool,
+) -> Result<()>
 where
     S: BlockStore + 'static,
 {
@@ -256,15 +263,42 @@ where
                     Ok(())
                 },
             ));
+
             tasks.spawn(walk_versioned_map_elements_and(
                 content,
                 store.clone(),
                 move |_, link, store| async move {
-                    link.load_from(&store).await?;
+                    if include_content {
+                        walk_memo_body(store, &link, true).await?;
+                    } else {
+                        link.load_from(&store).await?;
+                    }
+
                     Ok(())
                 },
             ));
-            tasks.spawn(walk_versioned_map_elements(delegations));
+
+            tasks.spawn(async move {
+                walk_versioned_map_elements_and(
+                    delegations,
+                    store,
+                    |_, delegation, store| async move {
+                        let ucan_store = UcanStore(store);
+
+                        collect_ucan_proofs(
+                            &Ucan::from_str(&ucan_store.require_token(&delegation.jwt).await?)?,
+                            &ucan_store,
+                        )
+                        .await?;
+
+                        Ok(())
+                    },
+                )
+                .await?;
+
+                Ok(()) as Result<_, anyhow::Error>
+            });
+
             tasks.spawn(walk_versioned_map_elements(revocations));
 
             tasks.join().await?;

--- a/rust/noosphere-core/src/stream/mod.rs
+++ b/rust/noosphere-core/src/stream/mod.rs
@@ -14,16 +14,22 @@ pub use walk::*;
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use cid::Cid;
+    use libipld_core::{codec::Codec, ipld::Ipld, raw::RawCodec};
     use std::collections::BTreeSet;
-    use ucan::store::UcanJwtStore;
+    use ucan::{crypto::KeyMaterial, store::UcanJwtStore};
 
     use crate::{
-        authority::Access,
+        authority::{generate_ed25519_key, Access},
         context::{
-            HasMutableSphereContext, HasSphereContext, SphereContentWrite, SpherePetnameWrite,
+            HasMutableSphereContext, HasSphereContext, SphereAuthorityWrite, SphereContentRead,
+            SphereContentWrite, SpherePetnameWrite,
         },
-        data::{BodyChunkIpld, ContentType, LinkRecord, MemoIpld},
-        helpers::{make_valid_link_record, simulated_sphere_context, touch_all_sphere_blocks},
+        data::{BodyChunkIpld, ContentType, Link, LinkRecord, MemoIpld},
+        helpers::{
+            make_valid_link_record, simulated_sphere_context, touch_all_sphere_blocks,
+            SimulatedHasMutableSphereContext,
+        },
         stream::{from_car_stream, memo_body_stream, memo_history_stream, to_car_stream},
         tracing::initialize_tracing,
         view::{BodyChunkDecoder, Sphere},
@@ -37,6 +43,58 @@ mod tests {
 
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    pub const SCAFFOLD_CHANGES: &[(&[&str], &[&str])] = &[
+        (&["dogs", "birds"], &["alice", "bob"]),
+        (&["cats", "dogs"], &["gordon"]),
+        (&["birds"], &["cdata"]),
+        (&["cows", "beetles"], &["jordan", "ben"]),
+    ];
+
+    pub async fn scaffold_sphere_context_with_history(
+    ) -> Result<(SimulatedHasMutableSphereContext, Vec<Link<MemoIpld>>)> {
+        let (mut sphere_context, _) = simulated_sphere_context(Access::ReadWrite, None).await?;
+        let mut versions = Vec::new();
+        let store = sphere_context.sphere_context().await?.db().clone();
+
+        for (content_change, petname_change) in SCAFFOLD_CHANGES.iter() {
+            for slug in *content_change {
+                sphere_context
+                    .write(
+                        slug,
+                        &ContentType::Subtext,
+                        format!("{} are cool", slug).as_bytes(),
+                        None,
+                    )
+                    .await?;
+            }
+
+            for petname in *petname_change {
+                let (id, record, _) = make_valid_link_record(&mut UcanStore(store.clone())).await?;
+                sphere_context.set_petname(petname, Some(id)).await?;
+                versions.push(sphere_context.save(None).await?);
+                sphere_context.set_petname_record(petname, &record).await?;
+            }
+
+            versions.push(sphere_context.save(None).await?);
+        }
+
+        let additional_device_credential = generate_ed25519_key();
+        let additional_device_did = additional_device_credential.get_did().await?.into();
+        let additional_device_authorization = sphere_context
+            .authorize("otherdevice", &additional_device_did)
+            .await?;
+
+        sphere_context.save(None).await?;
+
+        sphere_context
+            .revoke_authorization(&additional_device_authorization)
+            .await?;
+
+        sphere_context.save(None).await?;
+
+        Ok((sphere_context, versions))
+    }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
@@ -61,6 +119,7 @@ mod tests {
         let stream = memo_body_stream(
             sphere_context.sphere_context().await?.db().clone(),
             &final_version,
+            false,
         );
 
         tokio::pin!(stream);
@@ -87,35 +146,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version() -> Result<()> {
         initialize_tracing(None);
 
-        let (mut sphere_context, _) = simulated_sphere_context(Access::ReadWrite, None).await?;
-
-        let changes = vec![
-            (vec!["dogs", "birds"], vec!["alice", "bob"]),
-            (vec!["cats", "dogs"], vec!["gordon"]),
-            (vec!["birds"], vec!["cdata"]),
-            (vec!["cows", "beetles"], vec!["jordan", "ben"]),
-        ];
-
-        for (content_change, petname_change) in changes.iter() {
-            for slug in content_change {
-                sphere_context
-                    .write(
-                        slug,
-                        &ContentType::Subtext,
-                        format!("{} are cool", slug).as_bytes(),
-                        None,
-                    )
-                    .await?;
-            }
-
-            for petname in petname_change {
-                sphere_context
-                    .set_petname(petname, Some(format!("did:key:{}", petname).into()))
-                    .await?;
-            }
-
-            sphere_context.save(None).await?;
-        }
+        let (sphere_context, _) = scaffold_sphere_context_with_history().await?;
 
         let final_version = sphere_context.version().await?;
 
@@ -126,6 +157,7 @@ mod tests {
         let stream = memo_body_stream(
             sphere_context.sphere_context().await?.db().clone(),
             &final_version,
+            false,
         );
 
         tokio::pin!(stream);
@@ -145,12 +177,12 @@ mod tests {
         let content = sphere.get_content().await?;
         let identities = sphere.get_address_book().await?.get_identities().await?;
 
-        for (content_change, petname_change) in changes.iter() {
-            for slug in content_change {
+        for (content_change, petname_change) in SCAFFOLD_CHANGES.iter() {
+            for slug in *content_change {
                 let _ = content.get(&slug.to_string()).await?.cloned().unwrap();
             }
 
-            for petname in petname_change {
+            for petname in *petname_change {
                 let _ = identities.get(&petname.to_string()).await?;
             }
         }
@@ -165,45 +197,14 @@ mod tests {
     async fn it_can_stream_all_delta_blocks_for_a_range_of_history() -> Result<()> {
         initialize_tracing(None);
 
-        let (mut sphere_context, _) = simulated_sphere_context(Access::ReadWrite, None).await?;
-
-        let changes = vec![
-            (vec!["dogs", "birds"], vec!["alice", "bob"]),
-            (vec!["cats", "dogs"], vec!["gordon"]),
-            (vec!["birds"], vec!["cdata"]),
-            (vec!["cows", "beetles"], vec!["jordan", "ben"]),
-        ];
+        let (sphere_context, versions) = scaffold_sphere_context_with_history().await?;
 
         let original_store = sphere_context.sphere_context().await?.db().clone();
-        let mut versions = Vec::new();
-
-        for (content_change, petname_change) in changes.iter() {
-            for slug in content_change {
-                sphere_context
-                    .write(
-                        slug,
-                        &ContentType::Subtext,
-                        format!("{} are cool", slug).as_bytes(),
-                        None,
-                    )
-                    .await?;
-            }
-
-            for petname in petname_change {
-                let (id, record, _) =
-                    make_valid_link_record(&mut UcanStore(original_store.clone())).await?;
-                sphere_context.set_petname(petname, Some(id)).await?;
-                versions.push(sphere_context.save(None).await?);
-                sphere_context.set_petname_record(petname, &record).await?;
-            }
-
-            versions.push(sphere_context.save(None).await?);
-        }
 
         let mut other_store = MemoryStore::default();
 
         let first_version = versions.first().unwrap();
-        let stream = memo_body_stream(original_store.clone(), first_version);
+        let stream = memo_body_stream(original_store.clone(), first_version, false);
 
         tokio::pin!(stream);
 
@@ -275,6 +276,7 @@ mod tests {
         let stream = memo_body_stream(
             sphere_context.sphere_context().await?.db().clone(),
             &content_cid,
+            false,
         );
 
         let mut store = MemoryStore::default();
@@ -306,35 +308,7 @@ mod tests {
     async fn it_can_stream_all_blocks_in_a_sphere_version_as_a_car() -> Result<()> {
         initialize_tracing(None);
 
-        let (mut sphere_context, _) = simulated_sphere_context(Access::ReadWrite, None).await?;
-
-        let changes = vec![
-            (vec!["dogs", "birds"], vec!["alice", "bob"]),
-            (vec!["cats", "dogs"], vec!["gordon"]),
-            (vec!["birds"], vec!["cdata"]),
-            (vec!["cows", "beetles"], vec!["jordan", "ben"]),
-        ];
-
-        for (content_change, petname_change) in changes.iter() {
-            for slug in content_change {
-                sphere_context
-                    .write(
-                        slug,
-                        &ContentType::Subtext,
-                        format!("{} are cool", slug).as_bytes(),
-                        None,
-                    )
-                    .await?;
-            }
-
-            for petname in petname_change {
-                sphere_context
-                    .set_petname(petname, Some(format!("did:key:{}", petname).into()))
-                    .await?;
-            }
-
-            sphere_context.save(None).await?;
-        }
+        let (mut sphere_context, _) = scaffold_sphere_context_with_history().await?;
 
         let mut db = sphere_context.sphere_context().await?.db().clone();
         let (id, link_record, _) = make_valid_link_record(&mut db).await?;
@@ -350,8 +324,8 @@ mod tests {
         let mut other_store = MemoryStore::default();
 
         let stream = to_car_stream(
-            vec![final_version.clone().into()],
-            memo_body_stream(db.clone(), &final_version),
+            vec![final_version.into()],
+            memo_body_stream(db.clone(), &final_version, false),
         );
 
         let block_stream = from_car_stream(stream);
@@ -374,12 +348,12 @@ mod tests {
         let content = sphere.get_content().await?;
         let identities = sphere.get_address_book().await?.get_identities().await?;
 
-        for (content_change, petname_change) in changes.iter() {
-            for slug in content_change {
+        for (content_change, petname_change) in SCAFFOLD_CHANGES.iter() {
+            for slug in *content_change {
                 let _ = content.get(&slug.to_string()).await?.cloned().unwrap();
             }
 
-            for petname in petname_change {
+            for petname in *petname_change {
                 let _ = identities.get(&petname.to_string()).await?;
             }
         }
@@ -393,6 +367,115 @@ mod tests {
         );
 
         touch_all_sphere_blocks(&sphere).await?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_only_omits_memo_parent_references_when_streaming_sphere_body_with_content(
+    ) -> Result<()> {
+        initialize_tracing(None);
+
+        let (sphere_context, mut versions) = scaffold_sphere_context_with_history().await?;
+
+        debug!(
+            "Versions: {:#?}",
+            versions
+                .iter()
+                .map(|cid| cid.to_string())
+                .collect::<Vec<String>>()
+        );
+
+        let store = sphere_context.lock().await.db().clone();
+        let last_version = versions.pop().unwrap();
+        let last_version_parent = versions.pop().unwrap();
+
+        let mut links_referenced = BTreeSet::new();
+        let mut links_included = BTreeSet::new();
+
+        // The root is referenced implicitly
+        links_referenced.insert(*last_version);
+
+        let stream = memo_body_stream(store.clone(), &last_version, true);
+
+        tokio::pin!(stream);
+
+        while let Some((cid, block)) = stream.try_next().await? {
+            if cid == *last_version {
+                // Verify that parent of root is what we expect...
+                let memo = store.load::<DagCborCodec, MemoIpld>(&cid).await?;
+                assert_eq!(memo.parent, Some(last_version_parent));
+
+                let codec = DagCborCodec;
+                let mut root_references = BTreeSet::new();
+                codec.references::<Ipld, BTreeSet<Cid>>(&block, &mut root_references)?;
+
+                assert!(root_references.contains(&last_version_parent));
+            }
+
+            links_included.insert(cid);
+
+            match cid.codec() {
+                codec if codec == u64::from(DagCborCodec) => {
+                    let codec = DagCborCodec;
+                    codec.references::<Ipld, BTreeSet<Cid>>(&block, &mut links_referenced)?;
+                }
+                codec if codec == u64::from(RawCodec) => {
+                    let codec = DagCborCodec;
+                    codec.references::<Ipld, BTreeSet<Cid>>(&block, &mut links_referenced)?;
+                }
+                _ => {
+                    unreachable!("No other codecs are used in our DAGs");
+                }
+            }
+        }
+
+        assert!(
+            !links_included.contains(&last_version_parent),
+            "Parent version should not be included"
+        );
+
+        let difference = links_referenced
+            .difference(&links_included)
+            .collect::<Vec<&Cid>>();
+
+        debug!(
+            "Difference: {:#?}",
+            difference
+                .iter()
+                .map(|cid| cid.to_string())
+                .collect::<Vec<String>>()
+        );
+
+        // These files have been each updated once after the first write, so their memos have
+        // parent pointers to old versions that won't be included in the CAR
+        let last_dogs_version = sphere_context
+            .read("dogs")
+            .await?
+            .unwrap()
+            .memo
+            .parent
+            .unwrap();
+        let last_birds_version = sphere_context
+            .read("birds")
+            .await?
+            .unwrap()
+            .memo
+            .parent
+            .unwrap();
+
+        let expected_difference: Vec<&Cid> = vec![
+            &last_version_parent,
+            &last_birds_version,
+            &last_dogs_version,
+        ];
+
+        assert_eq!(difference.len(), expected_difference.len());
+
+        for cid in expected_difference {
+            assert!(difference.contains(&cid));
+        }
 
         Ok(())
     }

--- a/rust/noosphere-core/src/view/timeline.rs
+++ b/rust/noosphere-core/src/view/timeline.rs
@@ -59,7 +59,7 @@ impl<'a, S: BlockStore> Timeline<'a, S> {
         exclude_past: bool,
     ) -> impl TryStream<Item = Result<(Link<MemoIpld>, MemoIpld)>> {
         stream::try_unfold(
-            (Some(future.clone()), past.cloned(), self.store.clone()),
+            (Some(*future), past.cloned(), self.store.clone()),
             move |(from, to, storage)| async move {
                 match &from {
                     Some(from) => {
@@ -73,12 +73,12 @@ impl<'a, S: BlockStore> Timeline<'a, S> {
                                 if exclude_past && to.as_ref() == next_dag.parent.as_ref() {
                                     None
                                 } else {
-                                    next_dag.parent.clone()
+                                    next_dag.parent
                                 }
                             }
                         };
 
-                        Ok(Some(((cid.clone(), next_dag), (next_from, to, storage))))
+                        Ok(Some(((*cid, next_dag), (next_from, to, storage))))
                     }
                     None => Ok(None),
                 }
@@ -177,7 +177,7 @@ mod tests {
         let owner_did = owner_key.get_did().await?;
 
         let (mut sphere, ucan, _) = Sphere::generate(&owner_did, &mut store).await?;
-        let mut lineage = vec![sphere.cid().clone()];
+        let mut lineage = vec![*sphere.cid()];
 
         for i in 0..5u8 {
             let mut mutation = SphereMutation::new(&owner_did);
@@ -192,8 +192,8 @@ mod tests {
             lineage.push(next_cid);
         }
 
-        let past = lineage[4].clone();
-        let future = lineage[4].clone();
+        let past = lineage[4];
+        let future = lineage[4];
 
         let timeline = Timeline::new(&store);
         let timeslice = timeline.slice(&future, Some(&past));
@@ -216,7 +216,7 @@ mod tests {
         let owner_did = owner_key.get_did().await?;
 
         let (mut sphere, ucan, _) = Sphere::generate(&owner_did, &mut store).await?;
-        let mut lineage = vec![sphere.cid().clone()];
+        let mut lineage = vec![*sphere.cid()];
 
         for i in 0..5u8 {
             let mut mutation = SphereMutation::new(&owner_did);
@@ -231,8 +231,8 @@ mod tests {
             lineage.push(next_cid);
         }
 
-        let past = lineage[1].clone();
-        let future = lineage[3].clone();
+        let past = lineage[1];
+        let future = lineage[3];
 
         let timeline = Timeline::new(&store);
         let timeslice = timeline.slice(&future, Some(&past));

--- a/rust/noosphere-gateway/Cargo.toml
+++ b/rust/noosphere-gateway/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/subconsciousnetwork/noosphere"
 homepage = "https://github.com/subconsciousnetwork/noosphere"
 readme = "README.md"
 
+[features]
+test-kubo = []
+
 [dependencies]
 tracing = { workspace = true }
 
@@ -34,11 +37,11 @@ bytes = { workspace = true }
 
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "trace"] }
 async-trait = "~0.1"
 async-stream = { workspace = true }
-deterministic-bloom = { workspace = true }
 
 url = { workspace = true, features = ["serde"] }
 mime_guess = "^2"
@@ -47,6 +50,7 @@ noosphere-ipfs = { version = "0.8.1", path = "../noosphere-ipfs" }
 noosphere-core = { version = "0.17.0", path = "../noosphere-core" }
 noosphere-ns = { version = "0.11.1", path = "../noosphere-ns" }
 noosphere-storage = { version = "0.9.0", path = "../noosphere-storage" }
+noosphere-common = { version = "0.1.0", path = "../noosphere-common" }
 ucan = { workspace = true }
 ucan-key-support = { workspace = true }
 cid = { workspace = true }

--- a/rust/noosphere-gateway/src/handlers/v0alpha1/push.rs
+++ b/rust/noosphere-gateway/src/handlers/v0alpha1/push.rs
@@ -101,7 +101,7 @@ where
         // These steps are order-independent
         let _ = tokio::join!(
             self.notify_name_resolver(),
-            self.notify_ipfs_syndicator(next_version.clone())
+            self.notify_ipfs_syndicator(next_version)
         );
 
         Ok(PushResponse::Accepted {
@@ -131,7 +131,7 @@ where
         let db = gateway_sphere_context.db();
 
         let local_sphere_base_cid = db.get_version(sphere_identity).await?.map(|cid| cid.into());
-        let request_sphere_base_cid = self.request_body.local_base.clone();
+        let request_sphere_base_cid = self.request_body.local_base;
 
         match (local_sphere_base_cid, request_sphere_base_cid) {
             (Some(mine), theirs) => {
@@ -335,7 +335,7 @@ where
 
         if let Err(error) = self.name_system_tx.send(NameSystemJob::ResolveSince {
             context: self.sphere_context.clone(),
-            since: self.request_body.local_base.clone(),
+            since: self.request_body.local_base,
         }) {
             warn!("Failed to request name system resolutions: {}", error);
         };

--- a/rust/noosphere-gateway/src/handlers/v0alpha1/replicate.rs
+++ b/rust/noosphere-gateway/src/handlers/v0alpha1/replicate.rs
@@ -105,7 +105,7 @@ where
     // Always fall back to a full replication
     Ok(StreamBody::new(Box::pin(to_car_stream(
         vec![memo_version],
-        memo_body_stream(store, &memo_version),
+        memo_body_stream(store, &memo_version.into(), false),
     ))))
 }
 

--- a/rust/noosphere-gateway/src/handlers/v0alpha2/push.rs
+++ b/rust/noosphere-gateway/src/handlers/v0alpha2/push.rs
@@ -110,10 +110,10 @@ where
         // These steps are order-independent
         let _ = tokio::join!(
             self.notify_name_resolver(&push_body),
-            self.notify_ipfs_syndicator(next_version.clone())
+            self.notify_ipfs_syndicator(next_version)
         );
 
-        let roots = vec![next_version.clone().into()];
+        let roots = vec![next_version.into()];
 
         let block_stream = try_stream! {
             yield block_serialize::<DagCborCodec, _>(PushResponse::Accepted {
@@ -155,7 +155,7 @@ where
         let db = gateway_sphere_context.db();
 
         let local_sphere_base_cid = db.get_version(sphere_identity).await?.map(|cid| cid.into());
-        let request_sphere_base_cid = push_body.local_base.clone();
+        let request_sphere_base_cid = push_body.local_base;
 
         match (local_sphere_base_cid, request_sphere_base_cid) {
             (Some(mine), theirs) => {
@@ -351,7 +351,7 @@ where
 
         if let Err(error) = self.name_system_tx.send(NameSystemJob::ResolveSince {
             context: self.sphere_context.clone(),
-            since: push_body.local_base.clone(),
+            since: push_body.local_base,
         }) {
             warn!("Failed to request name system resolutions: {}", error);
         };

--- a/rust/noosphere-gateway/src/worker/cleanup.rs
+++ b/rust/noosphere-gateway/src/worker/cleanup.rs
@@ -231,7 +231,7 @@ mod tests {
 
         wait(1).await;
 
-        let mut latest_version = base_version.clone();
+        let mut latest_version = base_version;
 
         for _ in 0..10 {
             let (_, link_record, _) = make_valid_link_record(&mut gateway_db.clone()).await?;

--- a/rust/noosphere-into/src/transform/sphere/html.rs
+++ b/rust/noosphere-into/src/transform/sphere/html.rs
@@ -48,8 +48,8 @@ where
 
         let sphere_file = SphereFile {
             sphere_identity,
-            sphere_version: sphere.cid().clone(),
-            memo_version: sphere.cid().clone(),
+            sphere_version: *sphere.cid(),
+            memo_version: *sphere.cid(),
             memo,
             contents: TransformStream(sphere_to_subtext_stream(sphere)).into_reader(),
         };

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -52,4 +52,6 @@ ipfs-api-prelude = "0.6"
 rand = { workspace = true }
 iroh-car = { workspace = true }
 libipld-cbor = { workspace = true }
+libipld-json = { workspace = true }
+multihash = { workspace = true }
 noosphere-core = { version = "0.17.0", path = "../noosphere-core" }

--- a/rust/noosphere-ipfs/examples/car.rs
+++ b/rust/noosphere-ipfs/examples/car.rs
@@ -1,0 +1,103 @@
+//! Simple utility to verify the contents of a .car file using the same
+//! CAR-reading facilities in use by Noosphere more generally
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::env;
+
+use anyhow::Result;
+use cid::Cid;
+use iroh_car::CarReader;
+use libipld_cbor::DagCborCodec;
+use libipld_core::raw::RawCodec;
+use multihash::MultihashDigest;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::fs::File;
+
+pub fn hash_for(cid: Cid) -> &'static str {
+    match multihash::Code::try_from(cid.hash().code()) {
+        Ok(multihash::Code::Blake3_256) => "BLAKE3",
+        Ok(multihash::Code::Sha2_256) => "SHA-256",
+        Ok(_) => "Other",
+        Err(error) => {
+            println!("ERROR: {}", error);
+            "Error reading codec"
+        }
+    }
+}
+
+pub fn codec_for(cid: Cid) -> &'static str {
+    match cid.codec() {
+        codec if codec == u64::from(DagCborCodec) => "DAG-CBOR",
+        codec if codec == u64::from(RawCodec) => "Raw",
+        _ => "Other",
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn main() {}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::main)]
+pub async fn main() -> Result<()> {
+    let file = if let Some(arg) = env::args().nth(1) {
+        println!("Opening {arg}...\n");
+        File::open(arg).await?
+    } else {
+        println!("Please specify a path to a CARv1 file");
+        std::process::exit(1);
+    };
+
+    let mut reader = CarReader::new(file).await?;
+
+    let header = reader.header();
+
+    println!("=== Header (CARv{}) ===\n", header.version());
+
+    for root in header.roots() {
+        println!("{}", root);
+    }
+
+    println!();
+
+    let mut index = 0usize;
+
+    while let Some((cid, block)) = reader.next_block().await? {
+        println!("=== Block {} ===\n", index);
+
+        let verification_sign = if cid.codec() == u64::from(DagCborCodec) {
+            let hasher = cid::multihash::Code::try_from(cid.hash().code())?;
+            let multihash = hasher.digest(&block);
+            let new_cid = Cid::new_v1(cid.codec(), multihash);
+
+            if cid == new_cid {
+                "✔️"
+            } else {
+                "🚫"
+            }
+        } else {
+            "🤷"
+        };
+
+        println!(
+            "{} {} ({:?}, {}, {})\n",
+            verification_sign,
+            cid,
+            cid.version(),
+            hash_for(cid),
+            codec_for(cid)
+        );
+        println!(
+            "{}\n",
+            block
+                .iter()
+                .map(|byte| format!("{:02X?}", byte))
+                .collect::<Vec<String>>()
+                .join(" ")
+        );
+
+        index += 1;
+    }
+
+    Ok(())
+}

--- a/rust/noosphere-storage/examples/bench/main.rs
+++ b/rust/noosphere-storage/examples/bench/main.rs
@@ -192,7 +192,7 @@ impl BenchmarkStorage {
     /// wipe any IndexedDb usage here.
     pub async fn dispose(self) -> Result<()> {
         #[cfg(target_arch = "wasm32")]
-        self.storage.to_inner().clear().await?;
+        self.storage.into_inner().clear().await?;
         Ok(())
     }
 }

--- a/rust/noosphere-storage/examples/bench/performance.rs
+++ b/rust/noosphere-storage/examples/bench/performance.rs
@@ -98,7 +98,7 @@ where
     }
 
     #[allow(unused)]
-    pub fn to_inner(self) -> S {
+    pub fn into_inner(self) -> S {
         self.storage
     }
 }


### PR DESCRIPTION
This change proposes a significant revision to how we syndicate to IPFS Kubo from gateways.

- We now use the same CAR streaming used in client<->gateway sync and replication
- The bloom filter is dropped in favor of keeping faith in "pin roots" and ensuring rigorous collection of blocks in `memo_body_stream`
- Syndication checkpoints now expire every 90 days, forcing re-syndication of history

Additionally, a small utility example has been implemented to verify the shape of CAR files produced by Noosphere's CAR streaming facilities.