### PR TITLE
chore: Remove duplicate continue-on-error

### DIFF
--- a/.github/workflows/run_test_suite.yaml
+++ b/.github/workflows/run_test_suite.yaml
@@ -38,7 +38,6 @@ jobs:
           swift test --sanitize=address
 
   run-linting-linux:
-    continue-on-error: true
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:


### PR DESCRIPTION
Erroneously introduced by applying #805 on inflight PRs to get tests running