### PR TITLE
feat: `orb version` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1291,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.11.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -1298,12 +1316,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.11.2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
  "syn 1.0.109",
 ]
 
@@ -3467,6 +3507,8 @@ dependencies = [
  "ucan",
  "ucan-key-support",
  "url",
+ "vergen",
+ "vergen-pretty",
  "wasm-bindgen",
  "witty-phrase-generator",
 ]
@@ -3819,6 +3861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -5448,6 +5499,8 @@ checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -5929,6 +5982,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6036,6 +6095,29 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1290fd64cc4e7d3c9b07d7f333ce0ce0007253e32870e632624835cc80b83939"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
+
+[[package]]
+name = "vergen-pretty"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741d3aa00b1153d1692b3fd3c9d825dd469d3ff03e5d58b6835be595892d70b5"
+dependencies = [
+ "anyhow",
+ "convert_case",
+ "derive_builder 0.12.0",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"
@@ -6299,7 +6381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef36a4d12baa6e842582fe9ec16a57184ba35e1a09308307b67d43ec8883100"
 dependencies = [
  "bytes",
- "derive_builder",
+ "derive_builder 0.11.2",
  "log",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ base64 = { version = "^0.21" }
 byteorder = { version = "~1.4" } # keep in sync with pinned libipld-* crates
 bytes = { version = "^1" }
 cid = { version = "0.10" }
+clap-vergen = { version = "0.2.0" }
 deterministic-bloom = { version = "0.1.0" }
 directories = { version = "5" }
 fastcdc = { version = "3.1" }
@@ -65,6 +66,8 @@ tracing-subscriber = { version = "~0.3.18", features = ["env-filter", "tracing-l
 ucan = { version = "0.4.0" }
 ucan-key-support = { version = "0.1.7" }
 url = { version = "^2" }
+vergen = { version = "8.2.6", features = ["build", "cargo", "git", "gitcl"] }
+vergen-pretty = { version = "0.3.0" }
 void = { version = "1" }
 wasm-bindgen = { version = "^0.2" }
 wasm-bindgen-test = { version = "^0.3" }

--- a/rust/noosphere-cli/Cargo.toml
+++ b/rust/noosphere-cli/Cargo.toml
@@ -23,6 +23,9 @@ rocksdb = ["noosphere/rocksdb"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+vergen = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 reqwest = { version = "~0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 
@@ -54,6 +57,9 @@ noosphere-ns = { version = "0.11.5", path = "../noosphere-ns", optional = true }
 noosphere = { version = "0.16.0", path = "../noosphere" }
 ucan = { workspace = true }
 ucan-key-support = { workspace = true }
+
+vergen-pretty = { workspace = true }
+
 cid = { workspace = true }
 symlink = { workspace = true }
 pathdiff = { workspace = true }

--- a/rust/noosphere-cli/build.rs
+++ b/rust/noosphere-cli/build.rs
@@ -1,0 +1,10 @@
+use vergen::EmitBuilder;
+
+fn main() {
+    EmitBuilder::builder()
+        .all_git()
+        .all_build()
+        .all_cargo()
+        .emit()
+        .unwrap();
+}

--- a/rust/noosphere-cli/src/native/cli.rs
+++ b/rust/noosphere-cli/src/native/cli.rs
@@ -34,6 +34,13 @@ pub enum OrbCommand {
         command: SphereCommand,
     },
 
+    /// Display version information for this build of the CLI
+    Version {
+        /// Display extra build and git metadata
+        #[clap(short, long)]
+        verbose: bool,
+    },
+
     /// Summon a gateway geist to manage the local sphere; it will accept
     /// push, fetch and other REST actions from any clients that are authorized
     /// to operate on its counterpart sphere. When it receives changes to its

--- a/rust/noosphere-cli/src/native/mod.rs
+++ b/rust/noosphere-cli/src/native/mod.rs
@@ -29,6 +29,7 @@ use anyhow::Result;
 use clap::Parser;
 use noosphere_core::tracing::initialize_tracing;
 use noosphere_storage::StorageConfig;
+use vergen_pretty::{vergen_pretty_env, PrettyBuilder};
 
 /// Additional context used to invoke a [Cli] command.
 pub struct CliContext<'a> {
@@ -85,6 +86,22 @@ pub async fn invoke_cli_with_workspace(cli: Cli, mut workspace: Workspace) -> Re
             KeyCommand::Create { name } => key_create(&name, &workspace).await?,
             KeyCommand::List { as_json } => key_list(as_json, &workspace).await?,
         },
+        OrbCommand::Version { verbose } => {
+            let version = env!("CARGO_PKG_VERSION");
+
+            if verbose {
+                let mut out = Vec::new();
+                PrettyBuilder::default()
+                    .env(vergen_pretty_env!())
+                    .build()?
+                    .display(&mut out)?;
+
+                info!("{:>28}: {}", "Version (  orb)", version);
+                info!("{}", std::str::from_utf8(&out)?);
+            } else {
+                info!("{}", version);
+            }
+        }
         OrbCommand::Sphere { command } => match command {
             SphereCommand::Create { owner_key } => {
                 sphere_create(&owner_key, &mut workspace).await?;


### PR DESCRIPTION
This change proposes a new `orb version` command to help us track which version of the CLI is in use. It uses the [`vergen`](https://crates.io/crates/vergen) crate, which captures build-relevant environment information for later use in the final binary.

The output of the new command has two levels of verbosity. Simple:

```shell
❯ orb version
0.15.4
```

And verbose:

```shell
❯ orb version --verbose
             Version (  orb): 0.15.4
                Date (build): 2023-11-16
           Timestamp (build): 2023-11-16T21:48:24.943980651Z
               Debug (cargo): true
            Features (cargo): default
           Opt Level (cargo): 0
       Target Triple (cargo): x86_64-unknown-linux-gnu
              Branch (  git): fix/make-orb-render-good
 Commit Author Email (  git): 0xcda7a@gmail.com
  Commit Author Name (  git): Chris Joel
        Commit Count (  git): 475
         Commit Date (  git): 2023-11-16
      Commit Message (  git): feat: `orb version` command
    Commit Timestamp (  git): 2023-11-16T13:37:32.000000000-08:00
            Describe (  git): 63588c9
                 SHA (  git): 63588c908e8fee4359e0268e1aa3062ed9849001
```