### PR TITLE
chore: Revert "feat: Rewrite host headers in API client to embed sphere identity in subdomain when feature 'test-gateway' is enabled."

### DIFF
--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -22,7 +22,6 @@ readme = "README.md"
 default = []
 sentry = ["dep:sentry-tracing"]
 helpers = []
-test-gateway = []
 
 [dependencies]
 tracing = { workspace = true }


### PR DESCRIPTION


This reverts commit da912235ed3c5e1e3200110b98980fa393dbe91e.