### PR TITLE
fix: Remove vestigial getrandom dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,7 +3405,6 @@ dependencies = [
  "fastcdc",
  "futures",
  "futures-util",
- "getrandom",
  "gloo-net",
  "http 1.0.0",
  "instant",
@@ -5814,8 +5813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -6309,3 +6306,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "reqwest"
+version = "0.11.24"
+source = "git+https://github.com/seanmonstar/reqwest?rev=e639bdc1264c266a84dae3bae3193e07cae6861b#e639bdc1264c266a84dae3bae3193e07cae6861b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ libipld-json = { version = "0.16" }
 multihash = { version = "0.18" }
 pathdiff = { version = "0.2.1" }
 rand = { version = "0.8" }
-reqwest = { version = "=0.11.20", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sentry-tracing = { version = "0.31.8" }
 serde = { version = "^1" }
 serde_json = { version = "^1" }
@@ -81,3 +81,5 @@ web-sys = { version = "0.3" }
 opt-level = 'z'
 lto = true
 
+[patch.crates-io]
+reqwest = { git = "https://github.com/seanmonstar/reqwest", rev = "e639bdc1264c266a84dae3bae3193e07cae6861b", features = ["json", "rustls-tls", "stream"], default-features = false }

--- a/rust/noosphere-core/Cargo.toml
+++ b/rust/noosphere-core/Cargo.toml
@@ -76,7 +76,7 @@ tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: This is needed so that rand can be included in WASM builds
-getrandom = { version = "~0.2", features = ["js"] }
+# getrandom = { version = "~0.2", features = ["js"] }
 gloo-net = { workspace = true }
 wasm-streams = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/rust/noosphere-core/src/api/mod.rs
+++ b/rust/noosphere-core/src/api/mod.rs
@@ -11,6 +11,7 @@ pub mod v0alpha2;
 
 pub use client::*;
 pub use data::*;
+pub use route::*;
 
 // Re-export `http::StatusCode` here as our preferred `StatusCode` instance,
 // disambiguating from other crate's implementations.

--- a/rust/noosphere-storage/Cargo.toml
+++ b/rust/noosphere-storage/Cargo.toml
@@ -50,7 +50,7 @@ rocksdb = { version = "0.21.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, features = ["sync", "macros"] }
-wasm-bindgen = { workspace = true, features = ["serde-serialize"] }
+wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }


### PR DESCRIPTION
Notes:
- `wasm-bindgen` deprecates `serde-serialize`: https://github.com/rustwasm/wasm-bindgen/issues/2770#issuecomment-1213637387