### PR TITLE
chore: Do not report flakes on main branch with no corresponding issue

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -132,7 +132,7 @@ jobs:
   report-test-flakes:
     name: 'Report test flakes (Linux)'
     needs: ['run-rust-test-suite']
-    if: always()
+    if: github.ref != 'refs/heads/main'
     uses: ./.github/workflows/report_test_flakes.yaml
     secrets: inherit
 


### PR DESCRIPTION
Not sure on how to test this, but builds on main are reporting as failing due to no corresponding issue to post a comment to