### PR TITLE
feat: Fix nightly builds and add to CI.

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -39,22 +39,28 @@ jobs:
 
   run-linting-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - toolchain: stable
+          - toolchain: nightly
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: 'Setup Rust'
         run: |
           curl -sSf https://sh.rustup.rs | sh -s -- -y
-          rustup component add clippy
-          rustup component add rustfmt
+          rustup toolchain install ${{matrix.toolchain}}
+          rustup +${{matrix.toolchain}} component add clippy
+          rustup +${{matrix.toolchain}} component add rustfmt
       - name: 'Install environment packages'
         run: |
           sudo apt-get update -qqy
           sudo apt-get install jq protobuf-compiler cmake
       - name: 'Check Format'
-        run: cargo fmt --all -- --check
+        run: cargo +${{matrix.toolchain}} fmt --all -- --check
       - name: 'Run Linter'
-        run: cargo clippy --all -- -D warnings
+        run: cargo +${{matrix.toolchain}} clippy --all -- -D warnings
 
   run-rust-test-suite:
     name: 'Run Rust test suite'
@@ -62,10 +68,16 @@ jobs:
       matrix:
         features: ['test-kubo,headers', 'test-kubo,headers,rocksdb']
         platform: ['ubuntu-latest', 'windows-latest', 'macos-13']
-        toolchain: ['stable']
+        toolchain: ['stable', 'nightly']
         exclude:
           - platform: 'windows-latest'
             features: 'test-kubo,headers,rocksdb'
+          - platform: 'macos-13'
+            toolchain: 'nightly'
+          - platform: 'windows-latest'
+            toolchain: 'nightly'
+          - features: 'test-kubo,headers,rocksdb'
+            toolchain: 'nightly'
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4778,9 +4778,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c1d19b288ca9898cd421c7b105fb7269918a7f8e9253a991e228981ca421ad"
+checksum = "395ace5aff9629c7268ca8255aceb945525b2cb644015f3caec5131a6a537c11"
 dependencies = [
  "inventory",
  "libc",
@@ -4795,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d7a04caa3ca2224f5ea4ddd850e2629c3b36b2b83621f87a8303bf41020110"
+checksum = "9255504d5467bae9e07d58b8de446ba6739b29bf72e1fa35b2387e30d29dcbfe"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease 0.1.25",

--- a/rust/noosphere-gateway/src/handlers/v0alpha2/push.rs
+++ b/rust/noosphere-gateway/src/handlers/v0alpha2/push.rs
@@ -50,7 +50,7 @@ pub async fn push_route<C, S>(
     stream: BodyStream,
 ) -> Result<StreamBody<impl Stream<Item = Result<Bytes, std::io::Error>>>, GatewayErrorResponse>
 where
-    C: HasMutableSphereContext<S>,
+    for<'a> C: HasMutableSphereContext<S> + 'a,
     S: Storage + 'static,
 {
     debug!("Invoking push route...");

--- a/rust/noosphere-ns/src/bin/orb-ns/main.rs
+++ b/rust/noosphere-ns/src/bin/orb-ns/main.rs
@@ -14,12 +14,10 @@ mod utils;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod inner {
-    pub use crate::cli;
     pub use anyhow::{anyhow, Result};
-    pub use noosphere::key::{InsecureKeyStorage, KeyStorage};
+    pub use noosphere::key::InsecureKeyStorage;
     pub use noosphere_core::tracing::initialize_tracing;
     pub use tokio;
-    pub use tracing::*;
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/rust/noosphere/Cargo.toml
+++ b/rust/noosphere/Cargo.toml
@@ -73,7 +73,7 @@ features = [
 ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-safer-ffi = { version = "0.1.2", features = ["proc_macros", "python-headers"] }
+safer-ffi = { version = "0.1.4", features = ["proc_macros", "python-headers"] }
 tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/rust/noosphere/build.rs
+++ b/rust/noosphere/build.rs
@@ -1,6 +1,8 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
     cfg_aliases! {
         // Platforms
         wasm: { target_arch = "wasm32" },

--- a/rust/noosphere/src/ffi/mod.rs
+++ b/rust/noosphere/src/ffi/mod.rs
@@ -1,7 +1,4 @@
-// TODO(getditto/safer_ffi#181): Re-enable this lint
-#![allow(clippy::incorrect_clone_impl_on_copy_type, non_snake_case)]
-
-//! This module defins a C FFI for Noosphere, suitable for cross-language
+//! This module defines a C FFI for Noosphere, suitable for cross-language
 //! embedding on many different targets
 
 mod authority;


### PR DESCRIPTION
Preparing with in-flight PR https://github.com/getditto/safer_ffi/pull/191.

~~There's a new clippy lint rule (documented as available since 1.72.0, though only appears in nightly channels), and some extra finesse on targeting nightly builds with a dynamic lint.~~ also fixed in latest safer_ffi

Other than that, just a lifetime change needed.