### PR TITLE
chore: Remove direct dependency to multihash -- use cid re-export instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -3861,7 +3861,6 @@ dependencies = [
  "libipld-cbor",
  "libipld-core",
  "libipld-json",
- "multihash 0.18.1",
  "noosphere-common",
  "noosphere-core",
  "noosphere-storage",
@@ -3906,7 +3905,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.8.10",
+ "toml",
  "tower-http",
  "tracing",
  "url",
@@ -4492,12 +4491,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror",
- "toml 0.5.11",
+ "once_cell",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -5817,15 +5816,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
@@ -5833,7 +5823,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -5843,6 +5833,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ libipld = { version = "0.16" }
 libipld-core = { version = "0.16" }
 libipld-cbor = { version = "0.16" }
 libipld-json = { version = "0.16" }
-multihash = { version = "0.18" }
 pathdiff = { version = "0.2.1" }
 rand = { version = "0.8" }
 reqwest = { version = "=0.11.20", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/rust/noosphere-ipfs/Cargo.toml
+++ b/rust/noosphere-ipfs/Cargo.toml
@@ -53,5 +53,4 @@ rand = { workspace = true }
 iroh-car = { workspace = true }
 libipld-cbor = { workspace = true }
 libipld-json = { workspace = true }
-multihash = { workspace = true }
 noosphere-core = { workspace = true }

--- a/rust/noosphere-ipfs/examples/car.rs
+++ b/rust/noosphere-ipfs/examples/car.rs
@@ -1,11 +1,15 @@
 //! Simple utility to verify the contents of a .car file using the same
 //! CAR-reading facilities in use by Noosphere more generally
 
-#[cfg(not(target_arch = "wasm32"))]
-pub fn hash_for(cid: cid::Cid) -> &'static str {
-    match multihash::Code::try_from(cid.hash().code()) {
-        Ok(multihash::Code::Blake3_256) => "BLAKE3",
-        Ok(multihash::Code::Sha2_256) => "SHA-256",
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
+
+pub fn hash_for(cid: Cid) -> &'static str {
+    match Code::try_from(cid.hash().code()) {
+        Ok(Code::Blake3_256) => "BLAKE3",
+        Ok(Code::Sha2_256) => "SHA-256",
         Ok(_) => "Other",
         Err(error) => {
             println!("ERROR: {}", error);
@@ -36,7 +40,6 @@ pub async fn main() -> anyhow::Result<()> {
     use libipld_cbor::DagCborCodec;
     use libipld_core::ipld::Ipld;
     use libipld_core::raw::RawCodec;
-    use multihash::MultihashDigest;
     use noosphere_core::stream::BlockLedger;
     use noosphere_storage::block_decode;
     use std::env;


### PR DESCRIPTION
`multihash` is used by many of our dependencies (cid, libipld-*, libp2p) and there were some breaking changes in 0.19 (https://github.com/subconsciousnetwork/noosphere/pull/824) -- all of our usage of `multihash` is via `cid::multihash`, except in the single usage in an example where we use it directly. Continue using the version provided by `cid` (in sync with `libipld-*`)., as this is used throughout many dependencies, it's more important staying in sync than updating to the latest.