### PR TITLE
feat: 3P replication fall-back and resilience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3501,11 +3501,15 @@ dependencies = [
  "anyhow",
  "futures",
  "futures-util",
+ "gloo-timers",
+ "instant",
  "rand",
  "tokio",
+ "tokio-stream",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -3529,6 +3533,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.10",
  "gloo-net",
+ "instant",
  "iroh-car",
  "js-sys",
  "libipld-cbor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ fastcdc = { version = "3.1" }
 futures = { version = "0.3" }
 futures-util = { version = "0.3" }
 gloo-net = { version = "0.4" }
-gloo-timers = { version = "0.2", features = ["futures"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
 ignore = { version = "0.4.20" }
+instant = { version = "0.1", features = ["wasm-bindgen"] }
 iroh-car = { version = "^0.3.0" }
 js-sys = { version = "^0.3" }
 libipld = { version = "0.16" }

--- a/rust/noosphere-common/Cargo.toml
+++ b/rust/noosphere-common/Cargo.toml
@@ -13,16 +13,19 @@ homepage = "https://github.com/subconsciousnetwork/noosphere"
 readme = "README.md"
 
 [features]
-helpers = ["rand"]
+helpers = ["rand", "gloo-timers"]
 
 [dependencies]
 anyhow = { workspace = true }
+gloo-timers = { workspace = true, optional = true }
 tracing = { workspace = true }
 rand = { workspace = true, optional = true }
 futures-util = { workspace = true }
+instant = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+tokio-stream = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["full"] }
@@ -32,3 +35,6 @@ tokio = { workspace = true, features = ["sync", "macros"] }
 futures = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }

--- a/rust/noosphere-common/src/helpers/wait.rs
+++ b/rust/noosphere-common/src/helpers/wait.rs
@@ -1,8 +1,11 @@
-use std::time::Duration;
+use instant::Duration;
 
 /// Wait for the specified number of seconds; uses [tokio::time::sleep], so this
 /// will yield to the async runtime rather than block until the sleep time is
 /// elapsed.
 pub async fn wait(seconds: u64) {
+    #[cfg(not(target_arch = "wasm32"))]
     tokio::time::sleep(Duration::from_secs(seconds)).await;
+    #[cfg(target_arch = "wasm32")]
+    gloo_timers::future::sleep(Duration::from_secs(seconds)).await
 }

--- a/rust/noosphere-common/src/latency.rs
+++ b/rust/noosphere-common/src/latency.rs
@@ -1,0 +1,130 @@
+use instant::{Duration, Instant};
+
+use futures_util::Stream;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use crate::ConditionalSend;
+
+/// A helper for observing when [Stream] throughput appears to have stalled
+pub struct StreamLatencyGuard<S>
+where
+    S: Stream + Unpin,
+    S::Item: ConditionalSend + 'static,
+{
+    inner: S,
+    threshold: Duration,
+    last_ready_time: Instant,
+    tx: UnboundedSender<()>,
+}
+
+impl<S> StreamLatencyGuard<S>
+where
+    S: Stream + Unpin,
+    S::Item: ConditionalSend + 'static,
+{
+    /// Wraps a [Stream] and provides an [UnboundedReceiver<()>] that will receive
+    /// a message any time the wrapped [Stream] is pending for longer than the provided
+    /// threshold [Duration].
+    pub fn wrap(stream: S, threshold: Duration) -> (Self, UnboundedReceiver<()>) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        (
+            StreamLatencyGuard {
+                inner: stream,
+                threshold,
+                last_ready_time: Instant::now(),
+                tx,
+            },
+            rx,
+        )
+    }
+}
+
+impl<S> Stream for StreamLatencyGuard<S>
+where
+    S: Stream + Unpin,
+    S::Item: ConditionalSend + 'static,
+{
+    type Item = S::Item;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let result = std::pin::pin!(&mut self.inner).poll_next(cx);
+
+        if result.is_pending() {
+            if Instant::now() - self.last_ready_time > self.threshold {
+                let _ = self.tx.send(());
+            }
+        } else if result.is_ready() {
+            self.last_ready_time = Instant::now();
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use instant::Duration;
+    use tokio::select;
+    use tokio_stream::StreamExt;
+
+    use crate::{helpers::wait, StreamLatencyGuard};
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_does_not_impede_the_behavior_of_a_wrapped_stream() -> Result<()> {
+        let stream = tokio_stream::iter(Vec::from([0u32; 1024]));
+
+        let (guarded_stream, _latency_signal) =
+            StreamLatencyGuard::wrap(stream, Duration::from_secs(1));
+
+        tokio::pin!(guarded_stream);
+
+        guarded_stream.collect::<Vec<u32>>().await;
+
+        Ok(())
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_signals_when_a_stream_encounters_latency() -> Result<()> {
+        let stream = Box::pin(futures_util::stream::unfold(0, |index| async move {
+            match index {
+                512 => {
+                    for _ in 0..3 {
+                        // Uh oh, latency! Note that `tokio::time::sleep` is observed to cooperate
+                        // with the runtime, so we wait multiple times to ensure that the stream is
+                        // actually polled multiple times
+                        wait(1).await;
+                    }
+                    Some((index, index + 1))
+                }
+                _ if index < 1024 => Some((index, index + 1)),
+                _ => None,
+            }
+        }));
+
+        let (guarded_stream, mut latency_guard) =
+            StreamLatencyGuard::wrap(stream, Duration::from_millis(100));
+
+        tokio::pin!(guarded_stream);
+
+        select! {
+            _ = guarded_stream.collect::<Vec<u32>>() => {
+                unreachable!("Latency guard should be hit first");
+            },
+            _ = latency_guard.recv() => ()
+        }
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-common/src/lib.rs
+++ b/rust/noosphere-common/src/lib.rs
@@ -5,10 +5,12 @@
 extern crate tracing;
 
 pub mod channel;
+mod latency;
 mod sync;
 mod task;
 mod unshared;
 
+pub use latency::*;
 pub use sync::*;
 pub use task::*;
 pub use unshared::*;

--- a/rust/noosphere-common/src/unshared.rs
+++ b/rust/noosphere-common/src/unshared.rs
@@ -53,12 +53,12 @@ impl<T> std::fmt::Debug for Unshared<T> {
 pub struct UnsharedStream<T>(Unshared<T>)
 where
     T: Stream + Unpin,
-    T::Item: ConditionalSend + 'static;
+    for<'a> T::Item: ConditionalSend + 'a;
 
 impl<T> UnsharedStream<T>
 where
     T: Stream + Unpin,
-    T::Item: ConditionalSend + 'static,
+    for<'a> T::Item: ConditionalSend + 'a,
 {
     /// Initialize a new [UnsharedStream] wrapping a provided (presumably `!Sync`)
     /// [Stream]
@@ -70,7 +70,7 @@ where
 impl<T> Stream for UnsharedStream<T>
 where
     T: Stream + Unpin,
-    T::Item: ConditionalSend + 'static,
+    for<'a> T::Item: ConditionalSend + 'a,
 {
     type Item = T::Item;
 

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -35,6 +35,7 @@ async-stream = { workspace = true }
 async-once-cell = "~0.4"
 anyhow = { workspace = true }
 bytes = { workspace = true }
+instant = { workspace = true }
 iroh-car = { workspace = true }
 thiserror = { workspace = true }
 fastcdc = { workspace = true }

--- a/rust/noosphere-core/src/context/replication/mod.rs
+++ b/rust/noosphere-core/src/context/replication/mod.rs
@@ -1,3 +1,5 @@
 mod read;
+mod write;
 
 pub use read::*;
+pub use write::*;

--- a/rust/noosphere-core/src/context/replication/write.rs
+++ b/rust/noosphere-core/src/context/replication/write.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use instant::Duration;
+
+use async_trait::async_trait;
+use noosphere_storage::Storage;
+use ucan::{builder::UcanBuilder, store::UcanJwtStore};
+
+use crate::{
+    authority::{generate_capability, SphereAbility},
+    context::{internal::SphereContextInternal, HasMutableSphereContext},
+    data::{Jwt, LinkRecord, LINK_RECORD_FACT_NAME},
+};
+
+/// Implementors are able to write Noosphere data pertaining to replicating
+/// their spheres across the network
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SphereReplicaWrite<S>
+where
+    S: Storage + 'static,
+{
+    /// Produce a [LinkRecord] for this sphere pointing to the latest version
+    /// according to the implementor, optionally valid for the specified
+    /// lifetime.
+    async fn create_link_record(&mut self, lifetime: Option<Duration>) -> Result<LinkRecord>;
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<C, S> SphereReplicaWrite<S> for C
+where
+    C: HasMutableSphereContext<S>,
+    S: Storage + 'static,
+{
+    async fn create_link_record(&mut self, lifetime: Option<Duration>) -> Result<LinkRecord> {
+        self.assert_write_access().await?;
+
+        let mut context = self.sphere_context_mut().await?;
+        let author = context.author();
+        let identity = context.identity();
+        let version = context.version().await?;
+
+        let mut builder = UcanBuilder::default()
+            .issued_by(&author.key)
+            .for_audience(identity)
+            .claiming_capability(&generate_capability(identity, SphereAbility::Publish))
+            .with_fact(LINK_RECORD_FACT_NAME, version.to_string())
+            .with_nonce();
+
+        if let Some(lifetime) = lifetime {
+            builder = builder.with_lifetime(lifetime.as_secs());
+        }
+
+        // An authorization may not be present or required if the issuer is the root credential,
+        // which may happen in recovery scenarios where the user provides their mnemonic
+        if let Some(authorization) = &author.authorization {
+            builder = builder.witnessed_by(&authorization.as_ucan(context.db()).await?, None)
+        }
+
+        let link_record = LinkRecord::from(builder.build()?.sign().await?);
+
+        let jwt = Jwt(link_record.encode()?);
+        context.db_mut().write_token(&jwt).await?;
+
+        Ok(link_record)
+    }
+}

--- a/rust/noosphere-core/src/stream/car.rs
+++ b/rust/noosphere-core/src/stream/car.rs
@@ -42,12 +42,12 @@ where
 /// Takes a list of roots and a stream of blocks (pairs of [Cid] and
 /// corresponding [Vec<u8>]), and produces an async byte stream that yields a
 /// valid [CARv1](https://ipld.io/specs/transport/car/carv1/)
-pub fn to_car_stream<S>(
+pub fn to_car_stream<'a, S>(
     mut roots: Vec<Cid>,
     block_stream: S,
-) -> impl Stream<Item = Result<Bytes, IoError>> + ConditionalSend
+) -> impl Stream<Item = Result<Bytes, IoError>> + ConditionalSend + 'a
 where
-    S: Stream<Item = Result<(Cid, Vec<u8>)>> + ConditionalSend,
+    S: Stream<Item = Result<(Cid, Vec<u8>)>> + ConditionalSend + 'a,
 {
     if roots.is_empty() {
         roots = vec![Cid::default()]

--- a/rust/noosphere-core/src/stream/ledger.rs
+++ b/rust/noosphere-core/src/stream/ledger.rs
@@ -1,0 +1,170 @@
+use anyhow::Result;
+use async_stream::try_stream;
+use futures_util::Stream;
+use noosphere_common::ConditionalSend;
+use std::{collections::BTreeSet, sync::Arc};
+use tokio::sync::Mutex;
+
+use cid::Cid;
+use libipld_cbor::DagCborCodec;
+use libipld_core::{codec::Codec, ipld::Ipld, raw::RawCodec};
+
+/// A utility to help with tracking the relationship of blocks and references
+/// within a series of blocks.
+#[derive(Default, Clone, Debug)]
+pub struct BlockLedger {
+    references: BTreeSet<Cid>,
+    blocks: BTreeSet<Cid>,
+}
+
+impl BlockLedger {
+    /// Record a block in the ledger, extracting references from the block bytes
+    /// and noting the block's own [Cid]
+    pub fn record(&mut self, cid: &Cid, block: &[u8]) -> Result<()> {
+        self.blocks.insert(*cid);
+
+        match cid.codec() {
+            codec if codec == u64::from(DagCborCodec) => {
+                DagCborCodec.references::<Ipld, _>(block, &mut self.references)?;
+            }
+            codec if codec == u64::from(RawCodec) => {
+                RawCodec.references::<Ipld, _>(block, &mut self.references)?;
+            }
+            _ => (),
+        };
+
+        Ok(())
+    }
+
+    /// Get an iterator over the [Cid]s of orphan blocks based on the current
+    /// state of the [BlockLedger].
+    ///
+    /// Orphan blocks are blocks that are not referenced by any other blocks
+    /// in the set of blocks recorded by this [BlockLedger].
+    pub fn orphans(&self) -> impl IntoIterator<Item = &Cid> {
+        self.blocks.difference(&self.references)
+    }
+
+    /// Same as [BlockLedger::orphans], but consumes the [BlockLedger] and
+    /// yields owned [Cid]s.
+    pub fn into_orphans(self) -> impl IntoIterator<Item = Cid> {
+        self.blocks
+            .into_iter()
+            .filter(move |cid| !self.references.contains(cid))
+    }
+
+    /// Get an iterator over [Cid]s that are referenced by the recorded blocks
+    /// but have not been recorded by this [BlockLedger] themselves.
+    pub fn missing_references(&self) -> impl IntoIterator<Item = &Cid> {
+        self.references
+            .iter()
+            .filter(|cid| !self.blocks.contains(*cid))
+    }
+
+    /// Same as [BlockLedger::missing_references], but consumes the
+    /// [BlockLedger] and yields owned [Cid]s.
+    pub fn into_missing_references(self) -> impl IntoIterator<Item = Cid> {
+        self.references
+            .into_iter()
+            .filter(move |cid| !self.blocks.contains(cid))
+    }
+}
+
+/// Wraps a block stream (any stream yielding `Result<(Cid, Vec<u8>)>`), and
+/// records "orphan" blocks to a providede target buffer.
+///
+/// Orphan blocks are blocks that occurred in the stream but were not referenced
+/// by any other blocks in the stream.
+pub fn record_stream_orphans<E, S>(
+    orphans: Arc<Mutex<E>>,
+    block_stream: S,
+) -> impl Stream<Item = Result<(Cid, Vec<u8>)>> + ConditionalSend
+where
+    E: Extend<Cid> + ConditionalSend,
+    S: Stream<Item = Result<(Cid, Vec<u8>)>> + ConditionalSend,
+{
+    try_stream! {
+        let mut ledger = BlockLedger::default();
+        let mut locked_orphans = orphans.lock().await;
+
+        for await item in block_stream {
+          let (cid, block) = item?;
+
+          ledger.record(&cid, &block)?;
+
+          yield (cid, block);
+        }
+
+        locked_orphans.extend(ledger.into_orphans());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, sync::Arc};
+
+    use anyhow::Result;
+    use cid::Cid;
+    use futures_util::StreamExt;
+    use tokio::sync::Mutex;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use crate::{
+        authority::Access,
+        context::{HasMutableSphereContext, HasSphereContext, SpherePetnameWrite},
+        helpers::{make_valid_link_record, simulated_sphere_context},
+        stream::{memo_body_stream, record_stream_orphans},
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_records_orphans_in_a_stream() -> Result<()> {
+        let (mut sphere_context, _) = simulated_sphere_context(Access::ReadWrite, None).await?;
+        let mut db = sphere_context.sphere_context().await?.db().clone();
+        let (did, link_record, _) = make_valid_link_record(&mut db).await?;
+
+        sphere_context.set_petname("foo", Some(did)).await?;
+        sphere_context.save(None).await?;
+        sphere_context
+            .set_petname_record("foo", &link_record)
+            .await?;
+
+        let version_to_stream = sphere_context.save(None).await?;
+        let orphans: Arc<Mutex<BTreeSet<Cid>>> = Default::default();
+
+        let stream = record_stream_orphans(
+            orphans.clone(),
+            memo_body_stream(db.clone(), &version_to_stream, true),
+        );
+
+        tokio::pin!(stream);
+
+        let _ = stream.collect::<Vec<Result<(Cid, Vec<u8>)>>>().await;
+
+        let orphans = orphans.lock().await;
+
+        assert_eq!(orphans.len(), 2);
+
+        let root = sphere_context.version().await?;
+
+        assert!(orphans.contains(&root));
+
+        let orphan_link_record = Cid::try_from(
+            link_record
+                .proofs()
+                .as_ref()
+                .unwrap()
+                .first()
+                .unwrap()
+                .as_str(),
+        )?;
+
+        assert!(orphans.contains(&orphan_link_record));
+
+        Ok(())
+    }
+}

--- a/rust/noosphere-core/src/stream/mod.rs
+++ b/rust/noosphere-core/src/stream/mod.rs
@@ -3,11 +3,13 @@
 
 mod block;
 mod car;
+mod ledger;
 mod memo;
 mod walk;
 
 pub use block::*;
 pub use car::*;
+pub use ledger::*;
 pub use memo::*;
 pub use walk::*;
 
@@ -388,6 +390,7 @@ mod tests {
         );
 
         let store = sphere_context.lock().await.db().clone();
+
         let last_version = versions.pop().unwrap();
         let last_version_parent = versions.pop().unwrap();
 

--- a/rust/noosphere-ipfs/src/client/gateway.rs
+++ b/rust/noosphere-ipfs/src/client/gateway.rs
@@ -2,6 +2,7 @@ use super::{IpfsClient, IpfsClientAsyncReadSendSync};
 use anyhow::Result;
 use async_trait::async_trait;
 use cid::Cid;
+use noosphere_common::ConditionalSend;
 use reqwest::Client;
 use reqwest::StatusCode;
 use std::str::FromStr;
@@ -56,6 +57,14 @@ impl GatewayClient {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl IpfsClient for GatewayClient {
+    async fn pin_blocks<'a, I>(&self, _cids: I) -> Result<()>
+    where
+        I: IntoIterator<Item = &'a Cid> + ConditionalSend + std::fmt::Debug,
+        I::IntoIter: ConditionalSend,
+    {
+        unimplemented!("IPFS HTTP Gateway does not have this capability.");
+    }
+
     async fn block_is_pinned(&self, _cid: &Cid) -> Result<bool> {
         unimplemented!("IPFS HTTP Gateway does not have this capability.");
     }

--- a/rust/noosphere-storage/Cargo.toml
+++ b/rust/noosphere-storage/Cargo.toml
@@ -38,7 +38,7 @@ wasm-bindgen-test = { workspace = true }
 rand = { workspace = true }
 noosphere-core-dev = { path = "../noosphere-core", features = ["helpers"], package = "noosphere-core" }
 noosphere-common = { path = "../noosphere-common", features = ["helpers"] }
-instant = { version = "0.1.12", features = ["wasm-bindgen"] }
+instant = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = { workspace = true }

--- a/rust/noosphere-storage/src/db.rs
+++ b/rust/noosphere-storage/src/db.rs
@@ -80,9 +80,7 @@ where
 
     /// Record the tip of a local sphere lineage as a [Cid]
     pub async fn set_version(&mut self, identity: &str, version: &Cid) -> Result<()> {
-        self.version_store
-            .set_key(identity.to_string(), version)
-            .await
+        self.version_store.set_key(identity, version).await
     }
 
     /// Get the most recently recorded tip of a local sphere lineage

--- a/rust/noosphere-storage/src/retry.rs
+++ b/rust/noosphere-storage/src/retry.rs
@@ -7,11 +7,11 @@ use tokio::select;
 use crate::BlockStore;
 
 const DEFAULT_MAX_RETRIES: u32 = 2u32;
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(1500);
 const DEFAULT_MINIMUM_DELAY: Duration = Duration::from_secs(1);
 const DEFAULT_BACKOFF: Backoff = Backoff::Exponential {
     exponent: 2f32,
-    ceiling: Duration::from_secs(10),
+    ceiling: Duration::from_secs(6),
 };
 
 /// Backoff configuration used to define how [BlockStoreRetry] should time

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -33,6 +33,7 @@ async-stream = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 subtext = { workspace = true }
+instant = { workspace = true }
 itertools = "0.11.0"
 rand = { workspace = true }
 tokio-stream = { workspace = true }

--- a/rust/noosphere/tests/sphere_channel.rs
+++ b/rust/noosphere/tests/sphere_channel.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 #[cfg(target_arch = "wasm32")]
 use instant::Duration;
 #[cfg(not(target_arch = "wasm32"))]
-use std::time::Duration;
+use instant::Duration;
 
 use anyhow::Result;
 use async_stream::try_stream;


### PR DESCRIPTION
This change proposes the following:

- A "fall back to local data" strategy for peers with new versions that fail to replicate
- Per-block latency guards on CAR streams to detect stalled Kubo queries
- Secondary Kubo pinning for orphaned blocks in Noosphere CAR streams
- Timeouts when looking blocks up from Kubo have been reduced (net ~16s to net ~10s)
- Improvements to `car` example utility to report orphaned or missing blocks in a CARv1