### PR TITLE
chore: Revert "chore(deps): bump @reduxjs/toolkit from 1.9.7 to 2.0.1 in /typescript (#743)"

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -255,4 +255,4 @@ jobs:
         run: npm ci
       - name: 'Run TypeScript headless browser tests'
         working-directory: ./typescript
-        run: npm run test
+        run: npm run build && npm run test

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -232,6 +232,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.22.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
@@ -697,18 +708,18 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
-      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
       "dependencies": {
-        "immer": "^10.0.3",
-        "redux": "^5.0.0",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.0.1"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+        "react-redux": "^7.2.1 || ^8.0.2"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -718,11 +729,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/reselect": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.0.1.tgz",
-      "integrity": "sha512-D72j2ubjgHpvuCiORWkOUxndHJrxDaSolheiz5CO+roz8ka97/4msh2E8F5qay4GawR5vzBt5MkbDHT+Rdy/Wg=="
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.2.3",
@@ -3717,9 +3723,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
-      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -5600,17 +5606,25 @@
       }
     },
     "node_modules/redux": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.0.tgz",
-      "integrity": "sha512-blLIYmYetpZMET6Q6uCY7Jtl/Im5OBldy+vNPauA8vvsdqyt66oep4EUpAMWNHauTC6xa9JuRPhRB72rY82QGA=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
     },
     "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "peerDependencies": {
-        "redux": "^5.0.0"
+        "redux": "^4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6713,7 +6727,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@reduxjs/toolkit": "^2.0.1",
+        "@reduxjs/toolkit": "^1.9.7",
         "@subconsciousnetwork/orb": "*",
         "@web/dev-server": "^0.4.0",
         "lit": "^3.1.0",
@@ -6873,6 +6887,14 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
       "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
       "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
     },
     "@babel/types": {
       "version": "7.22.4",
@@ -7112,21 +7134,14 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
-      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
       "requires": {
-        "immer": "^10.0.3",
-        "redux": "^5.0.0",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.0.1"
-      },
-      "dependencies": {
-        "reselect": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.0.1.tgz",
-          "integrity": "sha512-D72j2ubjgHpvuCiORWkOUxndHJrxDaSolheiz5CO+roz8ka97/4msh2E8F5qay4GawR5vzBt5MkbDHT+Rdy/Wg=="
-        }
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -7291,7 +7306,7 @@
     "@subconsciousnetwork/sphere-viewer": {
       "version": "file:packages/sphere-viewer",
       "requires": {
-        "@reduxjs/toolkit": "^2.0.1",
+        "@reduxjs/toolkit": "^1.9.7",
         "@subconsciousnetwork/orb": "*",
         "@web/dev-server": "^0.4.0",
         "lit": "^3.1.0",
@@ -9361,9 +9376,9 @@
       "dev": true
     },
     "immer": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
-      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A=="
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="
     },
     "inflation": {
       "version": "2.0.0",
@@ -10810,15 +10825,23 @@
       }
     },
     "redux": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.0.tgz",
-      "integrity": "sha512-blLIYmYetpZMET6Q6uCY7Jtl/Im5OBldy+vNPauA8vvsdqyt66oep4EUpAMWNHauTC6xa9JuRPhRB72rY82QGA=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
     },
     "redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "requires": {}
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/typescript/packages/sphere-viewer/package.json
+++ b/typescript/packages/sphere-viewer/package.json
@@ -13,7 +13,7 @@
     "serve": "wireit"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^2.0.1",
+    "@reduxjs/toolkit": "^1.9.7",
     "@subconsciousnetwork/orb": "*",
     "@web/dev-server": "^0.4.0",
     "lit": "^3.1.0",


### PR DESCRIPTION
Currently breaking [documentation generation](https://github.com/subconsciousnetwork/noosphere/actions/runs/7184283771/job/19564995592), which only runs on `main`. Added a `npm run build` before `npm run test` in the test runner to uncover issues before they hit main. Not sure how `npm run test` runs without a prior build step.