### PR TITLE
feat: Add a healthcheck endpoint to the gateway.

### DIFF
--- a/rust/noosphere-gateway/src/gateway.rs
+++ b/rust/noosphere-gateway/src/gateway.rs
@@ -82,6 +82,7 @@ impl Gateway {
         let (cleanup_tx, cleanup_task) = start_cleanup::<M, C, S>(manager.clone());
 
         let app = Router::new()
+            .route("/healthz", get(|| async {}))
             .route(
                 &v0alpha1::Route::Did.to_string(),
                 get(handlers::v0alpha1::did_route),


### PR DESCRIPTION
The "did identity" route is not globally applicable, especially in cases where custom
GatewayManager implementations are in play.