### PR TITLE
chore: async compat to tokio utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,7 +3464,7 @@ dependencies = [
  "rexie",
  "safer-ffi",
  "serde_json",
- "subtext 0.3.4 (git+https://github.com/subconsciousnetwork/subtext?rev=afe4836)",
+ "subtext",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3506,7 +3506,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "subtext 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtext",
  "symlink",
  "tempfile",
  "tokio",
@@ -3674,7 +3674,7 @@ dependencies = [
  "libipld-cbor",
  "noosphere-core",
  "noosphere-storage",
- "subtext 0.3.4 (git+https://github.com/subconsciousnetwork/subtext?rev=afe4836)",
+ "subtext",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -5419,19 +5419,9 @@ dependencies = [
 
 [[package]]
 name = "subtext"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd41fd9fc6998faab4b179e626264e294226ecf922322f4a823bb9f774f78fa7"
-dependencies = [
- "anyhow",
- "log",
- "tendril",
-]
-
-[[package]]
-name = "subtext"
-version = "0.3.4"
-source = "git+https://github.com/subconsciousnetwork/subtext?rev=afe4836#afe4836642d13bc0a4b75cd83c4f6726eee992e4"
+checksum = "1466198dcef95b5c5e943ee4c92e4586b66c11eeb770f9272bc100b526a14fa7"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,19 +299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compat"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48b4ff0c2026db683dea961cd8ea874737f56cffca86fa84415eaddc51c00d"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,7 +3400,7 @@ dependencies = [
  "rexie",
  "safer-ffi",
  "serde_json",
- "subtext",
+ "subtext 0.3.4 (git+https://github.com/subconsciousnetwork/subtext?rev=afe4836)",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3455,7 +3442,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "subtext",
+ "subtext 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "symlink",
  "tempfile",
  "tokio",
@@ -3609,7 +3596,6 @@ name = "noosphere-into"
 version = "0.11.4"
 dependencies = [
  "anyhow",
- "async-compat",
  "async-stream",
  "async-trait",
  "async-utf8-decoder",
@@ -3621,7 +3607,7 @@ dependencies = [
  "libipld-cbor",
  "noosphere-core",
  "noosphere-storage",
- "subtext",
+ "subtext 0.3.4 (git+https://github.com/subconsciousnetwork/subtext?rev=afe4836)",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -3639,7 +3625,6 @@ name = "noosphere-ipfs"
 version = "0.8.4"
 dependencies = [
  "anyhow",
- "async-compat",
  "async-stream",
  "async-trait",
  "cid",
@@ -3660,6 +3645,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "ucan",
  "url",
@@ -5304,13 +5290,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd41fd9fc6998faab4b179e626264e294226ecf922322f4a823bb9f774f78fa7"
 dependencies = [
  "anyhow",
- "async-compat",
+ "log",
+ "tendril",
+]
+
+[[package]]
+name = "subtext"
+version = "0.3.4"
+source = "git+https://github.com/subconsciousnetwork/subtext?rev=afe4836#afe4836642d13bc0a4b75cd83c4f6726eee992e4"
+dependencies = [
+ "anyhow",
  "async-stream",
  "async-utf8-decoder",
  "futures",
  "log",
  "tendril",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_urlencoded = { version = "~0.7" }
 serde-wasm-bindgen = { version = "0.4" }
 strum = { version = "0.25" }
 strum_macros = { version = "0.25" }
-subtext = { version = "0.3.4" }
+subtext = { git = "https://github.com/subconsciousnetwork/subtext", rev = "afe4836" }
 symlink = { version = "0.1" }
 tempfile = { version = "^3" }
 thiserror = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_urlencoded = { version = "~0.7" }
 serde-wasm-bindgen = { version = "0.4" }
 strum = { version = "0.25" }
 strum_macros = { version = "0.25" }
-subtext = { git = "https://github.com/subconsciousnetwork/subtext", rev = "afe4836" }
+subtext = { version = "0.3.5" }
 symlink = { version = "0.1" }
 tempfile = { version = "^3" }
 thiserror = { version = "1" }

--- a/rust/noosphere-into/Cargo.toml
+++ b/rust/noosphere-into/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 [dependencies]
 noosphere-core = { version = "0.17.3", path = "../noosphere-core" }
 noosphere-storage = { version = "0.9.3", path = "../noosphere-storage" }
-subtext = { version = "0.3.2", features = ["stream"] }
+subtext = { workspace = true, features = ["stream"] }
 async-trait = "~0.1"
 url = { workspace = true }
 tracing = { workspace = true }
@@ -36,7 +36,6 @@ tokio = { workspace = true, features = ["io-util", "macros", "test-util"] }
 
 async-stream = { workspace = true }
 futures = { workspace = true }
-async-compat = { version = "~0.2" }
 async-utf8-decoder = { version = "~0.3" }
 
 ucan = { workspace = true }

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -26,7 +26,6 @@ test-kubo = []
 
 [dependencies]
 anyhow = { workspace = true }
-async-compat = { version = "~0.2" }
 async-trait = "~0.1"
 async-stream = { workspace = true }
 libipld-core = { workspace = true }
@@ -37,6 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 url = { workspace = true, features = [ "serde" ] }
 noosphere-storage = { version = "0.9.3", path = "../noosphere-storage" }

--- a/rust/noosphere-ipfs/src/client/kubo.rs
+++ b/rust/noosphere-ipfs/src/client/kubo.rs
@@ -6,12 +6,12 @@ use super::{IpfsClient, IpfsClientAsyncReadSendSync};
 use async_trait::async_trait;
 
 use anyhow::{anyhow, Result};
-use async_compat::CompatExt;
 use cid::Cid;
 use hyper::{
     client::connect::dns::GaiResolver, client::HttpConnector, Body, Client, Request, StatusCode,
 };
 use hyper_multipart_rfc7578::client::multipart::{Body as MultipartBody, Form};
+use tokio_util::compat::TokioAsyncReadCompatExt;
 // TODO(#587): Remove dependency on `ipfs-api` crate
 use ipfs_api_prelude::response::{PinAddResponse, PinLsResponse};
 use libipld_cbor::DagCborCodec;


### PR DESCRIPTION
[Issues with async-compat@0.2.3 in wasm32](https://github.com/subconsciousnetwork/noosphere/pull/695#issuecomment-1811621724), and this lets us continue using tokio-family crates.

Dependent on upstream subtext https://github.com/subconsciousnetwork/subtext/pull/59 landing

Fixes potentially multiple subtext instances (workspace consolidation)